### PR TITLE
Updated pt-BR translations

### DIFF
--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -53,7 +53,7 @@
             "text": "Nas teamfights decisivas, faltou coordenação e o adversário puniu cada engage. O que faltou para fechar essas lutas?"
           },
           "mentalResetAfterLoss": {
-            "text": "É uma derrota dura para o grupo. Como você protege o vestiário para que isso não pese na próxima série?"
+            "text": "É uma derrota dura para o grupo. Como você protege o elenco para que isso não pese na próxima série?"
           },
           "rivalryWeekPressure": {
             "text": "Semana de rivalidade traz barulho fora do jogo e pressão no Rift. Preparar essa partida parece diferente?"
@@ -86,7 +86,7 @@
           },
           "challengeRoster": {
             "label": "Cobrar o elenco",
-            "text": "Esse nível não basta. Jogadores e comissão precisam competir com mais presença desde o primeiro minuto."
+            "text": "Esse nível não basta. Jogadores e comissão precisam competir com mais confiança desde o primeiro minuto."
           },
           "creditOpponent": {
             "label": "Dar mérito ao adversário",
@@ -126,15 +126,15 @@
           },
           "takeResponsibility": {
             "label": "Assumir responsabilidade",
-            "text": "A responsabilidade começa em mim. Se o time não estava pronto para esses momentos, precisamos corrigir isso na comissão."
+            "text": "A responsabilidade começa em mim. Se o time não estava pronto para esses momentos, precisamos corrigir isso pela comissão."
           }
         },
         "conversations": {
           "playerPressureReset": {
-            "body": "{{player}} pediu um reset privado depois de um bloco pesado de scrims. A moral está em {{morale}} e ele sente que a pressão de stage já começa a afetar a comunicação do time.\n\n\"Eu preciso resetar antes que essa pressão entre na próxima série, chefe.\""
+            "body": "{{player}} pediu um reset privado depois de um bloco pesado de scrims. A moral está em {{morale}} e ele sente que a pressão do stage já começa a afetar a comunicação do time.\n\n\"Eu preciso resetar antes que essa pressão entre na próxima série, chefe.\""
           },
           "playerStageTimeRequest": {
-            "body": "{{player}} chegou frustrado com poucos minutos no stage. Ele sente que foi bem nos scrims e quer clareza sobre o que garante vaga na próxima série.\n\n\"Se eu não estou no plano de stage, preciso saber o que tem que mudar.\""
+            "body": "{{player}} chegou frustrado com poucos minutos no stage. Ele sente que foi bem nos scrims e quer clareza sobre o que garante vaga na próxima série.\n\n\"Se eu não estou no plano do time, preciso saber o que tenho que mudar.\""
           },
           "playerHighFormCheckin": {
             "body": "{{player}} apareceu depois de uma sequência forte em solo queue e treinos de equipe. Ele está curtindo a clareza na sala de draft e acredita que o elenco está perto de subir outro nível.\n\n\"Se mantivermos essa estrutura, eu vou levar essa confiança pro stage.\""
@@ -174,13 +174,13 @@
     "selectCountry": "Selecionar País/Região...",
     "searchNationalities": "Pesquisar nacionalidades...",
     "chooseWorld": "Escolher Mundo",
-    "placeholderFirst": "ex: José",
-    "placeholderLast": "ex: Mourinho"
+    "placeholderFirst": "ex: Jorge",
+    "placeholderLast": "ex: Jesus"
   },
   "validation": {
     "required": "{{field}} é obrigatório",
     "maxLength": "{{field}} não deve exceder {{max}} caracteres",
-    "minAge": "O treinador deve ter pelo menos {{min}} anos — altere a data de nascimento para continuar.",
+    "minAge": "O Head Coach deve ter pelo menos {{min}} anos — altere a data de nascimento para continuar.",
     "invalidDate": "Data inválida",
     "invalidDob": "Data de nascimento inválida"
   },
@@ -222,8 +222,8 @@
     "noResults": "Sem resultados.",
     "searchTeams": "Times",
     "searchPlayers": "Jogadores",
-    "scouting": "Observação",
-    "youthAcademy": "Academia",
+    "scouting": "Scouting",
+    "youthAcademy": "Academy",
     "saveGame": "Salvar jogo",
     "saving": "Salvando...",
     "saved": "Salvo!",
@@ -243,7 +243,7 @@
     "patchNumber": "Patch {{n}}",
     "patchLastDate": "Último patch: {{date}}",
     "patchPending": "Nenhum patch foi aplicado ainda.",
-    "metaHiddenHint": "Sua comissão ainda está descobrindo a meta deste patch. Melhores scouts revelam isso mais rápido.",
+    "metaHiddenHint": "Sua comissão ainda está descobrindo o meta deste patch. Melhores scouts revelam isso mais rápido.",
     "tierScore": "Pontuação de tier: {{value}}",
     "masteryTrainingTitle": "Treino de Maestria de Campeões",
     "noTarget": "Sem alvo",
@@ -394,14 +394,14 @@
     "repDeveloping": "Em Desenvolvimento"
   },
   "youthAcademy": {
-    "title": "Academia",
+    "title": "Academy",
     "playersUnder21": "{{count}} jogadores ≤21",
-    "youthPlayers": "Jogadores da Academia",
+    "youthPlayers": "Jogadores do Academy",
     "avgOvr": "OVR Médio",
     "avgPotential": "Potencial Médio",
     "highPotential": "Alto Potencial",
-    "youthCoach": "Coach da Academia:",
-    "youthProspects": "Talentos da Academia",
+    "youthCoach": "Coach do Academy:",
+    "youthProspects": "Talentos do Academy",
     "noYouthPlayers": "Nenhum jogador jovem (≤21) no seu elenco.",
     "player": "Jogador",
     "pos": "Pos",
@@ -416,23 +416,23 @@
     "potPromising": "Promissor",
     "potDecent": "Razoável",
     "potLimited": "Limitado",
-    "loadOptionsError": "Não foi possível carregar as opções da academia.",
-    "academyCardTitle": "Academia",
-    "acquisitionLoading": "Carregando opções para adquirir academia...",
-    "acquisitionIntro": "Você ainda não tem academia vinculada. Escolha um time ERL para adquiri-la.",
-    "acquisitionNoOptions": "Não há opções de academia disponíveis para seu time neste momento.",
+    "loadOptionsError": "Não foi possível carregar as opções do academy.",
+    "academyCardTitle": "Academy",
+    "acquisitionLoading": "Carregando opções para adquirir academy...",
+    "acquisitionIntro": "Você ainda não tem academy vinculada. Escolha um time ERL para adquiri-lo.",
+    "acquisitionNoOptions": "Não há opções de academy disponíveis para seu time neste momento.",
     "placeholderCustomName": "Nome personalizado (opcional)",
     "placeholderCustomShortName": "Sigla personalizada (opcional)",
     "placeholderCustomLogoUrl": "URL do logo (opcional)",
-    "fundAcademy": "Financiar academia",
+    "fundAcademy": "Financiar academy",
     "fundingAcademy": "Financiando...",
     "sourceTeamLogoAlt": "Logo do {{team}}",
-    "academyRosterLinked": "Elenco da academia",
-    "academyNotLinked": "Academia não vinculada",
+    "academyRosterLinked": "Elenco do academy",
+    "academyNotLinked": "Academy não vinculada",
     "promoting": "Subindo...",
     "promote": "Subir",
-    "academyPlayers": "jogadores da academia",
-    "academyPlayersStartingMayus": "Jogadores da academia"
+    "academyPlayers": "jogadores do academy",
+    "academyPlayersStartingMayus": "Jogadores do academy"
   },
   "common": {
     "loading": "Carregando...",
@@ -710,9 +710,9 @@
     "selectAnotherToSwap": "Selecione um segundo jogador para compará-los e confirmar a troca.",
     "lol": {
       "roles": {
-        "TOP": "Rota superior",
+        "TOP": "Rota superior (Top)",
         "JUNGLE": "Selva",
-        "MID": "Rota do meio",
+        "MID": "Rota do meio (Mid)",
         "ADC": "Rota inferior (ADC)",
         "SUPPORT": "Suporte"
       },
@@ -774,11 +774,11 @@
         "junglePathing": {
           "TopToBot": {
             "label": "Top -> Bot",
-            "description": "Abrimos no top para terminar jogando pelo bot side."
+            "description": "Começamos no top para terminar jogando pelo bot side."
           },
           "BotToTop": {
             "label": "Bot -> Top",
-            "description": "Abrimos embaixo para impactar top nas primeiras janelas."
+            "description": "Começamos embaixo para impactar top nas primeiras janelas."
           }
         },
         "fightPlan": {
@@ -787,8 +787,8 @@
             "description": "Luta organizada: front line protege o carry."
           },
           "Pick": {
-            "label": "Picks",
-            "description": "Jogamos visão e picks para lutar em vantagem."
+            "label": "Pickoff",
+            "description": "Jogamos na visão, buscando pickoffs para lutar em vantagem."
           },
           "Dive": {
             "label": "Dive",
@@ -806,11 +806,11 @@
           },
           "RoamMid": {
             "label": "Rotar para mid",
-            "description": "Depois do reset, rota para mid por picks e controle de visão."
+            "description": "Depois do reset, rota para mid por pickoffs e controle de visão."
           },
           "RoamTop": {
             "label": "Rotar para top",
-            "description": "Rotações cedo para top por dives, grubs e ritmo de mapa."
+            "description": "Rotações cedo para top para dives, grubs e ritmo de mapa."
           }
         }
       },
@@ -922,12 +922,12 @@
       "Balanced": {
         "label": "Equilibrado",
         "desc": "4 dias de treino, 3 descanso",
-        "detail": "Treino seg, ter, qui, sex. Descanso qua, sáb, dom. Recomendado para a maioria dos elencos."
+        "detail": "Treino Seg, Ter, Qui, Sex. Descanso Qua, Sáb, Dom. Recomendado para a maioria dos elencos."
       },
       "Light": {
         "label": "Leve",
         "desc": "2 dias de treino, 5 descanso",
-        "detail": "Treino apenas ter e qui. Prioriza recuperação. Bom após sequência intensa de jogos."
+        "detail": "Treino apenas Ter e Qui. Prioriza recuperação. Bom após sequência intensa de jogos."
       }
     },
     "days": {
@@ -964,13 +964,13 @@
     },
     "scrims": {
       "title": "Scrims semanais",
-      "description": "Planeje scrims por dia. O nivel do rival e calculado pelos cinco titulares; rivais mais fortes aceleram o crescimento nos scrims.",
+      "description": "Planeje scrims por dia. O nivel do rival é calculado pelos cinco titulares; rivais mais fortes aceleram o crescimento nas scrims.",
       "weekCapacity": "Capacidade semanal",
       "lossStreak": "Sequencia",
       "autoRandom": "Auto-random ativo",
-      "noOpponent": "Aleatorio",
-      "randomResolved": "Aleatorio -> {{team}}",
-      "opponentLogoAlt": "Logo do adversario"
+      "noOpponent": "Aleatório",
+      "randomResolved": "Aleatório -> {{team}}",
+      "opponentLogoAlt": "Logo do adversário"
     }
   },
   "staff": {
@@ -1018,7 +1018,7 @@
       "execution": "Execução",
       "recovery": "Recuperação",
       "draftAnalysis": "Análise de draft",
-      "futureMeta": "Meta futura",
+      "futureMeta": "Meta futuro",
       "tiltControl": "Controle de tilt"
     }
   },
@@ -1047,18 +1047,18 @@
     "facilityRecoverySuite": "Suíte de recuperação",
     "facilityContentStudio": "Estúdio de conteúdo",
     "facilityScoutingLab": "Laboratório de olheiros",
-    "facilityScrimsRoomEffect": "Melhora a qualidade dos scrims e as repetições da equipe.",
+    "facilityScrimsRoomEffect": "Melhora a qualidade das scrims e as repetições da equipe.",
     "facilityAnalysisRoomEffect": "Melhora a revisão de VODs e a preparação de partidas.",
     "facilityBootcampAreaEffect": "Melhora os blocos de preparação em bootcamp.",
     "facilityRecoverySuiteEffect": "Melhora a recuperação dos jogadores e o suporte ao tratamento.",
     "facilityContentStudioEffect": "Melhora a ativação de patrocinadores e as operações de conteúdo.",
     "facilityScoutingLabEffect": "Melhora a qualidade da observação e a profundidade das informações.",
-    "facilityTraining": "Centro de treino",
+    "facilityTraining": "Centro de treinamento",
     "facilityMedical": "Centro médico",
     "facilityScouting": "Departamento de olheiros",
     "facilityTrainingEffect": "Melhora a eficácia do treino ao longo do tempo.",
     "facilityMedicalEffect": "Melhora a recuperação e o suporte médico dos jogadores.",
-    "facilityScoutingEffect": "Melhora a qualidade da observação e a profundidade das informações.",
+    "facilityScoutingEffect": "Melhora a qualidade do scouting e a profundidade das informações.",
     "facilityLevel": "Nível {{level}}",
     "monthlyUpkeep": "Manutenção mensal: €{{amount}}",
     "nextUpgradeCost": "Próxima melhoria: €{{amount}}",
@@ -1113,14 +1113,14 @@
     "sortByDate": "Ordenar mensagens por data",
     "sortNewest": "Mais recentes primeiro",
     "sortOldest": "Mais antigas primeiro",
-    "selectMessages": "Selecionar mensagens",
+    "selectMessages": "Selecionar mensagem(ns)",
     "cancelSelection": "Cancelar seleção",
     "selectedCount": "{{count}} selecionada(s)",
-    "deleteSelected": "Excluir selecionadas",
-    "deleteMessage": "Excluir mensagem",
-    "deleteMessageTitle": "Excluir mensagem?",
+    "deleteSelected": "Excluir selecionada(s)",
+    "deleteMessage": "Excluir mensagem(ns)",
+    "deleteMessageTitle": "Excluir mensagem(ns)?",
     "deleteMessageBody": "Isto excluirá permanentemente \"{{subject}}\". Esta ação não pode ser desfeita.",
-    "deleteSelectedTitle": "Excluir mensagens selecionadas?",
+    "deleteSelectedTitle": "Excluir mensagem(ns) selecionada(s)?",
     "deleteSelectedBody": "Isto excluirá permanentemente {{count}} mensagem(ns) selecionada(s). Esta ação não pode ser desfeita.",
     "deleteAction": "Excluir",
     "selectMessageForDeletion": "Selecionar {{subject}}",
@@ -1201,7 +1201,7 @@
     "playerValue": "Valor: {{value}}",
     "bidAmount": "Valor da Proposta",
     "bidAccepted": "Proposta aceita!",
-    "bidCountered": "Eles voltaram com condições revisadas.",
+    "bidCountered": "Eles voltaram com as condições revisadas.",
     "bidRejected": "Proposta rejeitada.",
     "submitting": "Enviando...",
     "submitBid": "Enviar Proposta",
@@ -1216,7 +1216,7 @@
     "counterCountered": "Eles devolveram com um valor menor.",
     "acceptOffer": "Aceitar",
     "rejectOffer": "Rejeitar",
-    "negotiationPulse": "Pulso da negociação",
+    "negotiationPulse": "Ritmo da negociação",
     "negotiationRound": "Rodada {{count}}",
     "negotiationPatience": "Paciência",
     "negotiationTension": "Tensão",
@@ -1238,8 +1238,8 @@
     "transferFeedbackCounterHeadline": "Eles querem mais antes de bater o martelo.",
     "transferFeedbackCounterDetail": "A proposta ficou perto o bastante para manter a conversa, mas o lado deles aponta para um valor mais próximo de {{fee}}.",
     "transferFeedbackRejectedHeadline": "Eles encerraram esta rodada.",
-    "transferFeedbackRejectedDetail": "A proposta não os moveu o suficiente. Você precisaria de um valor mais forte, mais perto de {{fee}}, para reabrir conversas sérias.",
-    "transferFeedbackPlayerRejectedDetail": "O clube aceitou, mas o jogador recusou a transferência após avaliar papel, salário e projeto esportivo."
+    "transferFeedbackRejectedDetail": "A proposta não os agradou o suficiente. Você precisaria de um valor mais forte, mais perto de {{fee}}, para reabrir conversas sérias.",
+    "transferFeedbackPlayerRejectedDetail": "O clube aceitou, mas o jogador recusou a transferência após avaliar papel, salário e projeto de equipe."
   },
   "schedule": {
     "noSchedule": "Nenhum calendário de liga disponível.",
@@ -1271,8 +1271,8 @@
     "roleSetupValue": "TOP · JG · MID · ADC · SUP",
     "draftIdentity": "Draft",
     "playStyleBalanced": "Equilibrado",
-    "playStyleCounter": "Escala e counter",
-    "playStyleDirect": "Escaramuça cedo",
+    "playStyleCounter": "Escalado e Counter",
+    "playStyleDirect": "Lutas cedo (Skirmishs)",
     "winRateShort": "WR"
   },
   "playersList": {
@@ -1353,17 +1353,17 @@
     "renewalRejected": "Proposta recusada",
     "renewalCounter": "Quer mais: €{{wage}}/semana por {{years}} anos",
     "renewalBlocked": "As conversas estão bloqueadas após sua decisão anterior",
-    "renewalCooledOff": "As conversas anteriores esfriaram, então isto recomeça como uma nova negociação.",
+    "renewalCooledOff": "As conversas anteriores esfriaram, então tudo recomeça como uma nova negociação.",
     "delegateRenewal": "Delegar ao assistente",
     "renewalDelegateMissingReport": "O relatório do assistente não incluía este jogador.",
-    "renewalConversationTitle": "Pulso da negociação",
+    "renewalConversationTitle": "Ritmo da negociação",
     "renewalRound": "Rodada {{count}}",
     "renewalPatience": "Paciência",
     "renewalTension": "Tensão",
     "renewalFeedbackCalmHeadline": "O entorno do jogador ainda está disposto a ouvir.",
     "renewalFeedbackCalmDetail": "Por enquanto, é principalmente uma conversa de negócios. O momento importa, mas a relação ainda não está realmente sob pressão.",
     "renewalFeedbackFirmHeadline": "Eles querem condições melhores antes de avançar.",
-    "renewalFeedbackFirmDetail": "A conversa segue aberta, mas salário e duração precisam parecer claramente mais vantajosos para o lado deles.",
+    "renewalFeedbackFirmDetail": "A conversa segue aberta, mas o salário e a duração precisam parecer claramente mais vantajosos para o lado deles.",
     "renewalFeedbackTenseHeadline": "A conversa está ficando difícil.",
     "renewalFeedbackTenseDetail": "Pouca confiança, moral baixa ou pressão contratual estão endurecendo a posição deles. Outra oferta fraca pode encerrar tudo.",
     "renewalFeedbackAcceptedHeadline": "O pacote convenceu rapidamente.",
@@ -1375,13 +1375,13 @@
     "attributes": "Atributos",
     "lolStatGroups": {
       "gameplay": "Gameplay",
-      "gameIq": "Game IQ",
+      "gameIq": "Conhecimento de Jogo",
       "competitive": "Competitivo"
     },
     "lolStats": {
       "mechanics": "Mecânicas",
       "laning": "Laning",
-      "teamfighting": "Teamfighting",
+      "teamfighting": "Team Fighting",
       "macro": "Macro",
       "consistency": "Consistência",
       "shotcalling": "Shotcalling",
@@ -1425,13 +1425,13 @@
     "renewalProjectionBudgetUsage": "Uso do orçamento salarial {{before}}% → {{after}}%",
     "renewalProjectionRunway": "Reserva de caixa {{before}} → {{after}}",
     "scoutSending": "Enviando...",
-    "championPoolTitle": "Pool de campeões",
-    "championInsignia": "Insígnia",
+    "championPoolTitle": "Pool de Campeões",
+    "championInsignia": "Característico",
     "championWinRateShort": "WR",
     "championMasteryLabel": "Maestria {{value}}",
     "championGames": "Partidas",
     "promoteToMain": "Promover ao time principal",
-    "demoteToAcademy": "Rebaixar para a academia",
+    "demoteToAcademy": "Rebaixar para o academy",
     "rerollWarning": "Alterar a posição recalcula atributos e pode mudar o OVR dos jogadores."
   },
   "teamProfile": {
@@ -1442,8 +1442,8 @@
     "roleSetup": "Funções-chave",
     "draftIdentity": "Identidade de draft",
     "playStyleBalanced": "Equilibrado",
-    "playStyleCounter": "Escala e counter",
-    "playStyleDirect": "Escaramuça cedo",
+    "playStyleCounter": "Escalado e Counter",
+    "playStyleDirect": "Lutas cedo (Skirmishs)",
     "stadium": "Estádio",
     "capacity": "Capacidade",
     "leaguePos": "Pos na Liga",
@@ -1564,12 +1564,12 @@
     "keyEvents": "Eventos-Chave",
     "noEventsYet": "A partida ainda não começou.",
     "waitingKickoff": "Aguardando o pontapé inicial...",
-    "waitingFirstSkirmish": "Aguardando a primeira escaramuça...",
+    "waitingFirstSkirmish": "Aguardando o primeiro skirmishs...",
     "liveControls": "Controles ao vivo",
     "play": "Jogar",
     "reset": "Reiniciar",
     "skipWarningTitle": "Aviso",
-    "skipWarningBody": "Skip Match agora simula novamente desde o minuto 0. Você vai perder todo o progresso desta partida ao vivo.",
+    "skipWarningBody": "Pular Partida agora simula novamente desde o minuto 0. Você vai perder todo o progresso desta partida ao vivo.",
     "resimFromZero": "Re-simular do 0",
     "clearingBattlefield": "Limpando campo de batalha...",
     "draft": {
@@ -1632,7 +1632,7 @@
         "comfort": "Conforto",
         "preparation": "Preparação"
       },
-      "seriesBans": "Series Bans · campeões banidos",
+      "seriesBans": "Bans da Série · campeões banidos",
       "actions": {
         "ban": "Ban",
         "pick": "Pick"
@@ -1646,7 +1646,7 @@
       "phrases": {
         "coachBan": {
           "0": "Se deixarmos {{champion}}, {{player}} pune a gente: {{mastery}}% de maestria.",
-          "1": "{{champion}} é puro comfort para {{player}} ({{mastery}}%). Eu tiro nos bans.",
+          "1": "{{champion}} é puro confort para {{player}} ({{mastery}}%). Eu tiro nos bans.",
           "2": "Prioridade de ban: {{champion}}. {{player}} joga isso em nível de {{mastery}}%.",
           "3": "Não vamos entregar {{champion}}; {{player}} já mostrou {{mastery}}% nesse pick.",
           "4": "Ban cedo em {{champion}}. Esse matchup na mão de {{player}} é perigoso ({{mastery}}%).",
@@ -1654,15 +1654,15 @@
         },
         "playerCounterPick": {
           "0": "Me picka {{champion}}. Eu ganho o matchup contra {{enemy}}.",
-          "1": "Me dá {{champion}}, contra {{enemy}} eu quebro a lane.",
+          "1": "Me dá {{champion}}, contra {{enemy}} eu acabo com a lane.",
           "2": "Com {{champion}} eu tiro vantagem real de {{enemy}}. Confia.",
           "3": "{{champion}} é a resposta certa para {{enemy}}. Deixa comigo.",
           "4": "Se vier {{enemy}}, eu quero {{champion}}: estudei esse confronto.",
-          "5": "Comfort + counter pick: {{champion}} em {{enemy}}. É agora."
+          "5": "Conforto + counter pick: {{champion}} em {{enemy}}. É agora."
         },
         "playerSmartCounterPick": {
-          "0": "Por favor, me picka {{champion}}; com minha leitura de jogo eu quebro esse matchup contra {{enemy}}.",
-          "1": "Com {{champion}} eu consigo outplay em {{enemy}} desde a wave 1. Me dá esse pick.",
+          "0": "Por favor, picka {{champion}} pra mim; com minha leitura de jogo eu acabo com esse matchup contra {{enemy}}.",
+          "1": "Com {{champion}} eu consigo dar outplay em {{enemy}} desde a wave 1. Me dá esse pick.",
           "2": "Esse {{enemy}} fica exposto se você me der {{champion}}. Dá para snowballar.",
           "3": "Tenho timing perfeito para punir {{enemy}} com {{champion}}.",
           "4": "Confia em mim: {{champion}} vs {{enemy}} é vantagem técnica para nós.",
@@ -1681,7 +1681,7 @@
           "1": "Se tirarmos {{threat}}, meu {{champion}} fica bem mais livre.",
           "2": "Preciso de {{threat}} fora; complica demais o plano com {{champion}}.",
           "3": "Ban em {{threat}} e eu jogo {{champion}} com muito mais pressão.",
-          "4": "{{threat}} é counter duro de {{champion}}. Melhor negar agora.",
+          "4": "{{threat}} é hard counter de {{champion}}. Melhor banir agora.",
           "5": "Se vocês querem que eu jogue de {{champion}}, o ideal é tirar {{threat}}."
         }
       }
@@ -1807,7 +1807,7 @@
       "goldIcon": "Ouro",
       "lecLogo": "Logo da liga",
       "dragonIcon": "Dragão",
-      "voidgrubIcon": "Voidgrub",
+      "voidgrubIcon": "Vastilarvas",
       "killerIcon": "Abate",
       "victimIcon": "Eliminado"
     },
@@ -1908,7 +1908,7 @@
           },
           "deflect": {
             "tone": "Desviar",
-            "text": "Não gosto de destacar indivíduos. Futebol é jogo coletivo."
+            "text": "Não gosto de destacar indivíduos. LoL é jogo coletivo."
           }
         }
       },
@@ -2055,7 +2055,7 @@
     "compare": "Comparar"
   },
   "scouting": {
-    "title": "Central de Observação",
+    "title": "Central de Scouting",
     "scouts": "Olheiros",
     "activeAssignments": "Tarefas Ativas",
     "freeSlots": "Olheiros Livres",
@@ -2088,11 +2088,11 @@
     "estimatedAttributes": "Atributos estimados",
     "undiscovered": "Não descoberto",
     "confidence": "Confiança",
-    "academyScoutingTag": "Academia e scouting",
-    "academyAcquired": "Academia adquirida",
-    "academyPending": "Aquisição da academia pendente",
+    "academyScoutingTag": "Academy e scouting",
+    "academyAcquired": "Academy adquirida",
+    "academyPending": "Aquisição do academy pendente",
     "academyRosterCount": "{{count}} jogadores no elenco adquirido",
-    "academyPipelineHint": "Adquira uma equipe ERL existente na Academia para desbloquear o pipeline.",
+    "academyPipelineHint": "Adquira uma equipe ERL existente no Academy para desbloquear o pipeline.",
     "viewAcquisitionOptions": "Ver opções de aquisição"
   },
   "be": {
@@ -2139,15 +2139,17 @@
       "leagueWire": "Esports Insider",
       "riftWire": "Inven Global",
       "riftHerald": "Riot Games Newsroom",
-      "leaguePulse": "The Shotcaller"
+      "leaguePulse": "The Shotcaller",
+      "maisEsports": "Mais Esports",
+      "cblolInsider": "CBLOL Insider"
     },
     "msg": {
       "welcome": {
         "subject0": "Bem-vindo ao {{team}}",
         "subject1": "Nova Era no {{team}}",
         "subject2": "{{team}} Aguarda Sua Liderança",
-        "body0": "A diretoria do {{team}} tem o prazer de recebê-lo como novo treinador.\n\nTemos grandes expectativas para sua gestão e acreditamos que você pode levar este clube à glória. Sua primeira tarefa será revisar o elenco e preparar um plano tático para a próxima temporada.\n\nDesejamos a você a melhor sorte.",
-        "body1": "Em nome de toda a família {{team}}, estamos entusiasmados em anunciar sua nomeação como treinador.\n\nOs torcedores estão ansiosos para ver sua visão para o time. Reserve um tempo para avaliar o elenco, revisar nossa posição financeira e definir sua abordagem tática.\n\nA diretoria está com você.",
+        "body0": "A diretoria do {{team}} tem o prazer de recebê-lo como novo Head Coach.\n\nTemos grandes expectativas para sua gestão e acreditamos que você pode levar este clube à glória. Sua primeira tarefa será revisar o elenco e preparar um plano tático para a próxima temporada.\n\nDesejamos a você a melhor sorte.",
+        "body1": "Em nome de toda a família {{team}}, estamos entusiasmados em anunciar sua nomeação como Head Coach.\n\nOs torcedores estão ansiosos para ver sua visão para o time. Reserve um tempo para avaliar o elenco, revisar nossa posição financeira e definir sua abordagem tática.\n\nA diretoria está com você.",
         "body2": "Bem-vindo ao {{team}}! Os torcedores e a equipe estão empolgados com o futuro sob sua orientação.\n\nRecomendamos que comece revisando os pontos fortes e fracos do seu elenco, e depois configure sua formação e regime de treino preferidos.\n\nA próxima temporada será um verdadeiro teste — nos faça orgulhosos.",
         "actionReview": "Revisar Elenco",
         "actionThank": "Agradecer à Diretoria"
@@ -2192,7 +2194,7 @@
       },
       "boardObjectives": {
         "subject": "Temporada {{season}} — Objetivos da Diretoria",
-        "body": "A diretoria definiu os seguintes objetivos para esta temporada:\n\n1. Terminar entre os {{expectedPos}} primeiros\n2. Vencer pelo menos {{winTarget}} partidas\n3. Marcar pelo menos {{goalsTarget}} gols\n\nCumprir essas metas vai aumentar a confiança da diretoria no seu trabalho. Não atender às expectativas pode resultar em orçamentos menores ou em outras consequências."
+        "body": "A diretoria definiu os seguintes objetivos para esta temporada:\n\n1. Terminar entre os {{expectedPos}} primeiros\n2. Vencer pelo menos {{winTarget}} partidas\n\nCumprir essas metas vai aumentar a confiança da diretoria no seu trabalho. Não atender às expectativas pode resultar em orçamentos menores ou em outras consequências."
       },
       "financeCritical": {
         "subject": "URGENTE: Clube Endividado",
@@ -2215,7 +2217,7 @@
         "body": {
           "champion": "Parabéns! {{team}} é campeão da liga! Uma conquista incrível.\n\nA diretoria está absolutamente encantada com seu desempenho. Você terminou com {{points}} pontos.\n\nEsperamos defender o título na próxima temporada.",
           "topFour": "Uma temporada sólida para {{team}}. Você terminou em {{position}}º lugar com {{points}} pontos.\n\nA diretoria está satisfeita com a campanha. Vamos buscar o título na próxima temporada.",
-          "midTable": "{{team}} terminou a temporada em {{position}}º lugar com {{points}} pontos.\n\nUma campanha intermediária. A diretoria espera melhora na próxima temporada. Precisamos ser mais competitivos.",
+          "midTable": "{{team}} terminou a temporada em {{position}}º lugar com {{points}} pontos.\n\nUma campanha intermediária. A diretoria espera melhora para a próxima temporada. Precisamos ser mais competitivos.",
           "lowerHalf": "Uma temporada decepcionante para {{team}}. Terminar em {{position}}º lugar com apenas {{points}} pontos está abaixo das expectativas.\n\nA diretoria está preocupada. Melhorias significativas serão necessárias na próxima temporada, ou sua posição poderá ser reavaliada."
         }
       },
@@ -2255,7 +2257,7 @@
               "description": "Mostre empatia e incentive o jogador a continuar trabalhando duro."
             },
             "promiseTime": {
-              "label": "Prometer mais tempo de jogo",
+              "label": "Prometer mais jogos como titular",
               "description": "Diga que ele terá sua chance — grande aumento de moral, mas cria expectativas."
             },
             "workHarder": {
@@ -2312,7 +2314,7 @@
               "positive": "O jogador se sente um pouco melhor. Moral {{delta}}",
               "negative": "O jogador não compra a ideia. Moral {{delta}}"
             },
-            "promiseTime": "O jogador fica tranquilo com a promessa. Moral {{delta}}. Ele vai esperar ser titular em breve.",
+            "promiseTime": "O jogador fica tranquilo com a promessa. Moral {{delta}}. Ele espera ser titular em breve.",
             "workHarder": {
               "positive": "O jogador aceita o desafio. Moral {{delta}}",
               "negative": "O jogador se ofende com a bronca. Moral {{delta}}"
@@ -2347,7 +2349,7 @@
               "negative": "O jogador fica inquieto e infeliz. Moral {{delta}}"
             },
             "noRenewal": "O jogador fica devastado. Moral {{delta}}. Isso pode afetar o vestiário.",
-            "noRenewalWithDressingRoom": "O jogador fica devastado. Moral {{delta}}. Isso pode afetar o vestiário. O clima no vestiário piora — {{affected}} companheiros perdem moral."
+            "noRenewalWithDressingRoom": "O jogador fica devastado. Moral {{delta}}. Isso pode afetar a equipe. O clima na equipe piora — {{affected}} companheiros perdem moral."
           }
         }
       },
@@ -2368,19 +2370,19 @@
       "trainingInjury": {
         "subject": "Lesão — {{player}} ({{injury}})",
         "body0": "Más notícias do treino. {{player}} sofreu uma {{injury}} durante a sessão de hoje.\n\nA equipe médica estima {{days}} dias afastado. Vamos acompanhar a recuperação de perto.",
-        "body1": "Infelizmente, {{player}} caiu no treino hoje com uma {{injury}}.\n\nAvaliação inicial: fora por aproximadamente {{days}} dias. Manteremos você informado sobre o progresso."
+        "body1": "Infelizmente, {{player}} sentiu dores no treino hoje com uma {{injury}}.\n\nAvaliação inicial: fora por aproximadamente {{days}} dias. Manteremos você informado sobre o progresso."
       },
       "mediaPositive": {
         "subject": "Imprensa Positiva — {{player}}",
-        "body": "Os jornais locais estão publicando uma matéria muito positiva sobre {{player}} hoje.\n\nEles destacam a excelente forma recente e o comprometimento com o {{team}}. Esse tipo de cobertura é ótimo para a confiança do jogador e a imagem do clube."
+        "body": "Os jornais locais estão publicando uma matéria muito positiva sobre {{player}} hoje.\n\nEles destacam a excelente performance recente e o comprometimento com o {{team}}. Esse tipo de cobertura é ótimo para a confiança do jogador e a imagem do time."
       },
       "mediaNegative": {
         "subject": "Imprensa Negativa — {{player}}",
-        "body": "Algumas matérias desfavoráveis sobre {{player}} apareceram nos tabloides hoje.\n\nJornalistas estão questionando sua forma e comprometimento com o {{team}}. Isso pode afetar a moral do jogador — talvez seja bom ter uma conversa."
+        "body": "Algumas matérias desfavoráveis sobre {{player}} apareceram nos tablóides hoje.\n\nJornalistas estão questionando sua oerformance e comprometimento com o {{team}}. Isso pode afetar a moral do jogador — talvez seja bom ter uma conversa."
       },
       "intlCallup": {
         "subject": "Convocação Internacional — {{player}}",
-        "body": "{{player}} foi convocado para a seleção {{nationality}} para a próxima data FIFA.\n\nÉ uma grande honra para o jogador e reflete bem no clube. Ele estará de bom humor quando voltar, mas fique de olho nos níveis de fadiga."
+        "body": "{{player}} foi convocado para a seleção {{nationality}} para o próximo evento de Seleções.\n\nÉ uma grande honra para o jogador e reflete bem no clube. Ele estará de bom humor quando voltar, mas fique de olho nos níveis de fadiga."
       },
       "community": {
         "subject0": "Dia Aberto para a Comunidade",
@@ -2415,19 +2417,19 @@
       },
       "fanPetition": {
         "subject0": "Petição da torcida — Drafts mais proativos",
-        "subject1": "Petição da torcida — Mais espaço para a base",
+        "subject1": "Petição da torcida — Mais espaço para o Academy",
         "subject2": "Carta aberta — Transparência competitiva",
         "body0": "Um grupo de torcedores do {{team}} lançou uma petição pedindo drafts mais proativos e mais ritmo no early game.\n\n\"Queremos identidade desde o minuto um, não scaling passivo em toda série.\"\n\nJá são mais de 500 assinaturas. Como você responde?",
-        "body1": "Torcedores do {{team}} iniciaram uma campanha pedindo mais palco para jogadores da base e novos prospectos.\n\n\"O futuro da organização depende de desenvolver talento, não de deixar no banco para sempre.\"\n\nA campanha ganhou força nas redes. Qual é sua resposta?",
-        "body2": "Uma carta aberta da torcida do {{team}} foi publicada pedindo mais transparência da comissão competitiva.\n\n\"Queremos entender o rumo: identidade de draft, plano de elenco e metas de playoffs.\"\n\nA mídia de esports já repercute o tema. Como você lida com isso?",
+        "body1": "Torcedores do {{team}} iniciaram uma campanha pedindo mais palco para jogadores do Academy e novos prospectos.\n\n\"O futuro da organização depende de desenvolver talento, não de deixar no Academy para sempre.\"\n\nA campanha ganhou força nas redes. Qual é sua resposta?",
+        "body2": "Uma carta aberta da torcida do {{team}} foi publicada pedindo mais transparência da comissão técnica.\n\n\"Queremos entender o rumo: identidade de draft, plano de elenco e metas de playoffs.\"\n\nA mídia de esports já repercute o tema. Como você lida com isso?",
         "options": {
           "listenFans": {
             "label": "Ouvir a torcida",
-            "description": "Reúna-se com representantes da torcida e ouça suas preocupações. Bom para o moral."
+            "description": "Reúna-se com representantes da torcida e ouça suas preocupações. Bom para a moral."
           },
           "ignoreFans": {
-            "label": "Focar no futebol",
-            "description": "Recuse com educação — as decisões de futebol ficam dentro do vestiário."
+            "label": "Focar no LoL",
+            "description": "Recuse com educação — as decisões de staff ficam dentro dos escritórios."
           },
           "addressPublicly": {
             "label": "Fazer um pronunciamento público",
@@ -2456,23 +2458,23 @@
       },
       "moraleCrisis": {
         "subject": "{{player}} — Crise de Moral",
-        "body0": "Chefe, {{player}} pediu uma reunião particular. Ele parece muito abatido ultimamente e quer conversar sobre sua situação no clube.\n\nSua moral está em {{morale}} — você deveria resolver isso antes que afete o vestiário.",
-        "body1": "{{player}} tem parecido desanimado nos treinos. Ele pediu para conversar com você sobre seu estado de ánimo.\n\nMoral: {{morale}}. Como você lidar com isso pode fazer ou acabar com a confiança dele."
+        "body0": "Chefe, {{player}} pediu uma reunião particular. Ele parece muito abatido ultimamente e quer conversar sobre sua situação no clube.\n\nSua moral está em {{morale}} — você deveria resolver isso antes que afete a equipe.",
+        "body1": "{{player}} tem parecido desanimado nos treinos. Ele pediu para conversar com você sobre seu estado de ánimo.\n\nMoral: {{morale}}. Como você vai lidar com isso pode aumentar ou acabar com a confiança dele."
       },
       "benchComplaint": {
-        "subject": "{{player}} — Quer Mais Tempo de Jogo",
-        "body0": "Chefe, {{player}} veio falar com você. Ele está frustrado com a falta de tempo de jogo nas últimas partidas e quer saber o que precisa fazer para voltar ao time.\n\n\"Sinto que estou treinando bem, mas não estou tendo chance de mostrar isso em campo.\"",
-        "body1": "{{player}} bateu na porta do seu escritório parecendo infeliz. Ele não atuou nas últimas partidas e quer respostas.\n\n\"Vim para este clube para jogar futebol. Se não estou nos seus planos, prefiro que me diga logo.\""
+        "subject": "{{player}} — Quer Mais Prioridade no Jogo",
+        "body0": "Chefe, {{player}} veio falar com você. Ele está frustrado com a falta de prioridade dentro do jogo nas últimas partidas e quer saber o que precisa fazer para voltar a receber atenção.\n\n\"Sinto que estou treinando bem, mas não estou tendo chance de mostrar isso no stage.\"",
+        "body1": "{{player}} bateu na porta do seu escritório parecendo infeliz. Ele não atuou nas últimas partidas e quer respostas.\n\n\"Vim para este time para jogar LoL. Se não estou nos seus planos, prefiro que me diga logo.\""
       },
       "happyPlayer": {
         "subject": "{{player}} — Se Sentindo Ótimo",
-        "body0": "{{player}} passou pelo seu escritório com um grande sorriso. Ele está se sentindo ótimo com sua forma e a direção do time.\n\n\"Só queria dizer que estou curtindo muito meu futebol agora, chefe. O clima no vestiário está fantástico.\"",
-        "body1": "Seu assistente menciona que {{player}} tem estado de ótimo humor ultimamente. Ele te abordou após o treino.\n\n\"Chefe, estou adorando cada minuto aqui. Continue assim e eu corro até não poder mais por você.\""
+        "body0": "{{player}} passou pelo seu escritório com um grande sorriso. Ele está se sentindo ótimo com sua forma e a direção do time.\n\n\"Só queria dizer que estou curtindo muito minha gameplay agora, chefe. O clima na equipe está fantástico.\"",
+        "body1": "Seu assistente menciona que {{player}} tem estado de ótimo humor ultimamente. Ele te abordou após o treino.\n\n\"Chefe, estou adorando cada minuto aqui. Continue assim e eu treino até não poder mais por você.\""
       },
       "contractConcern": {
         "subject": "{{player}} — Contrato Chegando ao Fim",
         "body0": "{{player}} veio falar com você sobre a situação do contrato. Com apenas {{days}} dias restantes, ele quer saber qual é a posição dele.\n\n\"Chefe, meu contrato está acabando. Preciso saber se faço parte dos seus planos ou se devo começar a procurar outro lugar.\"",
-        "body1": "Seu assistente alerta que o contrato de {{player}} expira em aproximadamente {{months}} mês(es). O jogador tem perguntado no vestiário sobre seu futuro.\n\nPode ser prudente ter uma conversa antes que ele fique insatisfeito — ou antes que outros clubes comecem a circular."
+        "body1": "Seu assistente alerta que o contrato de {{player}} expira em aproximadamente {{months}} mês(es). O jogador tem perguntado no centro de treinamento sobre seu futuro.\n\nPode ser prudente ter uma conversa antes que ele fique insatisfeito — ou antes que outros clubes comecem a circular."
       },
       "delegatedRenewals": {
         "subject": "Relatório do assistente — Renovações contratuais",
@@ -2505,21 +2507,21 @@
       },
       "boardFired": {
         "subject": "Notificação de Demissão — {{team}}",
-        "body": "A diretoria do {{team}} decidiu demiti-lo de suas funções como treinador, com efeito imediato. Agradecemos pelo seu serviço e desejamos o melhor em sua futura carreira."
+        "body": "A diretoria do {{team}} decidiu demiti-lo de suas funções como Head Coach, com efeito imediato. Agradecemos pelo seu serviço e desejamos o melhor em sua futura carreira."
       },
       "jobOffer": {
-        "subject": "Vaga de Treinador — {{team}}",
-        "body": "A diretoria do {{team}} ({{city}}) está em busca de um novo treinador para conduzir o clube. Posição na última temporada: {{league_position}}.\n\nApós analisar o seu currículo, acreditamos que você pode ser o candidato certo. Teria interesse em aceitar este desafio?",
+        "subject": "Vaga de Head Coach — {{team}}",
+        "body": "A diretoria do {{team}} ({{city}}) está em busca de um novo Head Coach para conduzir o clube. Posição na última temporada: {{league_position}}.\n\nApós analisar o seu currículo, acreditamos que você pode ser o candidato certo. Teria interesse em aceitar este desafio?",
         "accept": "Aceitar o cargo",
         "decline": "Recusar a oferta"
       },
       "jobHired": {
         "subject": "Bem-vindo ao {{team}}",
-        "body": "A diretoria do {{team}} tem o prazer de recebê-lo como novo treinador. Estamos ansiosos para trabalhar com você e alcançar grandes feitos juntos."
+        "body": "A diretoria do {{team}} tem o prazer de recebê-lo como novo Head Coach. Estamos ansiosos para trabalhar com você e alcançar grandes feitos juntos."
       },
       "jobRejection": {
         "subject": "Atualização da Candidatura — {{team}}",
-        "body": "Obrigado pelo seu interesse no cargo de treinador do {{team}}. Após cuidadosa análise, decidimos seguir com outros candidatos. Desejamos o melhor em sua futura carreira."
+        "body": "Obrigado pelo seu interesse no cargo de Head Coach do {{team}}. Após cuidadosa análise, decidimos seguir com outros candidatos. Desejamos o melhor em sua futura carreira."
       },
       "transferComplete": {
         "subject": "Transferência concluída: {{player}}",
@@ -2543,25 +2545,25 @@
         "body": "Patch {{label}} aplicado.\n\nBuffs: {{buffed}}\nNerfs: {{nerfed}}\n\nSua comissão já está analisando as mudanças de tier."
       },
       "academyWeeklyEmpty": {
-        "subject": "Relatório semanal da academia",
-        "body": "A academia {{academy}} não tem jogadores ativos nesta semana. Revise aquisição e promoção para manter o pipeline."
+        "subject": "Relatório semanal do academy",
+        "body": "O academy {{academy}} não tem jogadores ativos nesta semana. Revise aquisição e promoção para manter o pipeline."
       },
       "academyWeekly": {
-        "subject": "Relatório semanal da academia: {{academy}}",
-        "body": "Resumo semanal da academia:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}",
-        "bodyWithPromotion": "Resumo semanal da academia:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}\n\nRecomendação: {{promotionCount}} jogador(es) prontos para promoção -> {{promotionList}}."
+        "subject": "Relatório semanal do academy: {{academy}}",
+        "body": "Resumo semanal do academy:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}",
+        "bodyWithPromotion": "Resumo semanal do academy:\n- Jogadores ativos: {{activePlayers}}\n- OVR médio: {{avgOvr}}\n- Talentos de alto potencial (>= 80): {{highPotential}}\n- Destaques: {{highlights}}\n- Posição atual na ERL: #{{position}} de {{total}}\n- Tabela rápida: {{tablePreview}}\n\nRecomendação: {{promotionCount}} jogador(es) prontos para promoção -> {{promotionList}}."
       }
     },
     "news": {
       "matchReport": {
         "headline": {
           "homeWin": {
-            "0": "{{home}} {{homeGoals}} - {{awayGoals}} {{away}}: Controle da Rift",
+            "0": "{{home}} {{homeGoals}} - {{awayGoals}} {{away}}: Controle do Rift",
             "1": "{{home}} supera {{away}} na rodada {{matchday}}",
             "2": "Série sólida de {{home}} sobre {{away}}"
           },
           "awayWin": {
-            "0": "{{home}} {{homeGoals}} - {{awayGoals}} {{away}}: Golpe visitante na Rift",
+            "0": "{{home}} {{homeGoals}} - {{awayGoals}} {{away}}: Golpe visitante no Rift",
             "1": "{{away}} pune {{home}} no draft e no ritmo",
             "2": "Vitória fora de casa para {{away}}"
           },
@@ -2573,10 +2575,10 @@
         },
         "body0": "A rodada {{matchday}} terminou com {{home}} {{homeGoals}} - {{awayGoals}} {{away}}. O resultado pode mexer no embalo da tabela durante o split.\n\nJogador da partida: {{playerOfMatch}}",
         "body1": "A série terminou {{home}} {{homeGoals}} - {{awayGoals}} {{away}} na rodada {{matchday}}. Os dois lados trocaram adaptações de draft, setups de objetivos e calls de late game.\n\nJogador da partida: {{playerOfMatch}}",
-        "body2": "A rodada {{matchday}} trouxe mais uma série competitiva entre {{home}} e {{away}} ({{homeGoals}}-{{awayGoals}}). Teve pivô de draft e disputa de objetivos até o fim.\n\nJogador da partida: {{playerOfMatch}}"
+        "body2": "A rodada {{matchday}} trouxe mais uma série competitiva entre {{home}} e {{away}} ({{homeGoals}}-{{awayGoals}}). Teve disputas de draft e de objetivos até o fim.\n\nJogador da partida: {{playerOfMatch}}"
       },
       "roundup": {
-        "headline0": "Resumo da rodada {{matchday}}: {{totalMaps}} mapas na Rift",
+        "headline0": "Resumo da rodada {{matchday}}: {{totalMaps}} mapas no Rift",
         "headline1": "Rodada {{matchday}} da liga: todos os resultados",
         "headline2": "Drafts, objetivos e mapas definem a rodada {{matchday}}",
         "body": "A rodada {{matchday}} acabou. Confira os resultados completos das séries:\n\n{{results}}\n\nForam {{totalMaps}} mapas em {{matchCount}} séries."
@@ -2605,7 +2607,7 @@
         },
         "unbeatenStreak": {
           "headline": "{{team}} amplia sequência para {{runLength}} séries",
-          "body": "{{team}} chegou a {{runLength}} séries sem perder e constrói embalo real em draft e objetivos."
+          "body": "{{team}} chegou a {{runLength}} séries sem perder e constrói embalo real em drafts e objetivos."
         }
       },
       "transferRumour": {
@@ -2697,14 +2699,14 @@
     }
   },
   "date": {
-    "day": "DD",
-    "month": "Mês",
-    "year": "AAAA"
+    "day": "Dia (DD)",
+    "month": "Mês (MM)",
+    "year": "Ano (AAAA)"
   },
   "sacked": {
     "title": "Você Foi Demitido",
-    "subtitle": "A diretoria perdeu confiança na sua capacidade de comandar o clube.",
-    "teamLabel": "Clube",
+    "subtitle": "A diretoria perdeu confiança na sua capacidade de comandar o time.",
+    "teamLabel": "Time",
     "finalSatisfaction": "Confiança da Diretoria",
     "careerOverview": "Resumo da Carreira",
     "matchesManaged": "Jogos",
@@ -2718,7 +2720,7 @@
     "returnToMenu": "Voltar ao Menu Principal",
     "present": "Atual",
     "bestLabel": "Melhor",
-    "dismissalLetter": "O conselho de administração decidiu dispensá-lo das suas funções como treinador do {{team}}, com efeito imediato.\n\nAgradecemos pelos seus serviços e desejamos-lhe o melhor para a sua futura carreira.\n\nAtenciosamente,\nO Conselho de Administração"
+    "dismissalLetter": "O conselho de administração decidiu dispensá-lo das suas funções como Head Coach do {{team}}, com efeito imediato.\n\nAgradecemos pelos seus serviços e desejamos-lhe o melhor para a sua futura carreira.\n\nAtenciosamente,\nO Conselho de Administração"
   },
   "jobs": {
     "opportunitiesTitle": "Oportunidades de emprego",


### PR DESCRIPTION
I manually improved the translation of the project into Brazilian Portuguese. Some words, verb agreements, expressions, and specific words were changed for the context of the game. And added 3 new News Sources, which are very popular in the LoL community in Brazil.

## Approved issue

N/A - Translation / Localization

- [ ] The linked issue has `status:approved`.
- [x] This PR targets `development` unless it is a maintainer release/hotfix PR.
- [ ] This PR has exactly one `type:*` label.

## Summary

- Added Brazilian Portuguese (`pt-BR`) localization.
- Created/Updated the `pt-BR.json` file inside the locales folder.

## Checks run

Required/stable PR checks are intentionally lightweight and production-build-free:

- [ ] `frontend-install` passed (dependency installation validation).
- [ ] `rust-check` passed (`cargo fmt --check` and `cargo check`).
- [x] Not applicable locally; docs/templates only.

Manual/experimental full checks are available for maintainer-requested validation and current debt tracking:

- `frontend-full-experimental` (`npm test`, `npm run build:types`).
- `rust-full-experimental` (`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`).

Do not mark the experimental full checks as required for this PR unless a maintainer explicitly asks.

## Documentation and provenance

- [x] Documentation was updated or no docs change is needed.
- [x] Data provenance was updated or no provenance change is needed.
- [x] No unclear third-party data, generated cache, secret, signing key, or private credential is included.

## Release impact

- [x] Changelog entry added or not needed.
- [x] Version changes are synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` when applicable.