### PR TITLE
Fix issue 131 - just 5 champs in draft

### DIFF
--- a/src/components/match/ChampionDraft.tsx
+++ b/src/components/match/ChampionDraft.tsx
@@ -1195,14 +1195,6 @@ export default function ChampionDraft({
         if (tier !== metaTierFilter) return false;
       }
 
-      if (
-        currentStep?.type === "pick" &&
-        currentStep.side !== controlledSide &&
-        knownRivalChampionIds.size > 0 &&
-        !knownRivalChampionIds.has(champion.id)
-      ) {
-        return false;
-      }
 
       return true;
     });


### PR DESCRIPTION


## Approved issue

Closes #131 

- [ ] The linked issue has `status:approved`.
- [ ] This PR targets `development` unless it is a maintainer release/hotfix PR.
- [ ] This PR has exactly one `type:*` label.

## Summary

Fixed a bug that just 5 champs in draft when machine pick/ban

## Checks run

Required/stable PR checks are intentionally lightweight and production-build-free:

- [ ] `frontend-install` passed (dependency installation validation).
- [ ] `rust-check` passed (`cargo fmt --check` and `cargo check`).
- [ ] Not applicable locally; docs/templates only.

Manual/experimental full checks are available for maintainer-requested validation and current debt tracking:

- `frontend-full-experimental` (`npm test`, `npm run build:types`).
- `rust-full-experimental` (`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`).

Do not mark the experimental full checks as required for this PR unless a maintainer explicitly asks.

## Documentation and provenance

- [ ] Documentation was updated or no docs change is needed.
- [ ] Data provenance was updated or no provenance change is needed.
- [ ] No unclear third-party data, generated cache, secret, signing key, or private credential is included.

## Release impact

- [ ] Changelog entry added or not needed.
- [ ] Version changes are synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` when applicable.
