### PR TITLE
fix: use match_name instead of full_name in transfer messages

### DIFF
--- a/src-tauri/crates/ofm_core/src/transfers.rs
+++ b/src-tauri/crates/ofm_core/src/transfers.rs
@@ -579,7 +579,7 @@ pub fn generate_incoming_transfer_offers(game: &mut Game) {
             date: today.clone(),
         });
 
-        let player_name = player.full_name.clone();
+        let player_name = player.match_name.clone();
         let buyer_name = buyer_team.name.clone();
         let message = crate::messages::incoming_transfer_offer_message(
             &offer_id,
@@ -979,7 +979,7 @@ pub fn make_transfer_bid(
             .players
             .iter()
             .find(|p| p.id == player_id)
-            .map(|p| p.full_name.clone())
+            .map(|p| p.match_name.clone())
             .unwrap_or_default();
 
         let msg = crate::messages::transfer_complete_message(&player_name, fee, &date);
@@ -1095,7 +1095,7 @@ pub fn make_transfer_bid(
             .players
             .iter()
             .find(|p| p.id == player_id)
-            .map(|p| p.full_name.clone())
+            .map(|p| p.match_name.clone())
             .unwrap_or_default();
 
         let msg = crate::messages::transfer_complete_message(&player_name, fee, &date);
@@ -1637,7 +1637,7 @@ pub fn release_player_contract(game: &mut Game, player_id: &str) -> Result<i64, 
 
         (
             owning_team_id,
-            player.full_name.clone(),
+            player.match_name.clone(),
             release_penalty_amount(player, current_date),
         )
     };
@@ -1946,7 +1946,7 @@ fn execute_transfer(
             game.news.push(crate::news::major_transfer_article(
                 &article_id,
                 player_id,
-                &player_snapshot.full_name,
+                &player_snapshot.match_name,
                 from_team_id,
                 &from_team_name,
                 to_team_id,

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -408,7 +408,7 @@ export default function DashboardHeader({
             </div>
 
             {showContinueMenu && (
-              <div className="absolute right-0 top-full z-20 mt-1 w-64 rounded-lg border border-gray-200 bg-white py-1 shadow-xl dark:border-navy-600 dark:bg-navy-700">
+              <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-gray-200 bg-white py-1 shadow-xl dark:border-navy-600 dark:bg-navy-700">
                 {(["live", "spectator", "delegate"] as const).map((mode) => {
                   const isActive = matchMode === mode;
                   const optionMeta = modeMeta[mode];


### PR DESCRIPTION
## Summary

This PR fixes two small but noticeable UI issues in the dashboard header.

## Changes

1. **Transfer messages use match_name instead of full_name** (Fixes #3)
   - generate_incoming_transfer_offers: incoming offer inbox message now uses match_name
   - make_transfer_bid (free agent path): transfer complete message now uses match_name
   - make_transfer_bid (accepted offer path): transfer complete message now uses match_name
   - release_player_contract: contract termination message now uses match_name
   - execute_transfer: major transfer news article now uses match_name

2. **Continue menu dropdown z-index raised to prevent overlap** (Fixes #5)
   - Changed z-20 -> z-50 on the Continue dropdown so it always renders above other stacked elements (search dropdown at z-30, modals at z-50, etc.)

## Checklist

- [x] Local cargo check passes
- [x] Transfer tests pass (excluding 2 pre-existing unrelated failures)
- [x] No data provenance changes required

Fixes #3
Fixes #5