### PR TITLE
fix: filter scoutable players by nationality name in any supported language

### DIFF
--- a/src/components/scouting/ScoutingTab.model.test.ts
+++ b/src/components/scouting/ScoutingTab.model.test.ts
@@ -166,6 +166,73 @@ describe("ScoutingTab.model", () => {
     expect(lastPage.players).toHaveLength(5);
   });
 
+  it("filters by nationality name in any supported language", () => {
+    const teams = [
+      createTeam(),
+      createTeam({ id: "team-2", name: "Beta FC", short_name: "BET", manager_id: "manager-2" }),
+      createTeam({ id: "team-3", name: "Gamma FC", short_name: "GAM", manager_id: "manager-3" }),
+    ];
+    const players = [
+      createPlayer({ id: "british", team_id: "team-2", full_name: "John Smith", nationality: "GB" }),
+      createPlayer({ id: "brazilian", team_id: "team-3", full_name: "Carlos Goal", nationality: "BR" }),
+    ];
+
+    // Search by English country name
+    expect(
+      filterScoutablePlayers({
+        players,
+        teams,
+        myTeamId: "team-1",
+        posFilter: "All",
+        searchQuery: "brazil",
+      }).map((player) => player.id),
+    ).toEqual(["brazilian"]);
+
+    // Search by Spanish country name
+    expect(
+      filterScoutablePlayers({
+        players,
+        teams,
+        myTeamId: "team-1",
+        posFilter: "All",
+        searchQuery: "brasil",
+      }).map((player) => player.id),
+    ).toEqual(["brazilian"]);
+
+    // Search by Portuguese country name
+    expect(
+      filterScoutablePlayers({
+        players,
+        teams,
+        myTeamId: "team-1",
+        posFilter: "All",
+        searchQuery: "brasil",
+      }).map((player) => player.id),
+    ).toEqual(["brazilian"]);
+
+    // Search by ISO code should still work
+    expect(
+      filterScoutablePlayers({
+        players,
+        teams,
+        myTeamId: "team-1",
+        posFilter: "All",
+        searchQuery: "BR",
+      }).map((player) => player.id),
+    ).toEqual(["brazilian"]);
+
+    // Search by English country name for UK
+    expect(
+      filterScoutablePlayers({
+        players,
+        teams,
+        myTeamId: "team-1",
+        posFilter: "All",
+        searchQuery: "united kingdom",
+      }).map((player) => player.id),
+    ).toEqual(["british"]);
+  });
+
   it("builds the set of already scouted player ids", () => {
     const ids = buildAlreadyScoutingIds([
       createAssignment({ player_id: "player-1" }),

--- a/src/components/scouting/ScoutingTab.model.ts
+++ b/src/components/scouting/ScoutingTab.model.ts
@@ -6,6 +6,18 @@ import type {
 import { getTeamName } from "../../lib/helpers";
 import { calculateLolOvr } from "../../lib/lolPlayerStats";
 import { getLolRoleForPlayer } from "../squad/SquadTab.helpers";
+import { countryName, SUPPORTED_LOCALES } from "../../lib/countries";
+
+function getAllCountryNames(code: string): Set<string> {
+  const names = new Set<string>();
+  for (const locale of SUPPORTED_LOCALES) {
+    const name = countryName(code, locale);
+    if (name) {
+      names.add(name.toLowerCase());
+    }
+  }
+  return names;
+}
 
 interface FilterScoutablePlayersParams {
   players: PlayerData[];
@@ -40,6 +52,9 @@ export function filterScoutablePlayers({
         player.match_name.toLowerCase().includes(query) ||
         player.full_name.toLowerCase().includes(query) ||
         player.nationality.toLowerCase().includes(query) ||
+        [...getAllCountryNames(player.nationality)].some((name) =>
+          name.includes(query),
+        ) ||
         (player.team_id &&
           getTeamName(teams, player.team_id).toLowerCase().includes(query))
       );

--- a/src/lib/countries.ts
+++ b/src/lib/countries.ts
@@ -21,7 +21,8 @@ countries.registerLocale(frLocale);
 countries.registerLocale(deLocale);
 countries.registerLocale(itLocale);
 
-type SupportedLocale = "en" | "es" | "pt" | "fr" | "de" | "it";
+export type SupportedLocale = "en" | "es" | "pt" | "fr" | "de" | "it";
+export const SUPPORTED_LOCALES: SupportedLocale[] = ["en", "es", "pt", "fr", "de", "it"];
 
 interface FootballIdentityDefinition {
   code: string;


### PR DESCRIPTION
## Summary

The player search in the Scouting tab now filters correctly by nationality name in any supported language.

## Problem

The search placeholder says players can be filtered by nationality, but typing a country name like "Spain", "España" or "Spanien" did not return any results. Only the raw ISO code (e.g. "ES") worked because the filter only checked `player.nationality.toLowerCase().includes(query)`.

## Changes

- `src/components/scouting/ScoutingTab.model.ts`
  - Added `getAllCountryNames(code)` helper that collects the localized country name for all 6 supported locales (`en`, `es`, `pt`, `fr`, `de`, `it`) using the existing `countryName` utility.
  - Extended the search filter to also check against every localized country name, so a German user can type "Spanien" and find Spanish players.

- `src/lib/countries.ts`
  - Exported `SUPPORTED_LOCALES` so the scouting filter stays in sync with the app's language support instead of duplicating the locale list.

- `src/components/scouting/ScoutingTab.model.test.ts`
  - Added tests verifying searches by English, Spanish, Portuguese country names and by ISO code.

## Checklist

- [x] Local `npm test` passes (15/15 scouting tests)
- [x] No data provenance changes required

Fixes #6
