### PR TITLE
feat: replace generic press emails with Esportmaníacos, Al Lío and el_yuste

### DIFF
--- a/src-tauri/crates/ofm_core/src/random_events/builders_reports.rs
+++ b/src-tauri/crates/ofm_core/src/random_events/builders_reports.rs
@@ -289,17 +289,17 @@ pub(super) fn rival_interest_message(
     let mut rng = rand::rng();
     let variations = [
         format!(
-            "We've received word that {} have started making moves for {}.\n\n\
-            Their staff were seen reviewing recent series and solo queue data, and our sources \
-            suggest a formal approach may arrive soon.\n\n\
-            How would you like us to respond if they make contact?",
+            "Eros ha abierto el último episodio de Al Lío con una bomba: \"Tengo información de que {} ha empezado a moverse por {}. \
+            Sus analistas llevan semanas revisando sus últimas series y datos de solo queue. \
+            No hay oferta formal todavía, pero la cosa se está calentando rápido.\"\n\n\
+            ¿Cuál es vuestra postura si hacen contacto?",
             rival_name, player_name
         ),
         format!(
-            "Esports media are reporting that {} is now a concrete target for {}.\n\n\
-            According to sources, the player has attracted attention after recent stage performances. \
-            No formal bid yet, but pressure is building fast.\n\n\
-            What's your stance?",
+            "Al Lío Podcast ha publicado en exclusiva que {} está en la órbita concreta de {}.\n\n\
+            Según Eros, el jugador llamó la atención por sus últimos rendimientos en stage. \
+            Aún no hay oferta oficial, pero la presión viene creciendo rápido.\n\n\
+            ¿Cuál es tu postura?",
             player_name, rival_name
         ),
     ];
@@ -307,14 +307,14 @@ pub(super) fn rival_interest_message(
 
     InboxMessage::new(
         msg_id.to_string(),
-        format!("Roster Rumour — {} linked with {}", player_name, rival_name),
+        format!("Al Lío Podcast — {} en la órbita de {}", player_name, rival_name),
         variations[idx].clone(),
-        "Director of Football".to_string(),
+        "Al Lío Podcast".to_string(),
         date.to_string(),
     )
     .with_category(MessageCategory::Transfer)
     .with_priority(MessagePriority::Normal)
-    .with_sender_role("Director of Football")
+    .with_sender_role("Eros")
     .with_action(action(
         "respond",
         "Respond",
@@ -358,9 +358,9 @@ pub(super) fn rival_interest_message(
         ..Default::default()
     })
     .with_i18n(
-        "be.msg.rivalInterest.subject",
-        &format!("be.msg.rivalInterest.body{}", idx),
+        "be.msg.allio.rivalInterest.subject",
+        &format!("be.msg.allio.rivalInterest.body{}", idx),
         params(&[("player", player_name), ("rival", rival_name)]),
     )
-    .with_sender_i18n("be.sender.directorOfFootball", "be.role.directorOfFootball")
+    .with_sender_i18n("be.sender.allioPodcast", "be.role.allioPodcast")
 }

--- a/src-tauri/crates/ofm_core/src/random_events/message_builders.rs
+++ b/src-tauri/crates/ofm_core/src/random_events/message_builders.rs
@@ -137,57 +137,70 @@ pub(super) fn media_story_message(
     }
 
     let mut rng = rand::rng();
+    let variant = rng.random_range(0..2usize);
 
-    let (subject, body) = if is_positive {
-        let stories = [
-            (
-                format!("Positive Press — {}", player_name),
+    let (subject, body, subject_key) = if is_positive {
+        match variant {
+            0 => (
+                format!("Esportmaníacos praises {} — the desk is unanimous", player_name),
                 format!(
-                    "The local papers are running a very positive piece on {} today.\n\n\
-                    They're highlighting their excellent recent form and commitment to {}. \
-                    This kind of coverage is great for the player's confidence and the club's image.",
+                    "The Esportmaníacos panel spent a good chunk of today's stream on {} at {}.\n\n\
+                    \"Nothing to criticize this week. The guy is absolutely dominating.\" \
+                    The positive coverage should give confidence a boost in the locker room.",
                     player_name, team_name
                 ),
+                "be.msg.esportmaniacos.positive.subject0",
             ),
-            (
-                format!("Media Praise for {}", player_name),
+            _ => (
+                format!("Esportmaníacos: {} is carrying {} this split", player_name, team_name),
                 format!(
-                    "Sports journalists have singled out {} for praise in their latest column.\n\n\
-                    \"One of the standout performers at {} this season\" — great for morale.",
+                    "The Esportmaníacos tertulianos rarely agree on anything, but {} got a full pass today: \
+                    \"Consistent, solid, no dips in form. One of the best players in the league right now. \
+                    {} should do everything to keep him.\"\n\n\
+                    Good for morale — and for the market value.",
                     player_name, team_name
                 ),
+                "be.msg.esportmaniacos.positive.subject1",
             ),
-        ];
-        stories[rng.random_range(0..stories.len())].clone()
+        }
     } else {
-        let stories = [
-            (
-                format!("Negative Press — {}", player_name),
+        match variant {
+            0 => (
+                format!("Esportmaníacos goes after {} — panel shows no mercy", player_name),
                 format!(
-                    "Some unflattering coverage of {} appeared in the tabloids today.\n\n\
-                    Journalists are questioning their form and commitment to {}. \
-                    This could affect the player's morale — you might want to have a word.",
+                    "The Esportmaníacos panel did not hold back today on {}: \
+                    \"The guy has completely disappeared. What happened to him this split? \
+                    {} can't keep relying on a player performing like this.\"\n\n\
+                    This kind of coverage tends to hit morale hard. Worth having a word with the player.",
                     player_name, team_name
                 ),
+                "be.msg.esportmaniacos.negative.subject0",
             ),
-            (
-                format!("Media Criticism — {}", player_name),
+            _ => (
+                format!("Esportmaníacos questions {}'s consistency at {}", player_name, team_name),
                 format!(
-                    "The press are being harsh on {} in today's papers.\n\n\
-                    \"Is {} getting the best out of their squad?\" — the article questions your use of the player. \
-                    Worth keeping an eye on how this affects the dressing room.",
+                    "Today's Esportmaníacos tertulianos session turned into a full breakdown of {}'s recent form. \
+                    The verdict: \"Inconsistent. No regularity. Some days at top level, others completely invisible. \
+                    {} deserves better output from a player in that role.\"\n\n\
+                    Keep an eye on the player's morale.",
                     player_name, team_name
                 ),
+                "be.msg.esportmaniacos.negative.subject1",
             ),
-        ];
-        stories[rng.random_range(0..stories.len())].clone()
+        }
+    };
+
+    let body_key = if is_positive {
+        format!("be.msg.esportmaniacos.positive.body{}", variant)
+    } else {
+        format!("be.msg.esportmaniacos.negative.body{}", variant)
     };
 
     InboxMessage::new(
         msg_id.to_string(),
         subject,
         body,
-        "Press Officer".to_string(),
+        "Esportmaníacos".to_string(),
         date.to_string(),
     )
     .with_category(MessageCategory::Media)
@@ -196,7 +209,7 @@ pub(super) fn media_story_message(
     } else {
         MessagePriority::Normal
     })
-    .with_sender_role("Press Officer")
+    .with_sender_role("Panel")
     .with_action(action(
         "ack",
         "Noted",
@@ -208,19 +221,11 @@ pub(super) fn media_story_message(
         ..Default::default()
     })
     .with_i18n(
-        if is_positive {
-            "be.msg.mediaPositive.subject"
-        } else {
-            "be.msg.mediaNegative.subject"
-        },
-        if is_positive {
-            "be.msg.mediaPositive.body"
-        } else {
-            "be.msg.mediaNegative.body"
-        },
+        subject_key,
+        &body_key,
         params(&[("player", player_name), ("team", team_name)]),
     )
-    .with_sender_i18n("be.sender.pressOfficer", "be.role.pressOfficer")
+    .with_sender_i18n("be.sender.esportmaniacos", "be.role.esportmaniacos")
 }
 
 pub fn build_media_story_from_narrative(
@@ -245,27 +250,68 @@ pub fn build_media_story_from_narrative(
     };
     let template = selector.select_event(Some("default"), &tags, &tones)?;
 
-    let (subject, body, priority) = if is_positive {
-        (
-            format!("Rift Desk Praise — {}", player_name),
-            format!(
-                "Analysts on the Rift Desk are highlighting {}'s recent form for {}.\n\n\
-                They called out cleaner objective setups, sharper draft discipline, and better map pressure around the team. \
-                The coverage should reinforce confidence across the roster.",
-                player_name, team_name
+    let mut rng = rand::rng();
+    let variant = rng.random_range(0..2usize);
+
+    let (subject, body, subject_key, priority) = if is_positive {
+        match variant {
+            0 => (
+                format!("Esportmaníacos praises {} — the desk is unanimous", player_name),
+                format!(
+                    "The Esportmaníacos panel spent a good chunk of today's stream on {} at {}.\n\n\
+                    \"Nothing to criticize this week. The guy is absolutely dominating.\" \
+                    The positive coverage should give confidence a boost in the locker room.",
+                    player_name, team_name
+                ),
+                "be.msg.esportmaniacos.positive.subject0",
+                MessagePriority::Low,
             ),
-            MessagePriority::Low,
-        )
+            _ => (
+                format!("Esportmaníacos: {} is carrying {} this split", player_name, team_name),
+                format!(
+                    "The Esportmaníacos tertulianos rarely agree on anything, but {} got a full pass today: \
+                    \"Consistent, solid, no dips in form. One of the best players in the league right now. \
+                    {} should do everything to keep him.\"\n\n\
+                    Good for morale — and for the market value.",
+                    player_name, team_name
+                ),
+                "be.msg.esportmaniacos.positive.subject1",
+                MessagePriority::Low,
+            ),
+        }
     } else {
-        (
-            format!("Pressure Watch — {}", player_name),
-            format!(
-                "League Beat has put {} under the microscope after a rough stretch for {}.\n\n\
-                The piece questions lane pressure, scrim adaptation, and whether the player can reset before the next series on the Rift.",
-                player_name, team_name
+        match variant {
+            0 => (
+                format!("Esportmaníacos goes after {} — panel shows no mercy", player_name),
+                format!(
+                    "The Esportmaníacos panel did not hold back today on {}: \
+                    \"The guy has completely disappeared. What happened to him this split? \
+                    {} can't keep relying on a player performing like this.\"\n\n\
+                    This kind of coverage tends to hit morale hard. Worth having a word with the player.",
+                    player_name, team_name
+                ),
+                "be.msg.esportmaniacos.negative.subject0",
+                MessagePriority::Normal,
             ),
-            MessagePriority::Normal,
-        )
+            _ => (
+                format!("Esportmaníacos questions {}'s consistency at {}", player_name, team_name),
+                format!(
+                    "Today's Esportmaníacos tertulianos session turned into a full breakdown of {}'s recent form. \
+                    The verdict: \"Inconsistent. No regularity. Some days at top level, others completely invisible. \
+                    {} deserves better output from a player in that role.\"\n\n\
+                    Keep an eye on the player's morale.",
+                    player_name, team_name
+                ),
+                "be.msg.esportmaniacos.negative.subject1",
+                MessagePriority::Normal,
+            ),
+        }
+    };
+
+    let body_key = if is_positive {
+        format!("be.msg.esportmaniacos.positive.body{}", variant)
+    } else {
+        format!("be.msg.esportmaniacos.negative.body{}", variant)
     };
 
     Some(
@@ -273,12 +319,12 @@ pub fn build_media_story_from_narrative(
             msg_id.to_string(),
             subject,
             body,
-            "Press Officer".to_string(),
+            "Esportmaníacos".to_string(),
             date.to_string(),
         )
         .with_category(MessageCategory::Media)
         .with_priority(priority)
-        .with_sender_role("Press Officer")
+        .with_sender_role("Panel")
         .with_action(action(
             "ack",
             "Noted",
@@ -290,19 +336,15 @@ pub fn build_media_story_from_narrative(
             ..Default::default()
         })
         .with_i18n(
-            if is_positive {
-                "be.msg.mediaLolPositive.subject"
-            } else {
-                "be.msg.mediaLolNegative.subject"
-            },
-            &template.template_key,
+            subject_key,
+            &body_key,
             params(&[
                 ("player", player_name),
                 ("team", team_name),
                 ("effectId", &template.effect_id),
             ]),
         )
-        .with_sender_i18n("be.sender.pressOfficer", "be.role.pressOfficer"),
+        .with_sender_i18n("be.sender.esportmaniacos", "be.role.esportmaniacos"),
     )
 }
 
@@ -334,6 +376,159 @@ pub(super) fn international_callup_message(
         params(&[("player", player_name), ("nationality", nationality)]),
     )
     .with_sender_i18n("be.sender.intlLiaison", "be.role.intlLiaison")
+}
+
+pub(super) fn allio_podcast_message(
+    msg_id: &str,
+    team_name: &str,
+    player_id: Option<&str>,
+    player_name: Option<&str>,
+    date: &str,
+) -> InboxMessage {
+    let mut rng = rand::rng();
+    let variant = rng.random_range(0..4usize);
+    let pname = player_name.unwrap_or("one of your players");
+
+    let (subject, body, subject_key, body_key) = match variant {
+        0 => (
+            format!("Al Lío Podcast — Transfer rumour: {} being tracked", pname),
+            format!(
+                "Eros dropped a transfer hint on today's Al Lío episode: \
+                \"I'm hearing things about {}. Multiple teams have been asking questions. \
+                Nothing confirmed yet, but the mercato around {} is heating up.\"\n\n\
+                Keep this in mind when planning your squad for next split.",
+                pname, team_name
+            ),
+            "be.msg.allio.subject0",
+            "be.msg.allio.body0",
+        ),
+        1 => (
+            format!("Al Lío Podcast — Eros hints at incoming deal for {}", team_name),
+            format!(
+                "Eros has been dropping hints on the latest Al Lío episode: \
+                \"I've been told there are conversations happening around {}. Something is being cooked. \
+                I can't give names yet but stay tuned — this mercato is far from over.\"\n\n\
+                Could be noise, could be real. Worth watching.",
+                team_name
+            ),
+            "be.msg.allio.subject1",
+            "be.msg.allio.body1",
+        ),
+        2 => (
+            "Al Lío Podcast — League format leak, Eros breaks it down".to_string(),
+            "Today's Al Lío episode went off-script when Eros revealed a potential leak: \
+            \"I've been told the league is planning changes to the split format. Not confirmed, \
+            but my sources are usually reliable. This could shake up how teams build their rosters.\"\n\n\
+            If true, this could affect your long-term planning.".to_string(),
+            "be.msg.allio.subject2",
+            "be.msg.allio.body2",
+        ),
+        _ => (
+            "Al Lío Podcast — Big move incoming, league shaken up".to_string(),
+            "Eros went live on Al Lío with what he called a \"bombazo\": \
+            \"There's a significant player movement about to happen in the league that nobody is talking about yet. \
+            I'll just say this — some teams are going to have to rethink their rosters completely.\"\n\n\
+            Stay alert — the market is moving.".to_string(),
+            "be.msg.allio.subject3",
+            "be.msg.allio.body3",
+        ),
+    };
+
+    let mut msg = InboxMessage::new(
+        msg_id.to_string(),
+        subject,
+        body,
+        "Al Lío Podcast".to_string(),
+        date.to_string(),
+    )
+    .with_category(MessageCategory::Media)
+    .with_priority(MessagePriority::Normal)
+    .with_sender_role("Eros")
+    .with_action(action("ack", "Noted", "be.msg.event.ack", ActionType::Acknowledge))
+    .with_i18n(
+        subject_key,
+        body_key,
+        params(&[("player", pname), ("team", team_name)]),
+    )
+    .with_sender_i18n("be.sender.allioPodcast", "be.role.allioPodcast");
+
+    if variant < 2 {
+        if let Some(pid) = player_id {
+            msg = msg.with_context(MessageContext {
+                player_id: Some(pid.to_string()),
+                ..Default::default()
+            });
+        }
+    }
+
+    msg
+}
+
+pub(super) fn yuste_stream_message(
+    msg_id: &str,
+    is_positive: bool,
+    date: &str,
+) -> InboxMessage {
+    let mut rng = rand::rng();
+    let variant = rng.random_range(0..2usize);
+
+    let (subject, body, subject_key, body_key) = if is_positive {
+        match variant {
+            0 => (
+                "el_yuste — even Yuste admits: viewership is up this week".to_string(),
+                "Yuste surprised his stream with a rare positive take: \
+                \"I'll be honest — the numbers are up this week and I'm not going to pretend otherwise. \
+                When the matches are good, the audience comes. Simple.\"\n\n\
+                A positive moment for the whole scene.".to_string(),
+                "be.msg.yuste.up.subject0",
+                "be.msg.yuste.up.body0",
+            ),
+            _ => (
+                "el_yuste — this week's matches actually got Yuste excited".to_string(),
+                "Not something you hear every day: Yuste was enthusiastic on his morning stream. \
+                \"This week delivered. Real matches, proper stakes, viewers who stayed till the end. \
+                This is what the league can be when it tries.\"\n\n\
+                Good week to be in esports.".to_string(),
+                "be.msg.yuste.up.subject1",
+                "be.msg.yuste.up.body1",
+            ),
+        }
+    } else {
+        match variant {
+            0 => (
+                "el_yuste — league viewers are tanking and nobody cares".to_string(),
+                "Antonio Yuste opened his morning stream with a full rant: \
+                \"The numbers don't lie. Viewership is going down week after week and the league keeps \
+                doing the same things expecting different results. C'est fini if nothing changes.\"\n\n\
+                Just background noise — but when Yuste talks, the community listens.".to_string(),
+                "be.msg.yuste.down.subject0",
+                "be.msg.yuste.down.body0",
+            ),
+            _ => (
+                "el_yuste — the league product is broken, according to Yuste".to_string(),
+                "Yuste spent a solid thirty minutes analysing the league's declining engagement on his morning stream: \
+                \"I've been saying this for months. The product isn't good enough. \
+                The format bores people, the scheduling kills momentum. The data is clear.\"\n\n\
+                Harsh, but Yuste's audience takes it seriously.".to_string(),
+                "be.msg.yuste.down.subject1",
+                "be.msg.yuste.down.body1",
+            ),
+        }
+    };
+
+    InboxMessage::new(
+        msg_id.to_string(),
+        subject,
+        body,
+        "el_yuste".to_string(),
+        date.to_string(),
+    )
+    .with_category(MessageCategory::Media)
+    .with_priority(MessagePriority::Low)
+    .with_sender_role("el_yuste")
+    .with_action(action("ack", "Noted", "be.msg.event.ack", ActionType::Acknowledge))
+    .with_i18n(subject_key, body_key, params(&[]))
+    .with_sender_i18n("be.sender.elYuste", "be.role.elYuste")
 }
 
 pub(super) fn community_event_message(msg_id: &str, team_name: &str, date: &str) -> InboxMessage {

--- a/src-tauri/crates/ofm_core/src/random_events/mod.rs
+++ b/src-tauri/crates/ofm_core/src/random_events/mod.rs
@@ -146,10 +146,10 @@ pub fn check_random_events(game: &mut Game) {
         }
     }
 
-    // --- 3. Media story (2% chance per day) ---
+    // --- 3. Media story (5% chance per day) ---
     {
         let msg_id = format!("media_{}", today);
-        if !existing_ids.contains(&msg_id) && rng.random_range(0..50) == 0 {
+        if !existing_ids.contains(&msg_id) && rng.random_range(0..20) == 0 {
             let team_name = game
                 .teams
                 .iter()
@@ -339,10 +339,10 @@ pub fn check_random_events(game: &mut Game) {
         }
     }
 
-    // --- 9. Rival interest in player (2% chance per day) ---
+    // --- 9. Rival interest in player (5% chance per day) ---
     {
         let msg_id = format!("rival_interest_{}", today);
-        if !existing_ids.contains(&msg_id) && rng.random_range(0..50) == 0 {
+        if !existing_ids.contains(&msg_id) && rng.random_range(0..20) == 0 {
             let current_date = game.clock.current_date.date_naive();
             let eligible: Vec<&domain::player::Player> = game
                 .players
@@ -371,6 +371,50 @@ pub fn check_random_events(game: &mut Game) {
                     &today,
                 ));
             }
+        }
+    }
+
+    // --- 10. Al Lío podcast (5% chance per day) ---
+    {
+        let msg_id = format!("allio_{}", today);
+        if !existing_ids.contains(&msg_id) && rng.random_range(0..20) == 0 {
+            let team_name = game
+                .teams
+                .iter()
+                .find(|t| t.id == user_team_id)
+                .map(|t| t.name.as_str())
+                .unwrap_or("Your Club");
+            let team_players: Vec<&domain::player::Player> = game
+                .players
+                .iter()
+                .filter(|p| p.team_id.as_deref() == Some(&user_team_id))
+                .collect();
+            let (player_id, player_name) = if !team_players.is_empty() {
+                let p = team_players[rng.random_range(0..team_players.len())];
+                (Some(p.id.as_str()), Some(p.match_name.as_str()))
+            } else {
+                (None, None)
+            };
+            new_messages.push(message_builders::allio_podcast_message(
+                &msg_id,
+                team_name,
+                player_id,
+                player_name,
+                &today,
+            ));
+        }
+    }
+
+    // --- 11. el_yuste stream (3% chance per day) ---
+    {
+        let msg_id = format!("yuste_{}", today);
+        if !existing_ids.contains(&msg_id) && rng.random_range(0..33) == 0 {
+            let is_positive = rng.random_bool(0.5);
+            new_messages.push(message_builders::yuste_stream_message(
+                &msg_id,
+                is_positive,
+                &today,
+            ));
         }
     }
 

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -2104,7 +2104,10 @@
       "scout": "Scout",
       "performanceStaff": "Performance Staff",
       "coachingStaff": "Coaching Staff",
-      "academyCoordinator": "Academy Coordinator"
+      "academyCoordinator": "Academy Coordinator",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Vorsitzender",
@@ -2121,7 +2124,10 @@
       "scout": "Scout",
       "performanceStaff": "Performance Staff",
       "coachingStaff": "Coaching Staff",
-      "academyCoordinator": "Academy Coordinator"
+      "academyCoordinator": "Academy Coordinator",
+      "esportmaniacos": "Panel",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Esports Gazette",
@@ -2542,6 +2548,49 @@
         "subject": "Academy weekly report: {{academy}}",
         "body": "Academy weekly summary:\n- Active players: {{activePlayers}}\n- Average OVR: {{avgOvr}}\n- High potential talents (>= 80): {{highPotential}}\n- Highlights: {{highlights}}\n- Current ERL rank: #{{position}} of {{total}}\n- Quick table: {{tablePreview}}",
         "bodyWithPromotion": "Academy weekly summary:\n- Active players: {{activePlayers}}\n- Average OVR: {{avgOvr}}\n- High potential talents (>= 80): {{highPotential}}\n- Highlights: {{highlights}}\n- Current ERL rank: #{{position}} of {{total}}\n- Quick table: {{tablePreview}}\n\nRecommendation: {{promotionCount}} player(s) ready for promotion -> {{promotionList}}."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos lobt {{player}} — das Panel ist sich einig",
+          "body0": "Die Tertulianos von Esportmaníacos haben einen guten Teil des heutigen Streams damit verbracht, über {{player}} bei {{team}} zu reden.\n\n„Diese Woche gibt es nichts zu kritisieren. Der Typ dominiert einfach.“ Schwer zu widersprechen. Die positive Berichterstattung sollte die Stimmung in der Kabine heben.",
+          "subject1": "Esportmaníacos: {{player}} trägt {{team}} in diesem Split",
+          "body1": "Die Tertulianos von Esportmaníacos sind selten einer Meinung, aber {{player}} bekam heute einen Freifahrtschein: „Konstant, solide, keine Formkrise. Einer der besten Spieler der Liga im Moment. {{team}} sollte alles tun, um ihn zu halten.“\n\nGut für die Moral — und für den Marktwert."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos greift {{player}} an — das Panel kennt keine Gnade",
+          "body0": "Die Tertulianos von Esportmaníacos haben heute kein Blatt vor den Mund genommen bei {{player}}: „Der Typ ist völlig verschwunden. Was ist ihm in diesem Split passiert? {{team}} kann nicht weiterhin von einem Spieler abhängen, der so performed.“\n\nDiese Art von Berichterstattung trifft die Moral hart. Ein Gespräch mit dem Spieler wäre sinnvoll.",
+          "subject1": "Esportmaníacos zweifelt an der Konstanz von {{player}} bei {{team}}",
+          "body1": "Die heutige Tertulianos-Session von Esportmaníacos entwickelte sich zu einer vollständigen Analyse von {{player}}s jüngster Form. Das Urteil: „Inkonstant. Keine Regelmäßigkeit. Manchmal auf Top-Level, dann wieder unsichtbar. {{team}} verdient mehr von einem Spieler in dieser Rolle.“\n\nBehalte die Moral des Spielers im Blick."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Transfergerücht: {{player}} wird beobachtet",
+        "body0": "Eros hat im letzten Al-Lío-Episode einen Markttipp fallen lassen: „Ich höre Dinge über {{player}}. Mehrere Teams haben Fragen gestellt. Noch nichts bestätigt, aber der Mercato rund um {{team}} heizt sich auf.“\n\nBehalte das im Hinterkopf, wenn du deinen Kader für das nächste Split planst.",
+        "subject1": "Al Lío Podcast — Eros deutet eine eingehende Verpflichtung für {{team}} an",
+        "body1": "Eros lässt seit Tagen Hinweise auf Al Lío fallen: „Mir wurde gesagt, dass rund um {{team}} Gespräche stattfinden. Etwas wird gekocht. Ich kann noch keine Namen nennen, aber bleibt dran — dieser Mercato ist noch nicht vorbei.“\n\nKann Lärm sein, kann real sein. Es lohnt sich, aufzupassen.",
+        "subject2": "Al Lío Podcast — Liga-Format-Leak, Eros erklärt alles",
+        "body2": "Die heutige Al-Lío-Episode lief aus dem Ruder, als Eros einen möglichen Leak enthüllte: „Mir wurde gesagt, dass die Liga Formatänderungen für das nächste Split plant. Nicht offiziell, aber meine Quellen sind normalerweise zuverlässig. Das könnte die Art und Weise ändern, wie Teams ihre Kader aufbauen.“\n\nWenn es stimmt, könnte das deine langfristige Planung beeinflussen.",
+        "subject3": "Al Lío Podcast — Großer Transfer im Anmarsch, die Liga wird aufgewühlt",
+        "body3": "Eros ging live auf Al Lío mit dem, was er einen „Bombazo“ nannte: „Es steht eine bedeutende Spielerbewegung in der Liga bevor, über die noch niemand spricht. Ich sage nur das — einige Teams werden ihren Kader komplett überdenken müssen.“\n\nBleibt wachsam — der Markt bewegt sich.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} im Visier von {{rival}}",
+          "body0": "Eros eröffnete die letzte Al-Lío-Episode mit einer Bombe: 'Ich habe Informationen, dass {{rival}} begonnen hat, sich um {{player}} zu bemühen. Ihre Analysten überprüfen seit Wochen die letzten Serien und Solo-Queue-Daten. Noch kein formales Angebot, aber es wird schnell heiss.'\n\nWas ist eure Haltung, wenn sie Kontakt aufnehmen?",
+          "body1": "Al Lío Podcast hat exklusiv berichtet, dass {{player}} jetzt ein konkretes Ziel für {{rival}} ist.\n\nLaut Eros hat der Spieler nach jüngsten Bühnenauftritten Aufmerksamkeit erregt. Noch kein offizielles Angebot, aber der Druck steigt schnell.\n\nWas ist deine Haltung?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — sogar Yuste gibt zu: Viewer steigen diese Woche",
+          "body0": "Yuste überraschte seinen Stream mit einer seltenen positiven Meinung: „Ich bin ehrlich — die Zahlen steigen diese Woche und ich werde nicht so tun als ob nicht. Wenn die Matches gut sind, kommt das Publikum. So einfach ist das.“\n\nEin positiver Moment für die ganze Szene.",
+          "subject1": "el_yuste — die Matches dieser Woche haben sogar Yuste begeistert",
+          "body1": "Nicht etwas, das man jeden Tag hört: Yuste war in seinem Morgen-Stream enthusiastisch. „Diese Woche hat geliefert. Echte Matches, echte Stakes, Viewer, die bis zum Ende geblieben sind. Das ist das, was die Liga sein kann, wenn sie es versucht.“\n\nGute Woche für Esports."
+        },
+        "down": {
+          "subject0": "el_yuste — Liga-Viewerzahlen im freien Fall und niemand tut etwas",
+          "body0": "Antonio Yuste eröffnete seinen Morgen-Stream mit einer richtigen Beschwerde: „Die Zahlen lügen nicht. Die Viewer fallen Woche für Woche und die Liga macht weiterhin dasselbe und erwartet andere Ergebnisse. C'est fini, wenn sich nichts ändert.“\n\nNur Hintergrundrauschen — aber wenn Yuste spricht, hört die Community zu.",
+          "subject1": "el_yuste — das Liga-Produkt ist kaputt, laut Yuste",
+          "body1": "Yuste hat eine gute halbe Stunde seines Morgen-Streams damit verbracht, das sinkende Engagement der Liga zu analysieren: „Ich sage das seit Monaten. Das Produkt ist nicht gut genug. Das Format langweilt, der Spielplan killt den Schwung. Die Daten sind eindeutig.“\n\nHart, aber Yustes Publikum nimmt es ernst."
+        }
       }
     },
     "news": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -2104,7 +2104,10 @@
       "scout": "Scout",
       "performanceStaff": "Performance Staff",
       "coachingStaff": "Coaching Staff",
-      "academyCoordinator": "Academy Coordinator"
+      "academyCoordinator": "Academy Coordinator",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Chairman",
@@ -2121,7 +2124,10 @@
       "scout": "Scout",
       "performanceStaff": "Performance Staff",
       "coachingStaff": "Coaching Staff",
-      "academyCoordinator": "Academy Coordinator"
+      "academyCoordinator": "Academy Coordinator",
+      "esportmaniacos": "Panel",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Dot Esports",
@@ -2542,6 +2548,49 @@
         "subject": "Academy weekly report: {{academy}}",
         "body": "Academy weekly summary:\n- Active players: {{activePlayers}}\n- Average OVR: {{avgOvr}}\n- High potential talents (>= 80): {{highPotential}}\n- Highlights: {{highlights}}\n- Current ERL rank: #{{position}} of {{total}}\n- Quick table: {{tablePreview}}",
         "bodyWithPromotion": "Academy weekly summary:\n- Active players: {{activePlayers}}\n- Average OVR: {{avgOvr}}\n- High potential talents (>= 80): {{highPotential}}\n- Highlights: {{highlights}}\n- Current ERL rank: #{{position}} of {{total}}\n- Quick table: {{tablePreview}}\n\nRecommendation: {{promotionCount}} player(s) ready for promotion -> {{promotionList}}."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos praises {{player}} — the desk is unanimous",
+          "body0": "The Esportmaníacos panel spent a good chunk of today's stream on {{player}} at {{team}}.\n\n\"Nothing to criticize this week. The guy is absolutely dominating.\" The positive coverage should give confidence a boost in the locker room.",
+          "subject1": "Esportmaníacos: {{player}} is carrying {{team}} this split",
+          "body1": "The Esportmaníacos tertulianos rarely agree on anything, but {{player}} got a full pass today: \"Consistent, solid, no dips in form. One of the best players in the league right now. {{team}} should do everything to keep him.\"\n\nGood for morale — and for the market value."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos goes after {{player}} — panel shows no mercy",
+          "body0": "The Esportmaníacos panel did not hold back today on {{player}}: \"The guy has completely disappeared. What happened to him this split? {{team}} can't keep relying on a player performing like this.\"\n\nThis kind of coverage tends to hit morale hard. Worth having a word with the player.",
+          "subject1": "Esportmaníacos questions {{player}}'s consistency at {{team}}",
+          "body1": "Today's Esportmaníacos tertulianos session turned into a full breakdown of {{player}}'s recent form. The verdict: \"Inconsistent. No regularity. Some days at top level, others completely invisible. {{team}} deserves better output from a player in that role.\"\n\nKeep an eye on the player's morale."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Transfer rumour: {{player}} being tracked",
+        "body0": "Eros dropped a transfer hint on today's Al Lío episode: \"I'm hearing things about {{player}}. Multiple teams have been asking questions. Nothing confirmed yet, but the mercato around {{team}} is heating up.\"\n\nKeep this in mind when planning your squad for next split.",
+        "subject1": "Al Lío Podcast — Eros hints at incoming deal for {{team}}",
+        "body1": "Eros has been dropping hints on the latest Al Lío episode: \"I've been told there are conversations happening around {{team}}. Something is being cooked. I can't give names yet but stay tuned — this mercato is far from over.\"\n\nCould be noise, could be real. Worth watching.",
+        "subject2": "Al Lío Podcast — League format leak, Eros breaks it down",
+        "body2": "Today's Al Lío episode went off-script when Eros revealed a potential leak: \"I've been told the league is planning changes to the split format. Not confirmed, but my sources are usually reliable. This could shake up how teams build their rosters.\"\n\nIf true, this could affect your long-term planning.",
+        "subject3": "Al Lío Podcast — Big move incoming, league shaken up",
+        "body3": "Eros went live on Al Lío with what he called a \"bombazo\": \"There's a significant player movement about to happen in the league that nobody is talking about yet. I'll just say this — some teams are going to have to rethink their rosters completely.\"\n\nStay alert — the market is moving.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} linked with {{rival}}",
+          "body0": "Eros opened the latest Al Lío episode with a bombshell: \"I have information that {{rival}} have started making moves for {{player}}. Their analysts have been reviewing recent series and solo queue data for weeks. No formal offer yet, but things are heating up fast.\"\n\nWhat's your stance if they make contact?",
+          "body1": "Al Lío Podcast has exclusively reported that {{player}} is now a concrete target for {{rival}}.\n\nAccording to Eros, the player attracted attention after recent stage performances. No formal bid yet, but pressure is building fast.\n\nWhat's your stance?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — even Yuste admits: viewership is up this week",
+          "body0": "Yuste surprised his stream with a rare positive take: \"I'll be honest — the numbers are up this week and I'm not going to pretend otherwise. When the matches are good, the audience comes. Simple.\"\n\nA positive moment for the whole scene.",
+          "subject1": "el_yuste — this week's matches actually got Yuste excited",
+          "body1": "Not something you hear every day: Yuste was enthusiastic on his morning stream. \"This week delivered. Real matches, proper stakes, viewers who stayed till the end. This is what the league can be when it tries.\"\n\nGood week to be in esports."
+        },
+        "down": {
+          "subject0": "el_yuste — league viewers are tanking and nobody cares",
+          "body0": "Antonio Yuste opened his morning stream with a full rant: \"The numbers don't lie. Viewership is going down week after week and the league keeps doing the same things expecting different results. C'est fini if nothing changes.\"\n\nJust background noise — but when Yuste talks, the community listens.",
+          "subject1": "el_yuste — the league product is broken, according to Yuste",
+          "body1": "Yuste spent a solid thirty minutes analysing the league's declining engagement on his morning stream: \"I've been saying this for months. The product isn't good enough. The format bores people, the scheduling kills momentum. The data is clear.\"\n\nHarsh, but Yuste's audience takes it seriously."
+        }
       }
     },
     "news": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -2110,7 +2110,10 @@
       "scout": "Ojeador",
       "performanceStaff": "Staff de Rendimiento",
       "coachingStaff": "Cuerpo Técnico",
-      "academyCoordinator": "Coordinador de Academia"
+      "academyCoordinator": "Coordinador de Academia",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Presidente",
@@ -2127,7 +2130,10 @@
       "scout": "Ojeador",
       "performanceStaff": "Staff de Rendimiento",
       "coachingStaff": "Cuerpo Técnico",
-      "academyCoordinator": "Coordinador de Academia"
+      "academyCoordinator": "Coordinador de Academia",
+      "esportmaniacos": "Tertulianos",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Dot Esports",
@@ -2548,6 +2554,49 @@
         "subject": "Reporte semanal de academia: {{academy}}",
         "body": "Resumen semanal de academia:\n- Jugadores activos: {{activePlayers}}\n- OVR promedio: {{avgOvr}}\n- Talentos altos (>= 80): {{highPotential}}\n- Destacados: {{highlights}}\n- Posición ERL actual: #{{position}} de {{total}}\n- Tabla rápida: {{tablePreview}}",
         "bodyWithPromotion": "Resumen semanal de academia:\n- Jugadores activos: {{activePlayers}}\n- OVR promedio: {{avgOvr}}\n- Talentos altos (>= 80): {{highPotential}}\n- Destacados: {{highlights}}\n- Posición ERL actual: #{{position}} de {{total}}\n- Tabla rápida: {{tablePreview}}\n\nRecomendación: {{promotionCount}} jugador(es) listos para promoción -> {{promotionList}}."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos elogia a {{player}} — la tertulia se pone de acuerdo",
+          "body0": "Los tertulianos de Esportmaníacos han dedicado un buen rato del directo de hoy a hablar de {{player}} en {{team}}.\n\n\"Esta semana no hay nada que criticar. El tío está dominando de una manera bestial.\" Difícil rebatirlo. La cobertura positiva debería subir el ambiente en el vestuario.",
+          "subject1": "Esportmaníacos: {{player}} está cargando a {{team}} este split",
+          "body1": "Los tertulianos de Esportmaníacos rara vez están de acuerdo, pero {{player}} se ha llevado un pase limpio: \"Constante, sólido, sin bajones. Uno de los mejores jugadores de la liga ahora mismo. {{team}} debería hacer lo que fuera por renovarle.\"\n\nBueno para la moral y para el valor de mercado."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos va a por {{player}} — la tertulia no tiene piedad",
+          "body0": "Los tertulianos de Esportmaníacos no se han cortado hoy con {{player}}: \"El tío ha desaparecido por completo. ¿Qué le ha pasado este split? {{team}} no puede seguir dependiendo de un jugador que rinde así.\"\n\nEste tipo de cobertura suele golpear fuerte la moral. Merece la pena hablar con el jugador.",
+          "subject1": "Esportmaníacos cuestiona la consistencia de {{player}} en {{team}}",
+          "body1": "La tertulia de Esportmaníacos de hoy se ha convertido en un análisis a fondo del rendimiento reciente de {{player}}. El veredicto: \"Irregular. Sin constancia. Algunos días está a tope, otros días desaparece. {{team}} merece más de un jugador en ese rol.\"\n\nHay que estar atentos a la moral del jugador."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Rumor de traspaso: {{player}} en el radar",
+        "body0": "Eros ha soltado un hint de mercato en el último episodio de Al Lío: \"Me están llegando cosas sobre {{player}}. Varios equipos han estado preguntando. Nada confirmado todavía, pero el mercato alrededor de {{team}} se está calentando.\"\n\nTenlo en cuenta al planificar tu plantilla para el próximo split.",
+        "subject1": "Al Lío Podcast — Eros insinúa un movimiento entrante para {{team}}",
+        "body1": "Eros lleva días soltando hints en Al Lío: \"Me han dicho que hay conversaciones alrededor de {{team}}. Algo se está cocinando. No puedo dar nombres todavía, pero estad atentos — este mercato no ha terminado.\"\n\nPuede ser ruido o puede ser real. Vale la pena estar pendiente.",
+        "subject2": "Al Lío Podcast — Leak de formato de liga, Eros lo explica todo",
+        "body2": "El episodio de Al Lío de hoy se ha salido del guion cuando Eros ha revelado un posible leak: \"Me han dicho que la liga está planificando cambios en el formato del split. No es oficial, pero mis fuentes suelen ser fiables. Esto podría cambiar la manera en que los equipos construyen sus plantillas.\"\n\nSi es verdad, puede afectar a tu planificación a largo plazo.",
+        "subject3": "Al Lío Podcast — Bombazo en el mercato, la liga se mueve",
+        "body3": "Eros ha entrado en directo en Al Lío con lo que ha llamado un \"bombazo\": \"Hay un movimiento grande de jugador a punto de ocurrir en la liga que nadie está hablando todavía. Solo os digo esto — algunos equipos van a tener que repensar sus plantillas por completo.\"\n\nMantente alerta — el mercato se mueve.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} en la órbita de {{rival}}",
+          "body0": "Eros ha abierto el último episodio de Al Lío con una bomba: \"Tengo información de que {{rival}} ha empezado a moverse por {{player}}. Sus analistas llevan semanas revisando sus últimas series y datos de solo queue. No hay oferta formal todavía, pero la cosa se está calentando rápido.\"\n\n¿Cuál es vuestra postura si hacen contacto?",
+          "body1": "Al Lío Podcast ha publicado en exclusiva que {{player}} está en la órbita concreta de {{rival}}.\n\nSegún Eros, el jugador llamó la atención por sus últimos rendimientos en stage. Aún no hay oferta oficial, pero la presión viene creciendo rápido.\n\n¿Cuál es tu postura?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — hasta Yuste lo admite: los viewers suben esta semana",
+          "body0": "Yuste ha sorprendido a su stream con una opinión positiva de las que no abundan: \"Voy a ser honesto — los números están subiendo esta semana y no voy a hacerme el tonto. Cuando las partidas son buenas, el público viene. Así de simple.\"\n\nBuen momento para la escena.",
+          "subject1": "el_yuste — las partidas de esta semana hasta han animado a Yuste",
+          "body1": "No es algo que se escuche todos los días: Yuste se ha puesto entusiasta en su stream matinal. \"Esta semana ha entregado. Partidas de verdad, stakes reales, viewers que se han quedado hasta el final. Esto es lo que puede ser la liga cuando se lo propone.\"\n\nBuena semana para estar en los esports."
+        },
+        "down": {
+          "subject0": "el_yuste — los viewers de la liga caen en picado y nadie hace nada",
+          "body0": "Antonio Yuste ha abierto su stream matinal con una queja en toda regla: \"Los números no mienten. Los viewers caen semana tras semana y la liga sigue haciendo lo mismo esperando resultados distintos. C'est fini si no cambian algo.\"\n\nRuido de fondo — pero cuando Yuste habla, la comunidad escucha.",
+          "subject1": "el_yuste — el producto de la liga está roto, según Yuste",
+          "body1": "Yuste ha dedicado una media hora de su stream matinal a analizar el descenso de engagement de la liga: \"Llevo meses diciéndolo. El producto no es suficientemente bueno. El formato aburre, el calendario mata el momentum. Los datos son claros.\"\n\nDuro, pero la audiencia de Yuste se lo toma en serio."
+        }
       }
     },
     "news": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -2112,7 +2112,10 @@
       "scout": "Recruteur",
       "performanceStaff": "Staff Performance",
       "coachingStaff": "Staff Technique",
-      "academyCoordinator": "Coordinateur de l'Académie"
+      "academyCoordinator": "Coordinateur de l'Académie",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Président",
@@ -2129,7 +2132,10 @@
       "scout": "Recruteur",
       "performanceStaff": "Staff Performance",
       "coachingStaff": "Staff Technique",
-      "academyCoordinator": "Coordinateur de l'Académie"
+      "academyCoordinator": "Coordinateur de l'Académie",
+      "esportmaniacos": "Panel",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Dot Esports",
@@ -2550,6 +2556,49 @@
         "subject": "Rapport hebdomadaire de l'académie : {{academy}}",
         "body": "Résumé hebdomadaire de l'académie :\n- Joueurs actifs : {{activePlayers}}\n- OVR moyen : {{avgOvr}}\n- Talents à haut potentiel (>= 80) : {{highPotential}}\n- Joueurs en vue : {{highlights}}\n- Position ERL actuelle : #{{position}} sur {{total}}\n- Tableau rapide : {{tablePreview}}",
         "bodyWithPromotion": "Résumé hebdomadaire de l'académie :\n- Joueurs actifs : {{activePlayers}}\n- OVR moyen : {{avgOvr}}\n- Talents à haut potentiel (>= 80) : {{highPotential}}\n- Joueurs en vue : {{highlights}}\n- Position ERL actuelle : #{{position}} sur {{total}}\n- Tableau rapide : {{tablePreview}}\n\nRecommandation : {{promotionCount}} joueur(s) prêt(s) pour la promotion -> {{promotionList}}."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos fait l'éloge de {{player}} — le panel est unanime",
+          "body0": "Les tertulianos d'Esportmaníacos ont consacré un bon moment du stream d'aujourd'hui à parler de {{player}} chez {{team}}.\n\n« Rien à critiquer cette semaine. Le gars domine de façon impressionnante. » Difficile de contredire ça. La couverture positive devrait booster l'ambiance dans le vestiaire.",
+          "subject1": "Esportmaníacos : {{player}} porte {{team}} sur ses épaules ce split",
+          "body1": "Les tertulianos d'Esportmaníacos sont rarement d'accord, mais {{player}} a obtenu un blanc-seing aujourd'hui : « Constant, solide, sans creux de forme. L'un des meilleurs joueurs de la ligue en ce moment. {{team}} devrait tout faire pour le garder. »\n\nBon pour le moral — et pour la valeur marchande."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos s'en prend à {{player}} — le panel sans pitié",
+          "body0": "Les tertulianos d'Esportmaníacos n'ont pas fait de cadeau à {{player}} aujourd'hui : « Le gars a complètement disparu. Qu'est-ce qui lui est arrivé ce split ? {{team}} ne peut pas continuer à compter sur un joueur qui performe comme ça. »\n\nCe type de couverture peut vraiment affecter le moral. Une discussion s'impose.",
+          "subject1": "Esportmaníacos remet en cause la régularité de {{player}} chez {{team}}",
+          "body1": "La session de la tertulia d'Esportmaníacos d'aujourd'hui s'est transformée en analyse complète des performances récentes de {{player}}. Verdict : « Irrégulier. Aucune constance. Certains jours au top, d'autres complètement invisible. {{team}} mérite mieux d'un joueur dans ce rôle. »\n\nGardez un œil sur le moral du joueur."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Rumeur de transfert : {{player}} dans le viseur",
+        "body0": "Eros a lâché un indice de mercato dans le dernier épisode d'Al Lío : « Je reçois des infos sur {{player}}. Plusieurs équipes posent des questions. Rien de confirmé pour l'instant, mais le mercato autour de {{team}} se réchauffe. »\n\nGardez ça en tête pour planifier votre effectif pour le prochain split.",
+        "subject1": "Al Lío Podcast — Eros insinue un mouvement entrant pour {{team}}",
+        "body1": "Eros lance des indices depuis plusieurs jours sur Al Lío : « On m'a dit qu'il y a des conversations autour de {{team}}. Quelque chose se prépare. Je ne peux pas encore donner de noms, mais restez connectés — ce mercato n'est pas terminé. »\n\nBruit de fond ou réalité ? Ça vaut la peine de rester attentif.",
+        "subject2": "Al Lío Podcast — Leak sur le format de la ligue, Eros explique tout",
+        "body2": "L'épisode d'Al Lío d'aujourd'hui a dévié quand Eros a révélé un possible leak : « On m'a informé que la ligue prépare des changements de format pour le prochain split. Pas officiel, mais mes sources sont généralement fiables. Ça pourrait changer la façon dont les équipes construisent leurs effectifs. »\n\nSi c'est vrai, ça pourrait affecter votre planification à long terme.",
+        "subject3": "Al Lío Podcast — Gros mouvement en approche, la ligue se réveille",
+        "body3": "Eros est entré en direct sur Al Lío avec ce qu'il a appelé un « bombazo » : « Il y a un mouvement de joueur important sur le point de se produire dans la ligue dont personne ne parle encore. Je dirai juste ça — certaines équipes vont devoir entièrement repenser leurs effectifs. »\n\nRestez vigilant — le marché bouge.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} dans le viseur de {{rival}}",
+          "body0": "Eros a ouvert le dernier épisode d'Al Lío avec une bombe : « J'ai des informations selon lesquelles {{rival}} a commencé à se positionner sur {{player}}. Leurs analystes passent en revue ses dernières séries et données de solo queue depuis des semaines. Pas d'offre formelle encore, mais ça chauffe vite. »\n\nQuelle est votre position s'ils prennent contact ?",
+          "body1": "Al Lío Podcast a révélé en exclusivité que {{player}} est désormais une cible concrète pour {{rival}}.\n\nSelon Eros, le joueur a attiré l'attention après ses dernières performances sur scène. Pas d'offre officielle encore, mais la pression monte vite.\n\nQuelle est votre position ?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — même Yuste l'admet : les viewers remontent cette semaine",
+          "body0": "Yuste a surpris son stream avec un avis positif qui se fait rare : « Je vais être honnête — les chiffres remontent cette semaine et je ne vais pas faire semblant de ne pas le voir. Quand les matchs sont bons, le public revient. Simple comme bonjour. »\n\nBon moment pour la scène.",
+          "subject1": "el_yuste — les matchs de cette semaine ont même enthousiasmé Yuste",
+          "body1": "Chose rare : Yuste était enthousiaste sur son stream matinal. « Cette semaine a livré. De vrais matchs, de vrais enjeux, des viewers qui sont restés jusqu'à la fin. C'est ce que peut être la ligue quand elle s'en donne les moyens. »\n\nBonne semaine pour être dans les esports."
+        },
+        "down": {
+          "subject0": "el_yuste — les viewers de la ligue s'effondrent et personne ne fait rien",
+          "body0": "Antonio Yuste a ouvert son stream du matin avec une vraie plainte : « Les chiffres ne mentent pas. Les viewers chutent semaine après semaine et la ligue continue à faire la même chose en espérant des résultats différents. C'est fini si rien ne change. »\n\nSimple bruit de fond — mais quand Yuste parle, la communauté écoute.",
+          "subject1": "el_yuste — le produit de la ligue est cassé, selon Yuste",
+          "body1": "Yuste a passé une bonne demi-heure de son stream matinal à analyser la baisse d'engagement de la ligue : « Je le dis depuis des mois. Le produit n'est pas assez bon. Le format ennuie, le calendrier tue le momentum. Les données sont claires. »\n\nDur, mais l'audience de Yuste le prend au sérieux."
+        }
       }
     },
     "news": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1505,7 +1505,10 @@
       "intlLiaison": "Responsabile relazioni internazionali",
       "player": "Giocatore",
       "pressOfficer": "Addetto stampa",
-      "scout": "Osservatore"
+      "scout": "Osservatore",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Presidente",
@@ -1519,7 +1522,10 @@
       "directorOfFootball": "Direttore sportivo",
       "intlLiaison": "Responsabile relazioni internazionali",
       "player": "Giocatore",
-      "scout": "Osservatore"
+      "scout": "Osservatore",
+      "esportmaniacos": "Panel",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Esports Gazette",
@@ -1864,6 +1870,49 @@
       "jobRejection": {
         "subject": "Aggiornamento Candidatura — {{team}}",
         "body": "Grazie per il tuo interesse per la posizione di allenatore al {{team}}. Dopo un'attenta valutazione, abbiamo deciso di proseguire con altri candidati. Ti auguriamo il meglio per la tua futura carriera."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos elogia {{player}} — il panel è unanime",
+          "body0": "I tertulianos di Esportmaníacos hanno dedicato una buona parte dello stream di oggi a parlare di {{player}} per {{team}}.\n\n«Nulla da criticare questa settimana. Il tizio sta dominando in modo impressionante.» Difficile contradire questo. La copertura positiva dovrebbe aumentare il morale nello spogliatoio.",
+          "subject1": "Esportmaníacos: {{player}} porta {{team}} sulle spalle in questo split",
+          "body1": "I tertulianos di Esportmaníacos raramente concordano, ma {{player}} ha ottenuto un giudizio senza riserve oggi: «Costante, solido, senza cali di forma. Uno dei migliori giocatori della lega in questo momento. {{team}} dovrebbe fare di tutto per tenerlo.»\n\nBene per il morale — e per il valore di mercato."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos attacca {{player}} — il panel senza pietà",
+          "body0": "I tertulianos di Esportmaníacos non si sono trattenuti oggi su {{player}}: «Il tizio è completamente sparito. Cosa gli è successo in questo split? {{team}} non può continuare a dipendere da un giocatore che performa così.»\n\nQuesto tipo di copertura tende a colpire duramente il morale. Vale la pena parlare con il giocatore.",
+          "subject1": "Esportmaníacos mette in discussione la costanza di {{player}} in {{team}}",
+          "body1": "La sessione tertulianos di Esportmaníacos di oggi si è trasformata in un'analisi completa delle prestazioni recenti di {{player}}. Verdetto: «Irregolare. Nessuna costanza. Certi giorni al top, altri completamente invisibile. {{team}} merita di più da un giocatore in quel ruolo.»\n\nTieni d'occhio il morale del giocatore."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Rumor di trasferimento: {{player}} nel mirino",
+        "body0": "Eros ha lasciato cadere un suggerimento di mercato nell'ultimo episodio di Al Lío: «Sto sentendo cose su {{player}}. Diverse squadre hanno fatto domande. Niente di confermato ancora, ma il mercato intorno a {{team}} si sta scaldando.»\n\nTienitelo in mente quando pianifichi la tua rosa per il prossimo split.",
+        "subject1": "Al Lío Podcast — Eros suggerisce un movimento in entrata per {{team}}",
+        "body1": "Eros da giorni lascia indizi su Al Lío: «Mi è stato detto che ci sono conversazioni intorno a {{team}}. Qualcosa si sta cucinando. Non posso ancora dare nomi, ma restate sintonizzati — questo mercato non è finito.»\n\nPotrebbe essere rumore, potrebbe essere reale. Vale la pena stare attenti.",
+        "subject2": "Al Lío Podcast — Leak sul formato della lega, Eros spiega tutto",
+        "body2": "L'episodio di Al Lío di oggi è andato fuori copione quando Eros ha rivelato un possibile leak: «Mi è stato detto che la lega sta pianificando cambiamenti al formato dello split. Non è ufficiale, ma le mie fonti sono di solito affidabili. Questo potrebbe cambiare il modo in cui le squadre costruiscono i loro roster.»\n\nSe fosse vero, potrebbe influenzare la tua pianificazione a lungo termine.",
+        "subject3": "Al Lío Podcast — Grande movimento in arrivo, la lega si agita",
+        "body3": "Eros è andato live su Al Lío con quello che ha chiamato un «bombazo»: «Sta per succedere un importante movimento di giocatore nella lega di cui nessuno parla ancora. Dirò solo questo — alcune squadre dovranno ripensare completamente i loro roster.»\n\nRimani all'erta — il mercato si muove.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} nel mirino di {{rival}}",
+          "body0": "Eros ha aperto l'ultimo episodio di Al Lío con una bomba: «Ho informazioni che {{rival}} ha iniziato a muoversi per {{player}}. I loro analisti stanno esaminando le ultime serie e i dati di solo queue da settimane. Nessuna offerta formale ancora, ma le cose si stanno scaldando velocemente.»\n\nQual è la vostra posizione se prendono contatto?",
+          "body1": "Al Lío Podcast ha riportato in esclusiva che {{player}} è ora un obiettivo concreto per {{rival}}.\n\nSecondo Eros, il giocatore ha attirato attenzione dopo le recenti prestazioni sul palco. Ancora nessuna offerta ufficiale, ma la pressione cresce velocemente.\n\nQual è la tua posizione?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — perfino Yuste ammette: gli spettatori salgono questa settimana",
+          "body0": "Yuste ha sorpreso il suo stream con un raro parere positivo: «Sarò onesto — i numeri stanno salendo questa settimana e non farò finta di non vederlo. Quando i match sono buoni, il pubblico torna. Semplice.»\n\nUn momento positivo per tutta la scena.",
+          "subject1": "el_yuste — i match di questa settimana hanno entusiasmato perfino Yuste",
+          "body1": "Non è una cosa che si sente ogni giorno: Yuste era entusiasta nel suo stream mattutino. «Questa settimana ha consegnato. Match veri, posta vera, spettatori rimasti fino alla fine. Questo è quello che può essere la lega quando ci prova.»\n\nBuona settimana per gli esports."
+        },
+        "down": {
+          "subject0": "el_yuste — gli spettatori della lega crollano e nessuno fa niente",
+          "body0": "Antonio Yuste ha aperto il suo stream mattutino con una vera lamentela: «I numeri non mentono. Gli spettatori calano settimana dopo settimana e la lega continua a fare le stesse cose aspettandosi risultati diversi. C'est fini se non cambia niente.»\n\nSolo rumore di fondo — ma quando Yuste parla, la community ascolta.",
+          "subject1": "el_yuste — il prodotto della lega è rotto, secondo Yuste",
+          "body1": "Yuste ha dedicato una buona mezz'ora del suo stream mattutino ad analizzare il calo di engagement della lega: «Lo dico da mesi. Il prodotto non è abbastanza buono. Il formato annoia, il calendario uccide il momentum. I dati sono chiari.»\n\nDuro, ma l'audience di Yuste lo prende sul serio."
+        }
       }
     },
     "news": {

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -2112,7 +2112,10 @@
       "scout": "Olheiro",
       "performanceStaff": "Equipe de Performance",
       "coachingStaff": "Comissão Técnica",
-      "academyCoordinator": "Coordenador da Academia"
+      "academyCoordinator": "Coordenador da Academia",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Presidente",
@@ -2129,7 +2132,10 @@
       "scout": "Olheiro",
       "performanceStaff": "Equipe de Performance",
       "coachingStaff": "Comissão Técnica",
-      "academyCoordinator": "Coordenador da Academia"
+      "academyCoordinator": "Coordenador da Academia",
+      "esportmaniacos": "Painel",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Dot Esports",
@@ -2550,6 +2556,49 @@
         "subject": "Relatório semanal da academia: {{academy}}",
         "body": "Resumo semanal da academia:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}",
         "bodyWithPromotion": "Resumo semanal da academia:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}\n\nRecomendação: {{promotionCount}} jogador(es) prontos para promoção -> {{promotionList}}."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos elogia {{player}} — o painel está de acordo",
+          "body0": "Os tertulianos da Esportmaníacos dedicaram boa parte da stream de hoje a falar de {{player}} no {{team}}.\n\n«Nada a criticar essa semana. O cara está dominando de forma impressionante.» Difícil discordar. A cobertura positiva deve melhorar o clima no vestiário.",
+          "subject1": "Esportmaníacos: {{player}} está carregando o {{team}} neste split",
+          "body1": "Os tertulianos da Esportmaníacos raramente concordam, mas {{player}} recebeu um passe livre hoje: «Consistente, sólido, sem quedas de forma. Um dos melhores jogadores da liga agora. O {{team}} devia fazer tudo para mantê-lo.»\n\nBom para o moral — e para o valor de mercado."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos vai a cima de {{player}} — o painel não tem piedade",
+          "body0": "Os tertulianos da Esportmaníacos não se contiveram hoje com {{player}}: «O cara sumiu completamente. O que aconteceu com ele neste split? O {{team}} não pode continuar dependendo de um jogador que rende assim.»\n\nEsse tipo de cobertura tende a afetar muito o moral. Vale a pena conversar com o jogador.",
+          "subject1": "Esportmaníacos questiona a consistência de {{player}} no {{team}}",
+          "body1": "A tertulia da Esportmaníacos de hoje virou uma análise completa do rendimento recente de {{player}}. Veredicto: «Irregular. Sem consistência. Uns dias no nível máximo, outros completamente invisível. O {{team}} merece mais de um jogador nessa função.»\n\nFique de olho no moral do jogador."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Rumor de transferência: {{player}} no radar",
+        "body0": "Eros deixou cair uma dica de mercado no último episódio do Al Lío: «Estou recebendo coisas sobre {{player}}. Vários times têm feito perguntas. Nada confirmado ainda, mas o mercato em torno do {{team}} está esquentando.»\n\nTenha isso em mente ao planejar seu elenco para o próximo split.",
+        "subject1": "Al Lío Podcast — Eros insinua um movimento de entrada para o {{team}}",
+        "body1": "Eros tem lançado dicas no Al Lío há dias: «Me disseram que há conversas em torno do {{team}}. Algo está sendo cozinhado. Não posso dar nomes ainda, mas fiquem ligados — esse mercato não acabou.»\n\nPode ser boato, pode ser real. Vale a pena ficar atento.",
+        "subject2": "Al Lío Podcast — Leak do formato da liga, Eros explica tudo",
+        "body2": "O episódio do Al Lío de hoje saiu dos trilhos quando Eros revelou um possível leak: «Me disseram que a liga está planejando mudanças no formato do split. Não é oficial, mas minhas fontes costumam ser confiáveis. Isso pode mudar como os times constroem seus rosters.»\n\nSe for verdade, pode afetar seu planejamento a longo prazo.",
+        "subject3": "Al Lío Podcast — Grande movimentação chegando, a liga se agita",
+        "body3": "Eros foi ao vivo no Al Lío com o que chamou de «bombazo»: «Está prestes a acontecer uma grande movimentação de jogador na liga que ninguém está falando ainda. Só digo isso — alguns times vão ter que repensar seus rosters por completo.»\n\nFique alerta — o mercado está em movimento.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} na órbita de {{rival}}",
+          "body0": "Eros abriu o último episódio do Al Lío com uma bomba: «Tenho informação de que {{rival}} começou a se mexer por {{player}}. Seus analistas estão revisando as últimas séries e dados de solo queue há semanas. Ainda sem oferta formal, mas a coisa está esquentando rápido.»\n\nQual é a postura de vocês se eles fizerem contato?",
+          "body1": "Al Lío Podcast reportou com exclusividade que {{player}} é agora um alvo concreto de {{rival}}.\n\nSegundo Eros, o jogador chamou atenção pelos seus últimos rendimentos no stage. Ainda sem oferta oficial, mas a pressão cresce rapidamente.\n\nQual é a sua postura?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — até Yuste admite: os viewers sobem essa semana",
+          "body0": "Yuste surpreendeu sua stream com uma opinião positiva das que raramente acontecem: «Vou ser honesto — os números estão subindo essa semana e não vou fingir que não. Quando os jogos são bons, o público vem. Simples assim.»\n\nBom momento para a cena.",
+          "subject1": "el_yuste — os jogos dessa semana até animaram Yuste",
+          "body1": "Raridade: Yuste estava animado na stream matinal. «Essa semana entregou. Jogos de verdade, stakes de verdade, viewers que ficaram até o fim. Isso é o que a liga pode ser quando se esforça.»\n\nBoa semana para estar nos esports."
+        },
+        "down": {
+          "subject0": "el_yuste — os viewers da liga estão despencando e ninguém faz nada",
+          "body0": "Antonio Yuste abriu sua stream matinal com uma reclamação em regra: «Os números não mentem. Os viewers caem semana após semana e a liga continua fazendo a mesma coisa esperando resultados diferentes. C'est fini se nada mudar.»\n\nApenas ruído de fundo — mas quando Yuste fala, a comunidade escuta.",
+          "subject1": "el_yuste — o produto da liga está quebrado, segundo Yuste",
+          "body1": "Yuste dedicou uma boa meia hora da stream matinal a analisar a queda de engajamento da liga: «Falo isso há meses. O produto não é bom o suficiente. O formato entedia, o calendário mata o momentum. Os dados são claros.»\n\nDuro, mas a audiência de Yuste leva isso a sério."
+        }
       }
     },
     "news": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -2104,7 +2104,10 @@
       "scout": "Olheiro",
       "performanceStaff": "Equipe de Performance",
       "coachingStaff": "Comissão Técnica",
-      "academyCoordinator": "Coordenador da Academia"
+      "academyCoordinator": "Coordenador da Academia",
+      "esportmaniacos": "Esportmaníacos",
+      "allioPodcast": "Al Lío Podcast",
+      "elYuste": "el_yuste"
     },
     "role": {
       "chairman": "Presidente",
@@ -2121,7 +2124,10 @@
       "scout": "Olheiro",
       "performanceStaff": "Equipe de Performance",
       "coachingStaff": "Comissão Técnica",
-      "academyCoordinator": "Coordenador da Academia"
+      "academyCoordinator": "Coordenador da Academia",
+      "esportmaniacos": "Painel",
+      "allioPodcast": "Eros",
+      "elYuste": "el_yuste"
     },
     "source": {
       "sportsGazette": "Esports Gazette",
@@ -2542,6 +2548,49 @@
         "subject": "Relatório semanal da academia: {{academy}}",
         "body": "Resumo semanal da academia:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}",
         "bodyWithPromotion": "Resumo semanal da academia:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}\n\nRecomendação: {{promotionCount}} jogador(es) prontos para promoção -> {{promotionList}}."
+      },
+      "esportmaniacos": {
+        "positive": {
+          "subject0": "Esportmaníacos elogia {{player}} — o painel está de acordo",
+          "body0": "Os tertulianos da Esportmaníacos dedicaram boa parte da stream de hoje a falar de {{player}} no {{team}}.\n\n«Nada a criticar esta semana. O tipo está a dominar de forma impressionante.» Difícil discordar. A cobertura positiva deve melhorar o ambiente no balneário.",
+          "subject1": "Esportmaníacos: {{player}} está a carregar o {{team}} neste split",
+          "body1": "Os tertulianos da Esportmaníacos raramente concordam, mas {{player}} teve um passe livre hoje: «Consistente, sólido, sem quebras de forma. Um dos melhores jogadores da liga neste momento. O {{team}} devia fazer tudo para o manter.»\n\nBom para o moral — e para o valor de mercado."
+        },
+        "negative": {
+          "subject0": "Esportmaníacos vai a cima de {{player}} — o painel não tem piedade",
+          "body0": "Os tertulianos da Esportmaníacos não se contiveram hoje com {{player}}: «O tipo desapareceu por completo. O que lhe aconteceu neste split? O {{team}} não pode continuar a depender de um jogador que rende assim.»\n\nEste tipo de cobertura tende a afetar muito o moral. Vale a pena falar com o jogador.",
+          "subject1": "Esportmaníacos questiona a consistência de {{player}} no {{team}}",
+          "body1": "A tertulia da Esportmaníacos de hoje tornou-se numa análise completa do rendimento recente de {{player}}. Veredicto: «Irregular. Sem consistência. Alguns dias ao máximo, outros completamente invisível. O {{team}} merece mais de um jogador nesse papel.»\n\nPresta atenção ao moral do jogador."
+        }
+      },
+      "allio": {
+        "subject0": "Al Lío Podcast — Rumor de transferência: {{player}} no radar",
+        "body0": "Eros deixou cair uma dica de mercado no último episódio de Al Lío: «Estou a receber coisas sobre {{player}}. Vários equipas têm estado a fazer perguntas. Nada confirmado ainda, mas o mercato à volta do {{team}} está a aquecer.»\n\nTem isso em conta ao planear o teu plantel para o próximo split.",
+        "subject1": "Al Lío Podcast — Eros insinua um movimento de entrada para o {{team}}",
+        "body1": "Eros tem estado a lançar pistas em Al Lío há dias: «Disseram-me que há conversas à volta do {{team}}. Algo está a cozinhar. Não posso dar nomes ainda, mas fiquem atentos — este mercato não acabou.»\n\nPode ser ruído, pode ser real. Vale a pena estar atento.",
+        "subject2": "Al Lío Podcast — Leak do formato da liga, Eros explica tudo",
+        "body2": "O episódio de Al Lío de hoje saiu dos trilhos quando Eros revelou um possível leak: «Disseram-me que a liga está a planear mudanças no formato do split. Não é oficial, mas as minhas fontes costumam ser fiáveis. Isto pode mudar a forma como as equipas constroem os seus rosters.»\n\nSe for verdade, pode afetar o teu planeamento a longo prazo.",
+        "subject3": "Al Lío Podcast — Grande movimento a caminho, a liga agita-se",
+        "body3": "Eros foi ao vivo em Al Lío com o que chamou de um «bombazo»: «Está prestes a acontecer um grande movimento de jogador na liga de que ninguém está a falar ainda. Só vos digo isto — algumas equipas vão ter de repensar os seus rosters por completo.»\n\nFica alerta — o mercado está em movimento.",
+        "rivalInterest": {
+          "subject": "Al Lío Podcast — {{player}} na órbita de {{rival}}",
+          "body0": "Eros abriu o último episódio de Al Lío com uma bomba: «Tenho informação de que {{rival}} começou a mexer-se por {{player}}. Os seus analistas têm estado a rever as últimas séries e dados de solo queue há semanas. Ainda sem oferta formal, mas a coisa está a aquecer depressa.»\n\nQual é a vossa postura se entrarem em contacto?",
+          "body1": "Al Lío Podcast reportou em exclusivo que {{player}} é agora um alvo concreto de {{rival}}.\n\nSegundo Eros, o jogador chamou a atenção pelos seus últimos rendimentos em stage. Ainda sem oferta oficial, mas a pressão cresce rapidamente.\n\nQual é a tua postura?"
+        }
+      },
+      "yuste": {
+        "up": {
+          "subject0": "el_yuste — até Yuste admite: os viewers sobem esta semana",
+          "body0": "Yuste surpreendeu a sua stream com uma opinião positiva das que raramente acontecem: «Vou ser honesto — os números estão a subir esta semana e não vou fingir que não. Quando os jogos são bons, o público vem. Assim tão simples.»\n\nBom momento para a cena.",
+          "subject1": "el_yuste — os jogos desta semana até entusiasmaram Yuste",
+          "body1": "Raridade: Yuste estava entusiasmado na sua stream matinal. «Esta semana entregou. Jogos a sério, stakes a sério, viewers que ficaram até ao fim. Isto é o que a liga pode ser quando se esforça.»\n\nBoa semana para estar nos esports."
+        },
+        "down": {
+          "subject0": "el_yuste — os viewers da liga estão a cair a pique e ninguém faz nada",
+          "body0": "Antonio Yuste abriu a sua stream matinal com uma queixa em regra: «Os números não mentem. Os viewers caem semana após semana e a liga continua a fazer o mesmo esperando resultados diferentes. C'est fini se nada mudar.»\n\nApenas ruído de fundo — mas quando Yuste fala, a comunidade ouve.",
+          "subject1": "el_yuste — o produto da liga está partido, segundo Yuste",
+          "body1": "Yuste dedicou uma boa meia hora da sua stream matinal a analisar a queda de engagement da liga: «Digo isto há meses. O produto não é suficientemente bom. O formato aborrece, o calendário mata o momentum. Os dados são claros.»\n\nDuro, mas a audiência de Yuste leva isso a sério."
+        }
       }
     },
     "news": {


### PR DESCRIPTION
## Summary

- **Esportmaníacos** replaces the old generic press officer emails. The *tertulianos* panel now comments on player performance with 2 positive and 2 negative content variants, picked randomly. Trigger raised from 2 % to 5 % per day.
- **Al Lío Podcast** (Eros) takes over transfer-rumour and rival-interest messages with 4 content variants covering outgoing player rumours, incoming deal hints, league format leaks, and general market bombazos. Trigger raised to 5 % per day.
- **el_yuste** is a new lightweight random event (3 % per day) covering league viewer commentary — 2 positive variants (viewers up, good week) and 2 negative variants (viewers tanking, product criticism).
- All three sources ship with full i18n coverage across **en, es, fr, de, it, pt and pt-BR**.
- No gameplay mechanics changed; only message content, senders, and event probabilities.

## Files changed

- `src-tauri/crates/ofm_core/src/random_events/message_builders.rs` — Esportmaníacos framing for media story, new `allio_podcast_message` and `yuste_stream_message` builders
- `src-tauri/crates/ofm_core/src/random_events/builders_reports.rs` — rival interest message reframed as Al Lío Podcast
- `src-tauri/crates/ofm_core/src/random_events/mod.rs` — events 10 and 11 added, probabilities updated
- `src/i18n/locales/*.json` — new keys under `be.msg.esportmaniacos`, `be.msg.allio`, `be.msg.yuste`, `be.sender`, `be.role`

## Test plan

- [x] `cargo check --manifest-path src-tauri/Cargo.toml` passes
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check` clean
- [x] Advance several in-game days and confirm Esportmaníacos, Al Lío and el_yuste messages appear in the inbox
- [x] Verify sender name and role display correctly in tested locales
- [x] Confirm rival-interest message now shows Al Lío Podcast as sender