### PR TITLE
fix: scroll inbox message list inside its column instead of the whole page

### DIFF
--- a/src/components/inbox/InboxTab.test.tsx
+++ b/src/components/inbox/InboxTab.test.tsx
@@ -22,6 +22,10 @@ const mockTranslationState = vi.hoisted(function () {
     translations: {
       en: {
         "inbox.effectOutcomeLabel": "Outcome",
+        "inbox.sortByDate": "Sort messages by date",
+        "inbox.sortOldest": "Oldest first",
+        "inbox.chooseResponseOutcomeVaries":
+          "Choose your response — outcome varies",
       },
       "pt-BR": {
         "inbox.effectOutcomeLabel": "Desfecho",
@@ -72,7 +76,9 @@ vi.mock("react-i18next", async (importOriginal) => {
 
 const mockedInvoke = vi.mocked(invoke);
 
-beforeAll(function defineMatchMedia(): void {
+beforeAll(async function setupTestEnvironment(): Promise<void> {
+  await i18n.changeLanguage("en");
+
   Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: vi.fn().mockImplementation((query: string) => ({

--- a/src/components/inbox/InboxTab.tsx
+++ b/src/components/inbox/InboxTab.tsx
@@ -301,7 +301,7 @@ export default function InboxTab({
   }
 
   return (
-    <div className="max-w-6xl mx-auto flex flex-col h-full">
+    <div className="max-w-6xl mx-auto flex flex-col h-[calc(100dvh-9rem)] min-h-0">
       <InboxToolbar
         allMessagesCount={allMessages.length}
         bulkSelectionEnabled={bulkSelectionEnabled}

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1100,6 +1100,7 @@
     "important": "Wichtig",
     "effectOutcomeLabel": "Ergebnis",
     "chooseResponse": "Wähle deine Antwort",
+    "chooseResponseOutcomeVaries": "Wähle deine Antwort — das Ergebnis kann variieren",
     "responded": "Antwort gesendet",
     "markAllRead": "Alle als gelesen markieren",
     "clearOld": "Alte löschen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1100,6 +1100,7 @@
     "important": "Important",
     "effectOutcomeLabel": "Outcome",
     "chooseResponse": "Choose your response",
+    "chooseResponseOutcomeVaries": "Choose your response — outcome varies",
     "responded": "Response sent",
     "markAllRead": "Mark all read",
     "clearOld": "Clear old",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1106,6 +1106,7 @@
     "important": "Importante",
     "effectOutcomeLabel": "Resultado",
     "chooseResponse": "Elige tu respuesta",
+    "chooseResponseOutcomeVaries": "Elige tu respuesta — el resultado puede variar",
     "responded": "Respuesta enviada",
     "markAllRead": "Marcar todo como leído",
     "clearOld": "Borrar antiguas",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1106,6 +1106,7 @@
     "important": "Important",
     "effectOutcomeLabel": "Résultat",
     "chooseResponse": "Choisissez votre réponse",
+    "chooseResponseOutcomeVaries": "Choisissez votre réponse — le résultat peut varier",
     "responded": "Réponse envoyée",
     "markAllRead": "Tout marquer comme lu",
     "clearOld": "Effacer les anciens",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -752,6 +752,7 @@
     "important": "Importante",
     "effectOutcomeLabel": "Esito",
     "chooseResponse": "Scegli la tua risposta",
+    "chooseResponseOutcomeVaries": "Scegli la tua risposta — l'esito può variare",
     "responded": "Risposta inviata",
     "markAllRead": "Segna tutto come letto",
     "clearOld": "Pulisci vecchi",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1106,6 +1106,7 @@
     "important": "Importante",
     "effectOutcomeLabel": "Desfecho",
     "chooseResponse": "Escolha sua resposta",
+    "chooseResponseOutcomeVaries": "Escolha sua resposta — o desfecho pode variar",
     "responded": "Resposta enviada",
     "markAllRead": "Marcar todas como lidas",
     "clearOld": "Limpar antigas",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1100,6 +1100,7 @@
     "important": "Importante",
     "effectOutcomeLabel": "Desfecho",
     "chooseResponse": "Escolhe a tua resposta",
+    "chooseResponseOutcomeVaries": "Escolhe a tua resposta — o desfecho pode variar",
     "responded": "Resposta enviada",
     "markAllRead": "Marcar todas como lidas",
     "clearOld": "Limpar antigas",


### PR DESCRIPTION
Fixes #31

## Summary

Fixes the inbox layout so the **message list scrolls inside its own column** instead of pushing the whole page into a giant scroll when there are many messages. Also greens up the 5 inbox tests that were failing on `develop` (issue #31) and adds a missing translation key.

## Behaviour

Before the fix the inbox toolbar plus the list of messages grew vertically and the workspace's `overflow-auto` ended up scrolling the entire page. Selecting a message produced an awkwardly long page. After the fix:

- The inbox occupies a viewport-bounded area (`100dvh` minus the dashboard chrome).
- The toolbar stays pinned at the top of that area.
- The message list column scrolls internally, exactly like a typical desktop email client.
- The detail pane on the right side of the inbox also stays within the same bounded area, so its own internal scroll works as expected.
- Mobile (<768px) is unaffected functionally — the list pane already collapses to full width and hides when a message is opened. Using `100dvh` (instead of `100vh`) means the height adjusts cleanly when the mobile browser's address bar shows or hides.

## Implementation

### Layout fix

`src/components/inbox/InboxTab.tsx`: outer wrapper changed from `flex flex-col h-full` to `flex flex-col h-[calc(100dvh-9rem)] min-h-0`. The 9rem offset accounts for the dashboard header plus the workspace padding (`p-6` × 2). `min-h-0` is needed so the inner `flex-1` panel container actually constrains its children, letting the existing `flex-1 overflow-y-auto` inside `InboxMessageListPane` take over the scroll.

### Test fixes (closes #31)

The 5 failing inbox tests were not caused by this PR — they were already red on `develop`. Root cause: `src/i18n/index.ts` initialises i18next with `lng: "es"`, and `resolveAction` resolves option labels via the real i18n module, not via the test's mocked `useTranslation`. So the assertions that expected `"Return the praise"` were getting `"Devolver el elogio"` instead. Two of the failing tests also asserted strings produced by mocked `t()` keys that were never registered in `mockTranslationState`.

Fixes applied to `src/components/inbox/InboxTab.test.tsx`:

1. `await i18n.changeLanguage("en")` in `beforeAll` so the real i18n resolver returns English.
2. Added the three missing keys to `mockTranslationState.translations.en`:
   - `inbox.sortByDate` → "Sort messages by date"
   - `inbox.sortOldest` → "Oldest first"
   - `inbox.chooseResponseOutcomeVaries` → "Choose your response — outcome varies"

### Real i18n bug

`InboxMessageDetailPane.tsx` calls `t("inbox.chooseResponseOutcomeVaries")` but the key was missing from **every** locale bundle, so production users would have seen the raw key string in the UI. Added the key to all 7 locales (en, es, fr, de, it, pt, pt-BR).

## Why not fix the parent layout

The deeper root cause is that `DashboardWorkspaceContent` wraps each tab in a `<div className="flex flex-col gap-4">` with no explicit height, so the `h-full` chain breaks. Fixing it there is more invasive — every tab would need to be audited to make sure none of them rely on growing past the viewport. This change keeps the fix scoped to the inbox.

## Test plan

- [x] `InboxTab.test.tsx`: all 11 tests green
- [x] Wider sanity check: `src/components/schedule` + `src/components/transfers` (28 tests) still green
- [x] Manual: open the inbox with many messages; confirm only the list column scrolls and the page does not gain a giant scrollbar
- [x] Manual: select a message — both panes stay within the bounded area and the detail pane scrolls internally
- [x] Manual: resize the window vertically; the inbox follows the viewport height
- [x] Manual on mobile: list pane occupies full width, opening a message swaps to the detail pane, no broken layout
