### PR TITLE
fix: disable native browser context menu

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,13 @@ import { ThemeProvider } from "./context/ThemeContext";
 import "./i18n";
 import App from "./App";
 
+// Disable the native browser context menu in the Tauri app.
+// Custom context menus (e.g. <ContextMenu>) handle their own onContextMenu
+// events and call stopPropagation(), so they continue to work.
+document.addEventListener("contextmenu", (event) => {
+  event.preventDefault();
+});
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <ThemeProvider>


### PR DESCRIPTION
## Summary

Disables the browser's native context menu (right-click) across the entire Tauri app.

## Problem

Right-clicking anywhere in the app opened the default WebView context menu with browser controls like "Reload", "Back", and "Inspect Element". This breaks the native desktop app feel.

## Changes

- `src/main.tsx`
  - Added a global `document` listener for the `contextmenu` event that calls `event.preventDefault()`.
  - The existing `<ContextMenu>` component already stops propagation on its own `onContextMenu` handler, so custom in-app context menus continue to work unaffected.

## Checklist

- [x] Local `npm test` passes
- [x] No data provenance changes required

Fixes #8
