### PR TITLE
fix(#84): unify OVR calculation across Squad and pre-game views

### DIFF
--- a/src/components/match/PreMatchLineup.tsx
+++ b/src/components/match/PreMatchLineup.tsx
@@ -3,6 +3,7 @@ import { MatchSnapshot, EnginePlayerData } from "./types";
 import { Badge } from "../ui";
 import { ArrowUpDown, AlertTriangle, Wand2 } from "lucide-react";
 import { resolvePlayerPhoto } from "../../lib/playerPhotos";
+import { calcOvr } from "../../lib/lolPlayerStats";
 
 export type LolRole = "TOP" | "JUNGLE" | "MID" | "ADC" | "SUPPORT";
 
@@ -50,19 +51,19 @@ export function getPlayerLolRole(player: EnginePlayerData): LolRole {
   return "JUNGLE";
 }
 
+/** Delegates to the shared OVR formula so every view uses the same calculation. */
 export function getPositionOvr(p: EnginePlayerData): number {
-  const avg =
-    (p.dribbling +
-      p.shooting +
-      p.teamwork +
-      p.vision +
-      p.decisions +
-      p.leadership +
-      p.agility +
-      p.composure +
-      p.stamina) /
-    9;
-  return Math.max(1, Math.min(99, Math.round(avg)));
+  return calcOvr(
+    p.dribbling,
+    p.shooting,
+    p.teamwork,
+    p.vision,
+    p.decisions,
+    p.leadership,
+    p.agility,
+    p.composure,
+    p.stamina,
+  );
 }
 
 export function condColor(c: number): string {

--- a/src/lib/lolPlayerStats.ts
+++ b/src/lib/lolPlayerStats.ts
@@ -67,26 +67,41 @@ export function getLolVisibleStatValue(player: PlayerData, statId: LolVisibleSta
   }
 }
 
-export function calculateLolOvr(player: PlayerData): number {
-  const mechanics = getLolVisibleStatValue(player, "mechanics");
-  const laning = getLolVisibleStatValue(player, "laning");
-  const teamfighting = getLolVisibleStatValue(player, "teamfighting");
-  const macro = getLolVisibleStatValue(player, "macro");
-  const consistency = getLolVisibleStatValue(player, "consistency");
-  const shotcalling = getLolVisibleStatValue(player, "shotcalling");
-  const championPool = getLolVisibleStatValue(player, "championPool");
-  const discipline = getLolVisibleStatValue(player, "discipline");
-  const mentalResilience = getLolVisibleStatValue(player, "mentalResilience");
-
+/** Shared OVR formula — takes raw stat values so any data source can use it. */
+export function calcOvr(
+  dribbling: number,
+  shooting: number,
+  teamwork: number,
+  vision: number,
+  decisions: number,
+  leadership: number,
+  agility: number,
+  composure: number,
+  stamina: number,
+): number {
   return clampOvr(
-    (mechanics +
-      laning +
-      teamfighting +
-      macro +
-      consistency +
-      shotcalling +
-      championPool +
-      discipline +
-      mentalResilience) / 9,
+    (dribbling +
+      shooting +
+      teamwork +
+      vision +
+      decisions +
+      leadership +
+      agility +
+      composure +
+      stamina) / 9,
+  );
+}
+
+export function calculateLolOvr(player: PlayerData): number {
+  return calcOvr(
+    getLolVisibleStatValue(player, "mechanics"),
+    getLolVisibleStatValue(player, "laning"),
+    getLolVisibleStatValue(player, "teamfighting"),
+    getLolVisibleStatValue(player, "macro"),
+    getLolVisibleStatValue(player, "consistency"),
+    getLolVisibleStatValue(player, "shotcalling"),
+    getLolVisibleStatValue(player, "championPool"),
+    getLolVisibleStatValue(player, "discipline"),
+    getLolVisibleStatValue(player, "mentalResilience"),
   );
 }


### PR DESCRIPTION
## Summary

The OVR displayed in the Squad view and the Pre-game tactics screen differed because they used separate calculation functions with different data sources.

### Root Cause

\calculateLolOvr()\ (used by Squad) and \getPositionOvr()\ (used by PreMatchLineup) implemented the same formula but consumed different attributes — squad used \PlayerData.attributes\ while pre-game used \EnginePlayerData\ flat fields — which could diverge after training or lineup changes.

### Fix

- Extracted shared \calcOvr()\ in \lolPlayerStats.ts\ with raw stat parameters
- Both views now delegate to \calcOvr()\, eliminating the discrepancy

### Changes

\\\
 src/components/match/PreMatchLineup.tsx | 25 ++++++++-------
 src/lib/lolPlayerStats.ts               | 55 +++++++++++++++++++-----------
 2 files changed, 48 insertions(+), 32 deletions(-)
\\\

Closes #84