### PR TITLE
refactor(squad): replace Starting XI with LoL lineup

### DIFF
--- a/src/components/squad/SquadRosterView.tsx
+++ b/src/components/squad/SquadRosterView.tsx
@@ -11,7 +11,13 @@ import { calcAge, formatVal } from "../../lib/helpers";
 import { useTranslation } from "react-i18next";
 import ContextMenu from "../ContextMenu";
 import playersSeed from "../../../data/lec/draft/players.json";
-import { buildStartingXIIds, isPlayerOutOfPosition } from "./SquadTab.helpers";
+import {
+  buildActiveLineupIds,
+  buildActiveLineupSlots,
+  isPlayerOutOfPosition,
+  LOL_ACTIVE_ROLES,
+  LOL_ROLE_LABELS,
+} from "./SquadTab.helpers";
 import { calculateLolOvr } from "../../lib/lolPlayerStats";
 import { resolvePlayerPhoto } from "../../lib/playerPhotos";
 import { fallbackChampionForRole, resolvePlayerLolRole } from "../../lib/lolIdentity";
@@ -28,11 +34,11 @@ const LOL_ROLE_ORDER: Record<LolRole, number> = {
 };
 
 const ROLE_LABEL: Record<LolRole, string> = {
-  TOP: "Top",
+  TOP: "TOP",
   JUNGLE: "JUNGLE",
-  MID: "Mid",
-  ADC: "Bot",
-  SUPPORT: "Support",
+  MID: "MID",
+  ADC: "ADC",
+  SUPPORT: "SUPPORT",
 };
 
 const ROLE_ICON_URLS: Record<LolRole, string> = {
@@ -147,8 +153,16 @@ export default function SquadRosterView({
 
   const roster = gameState.players.filter((player) => player.team_id === myTeam.id);
   const available = roster.filter((player) => !player.injury);
-  const startingXiIds = buildStartingXIIds(available, myTeam.starting_xi_ids || [], myTeam.formation || "4-4-2");
-  const xiIds = new Set(startingXiIds);
+  const activeLineupIds = buildActiveLineupIds(available, myTeam.starting_xi_ids || []);
+  const activeIds = new Set(activeLineupIds);
+  const playersById = useMemo(
+    () => new Map(roster.map((player) => [player.id, player])),
+    [roster],
+  );
+  const activeLineupSlots = useMemo(
+    () => buildActiveLineupSlots(LOL_ACTIVE_ROLES, activeLineupIds, playersById),
+    [activeLineupIds, playersById],
+  );
 
   const sortedRoster = useMemo(() => {
     const sorted = [...roster].sort((a, b) => {
@@ -206,7 +220,70 @@ export default function SquadRosterView({
       <Card>
         <div className="p-4 border-b border-[#22345d] bg-[#08132a] rounded-t-xl">
           <h3 className="text-sm font-heading font-bold text-blue-100 uppercase tracking-wide">
-            {t("squad.detailsTitle", { defaultValue: "Detalles de plantilla" })}
+            {t("squad.activeLineup", { defaultValue: "Active Lineup" })}
+          </h3>
+          <p className="mt-1 text-xs text-blue-200/70">
+            {t("squad.activeLineupHint", { defaultValue: "Core five-player League of Legends lineup." })}
+          </p>
+        </div>
+
+        <div
+          className="grid grid-cols-1 md:grid-cols-5 gap-3 p-3 md:p-4 bg-[#061027] rounded-b-xl"
+          data-testid="active-lineup"
+        >
+          {activeLineupSlots.map((slot) => {
+            const player = slot.player;
+            const roleLabel = LOL_ROLE_LABELS[slot.role];
+            const ovr = player ? calculateLolOvr(player) : null;
+            const photo = player ? resolvePlayerPhoto(player.id, player.match_name, player.profile_image_url) : null;
+
+            return (
+              <button
+                key={slot.role}
+                className="min-h-32 rounded-xl border border-[#21365f] bg-[#13274a] px-3 py-3 text-left hover:bg-[#17305a] transition-colors disabled:cursor-default disabled:hover:bg-[#13274a]"
+                data-testid={`active-lineup-role-${slot.role}`}
+                disabled={!player}
+                onClick={() => {
+                  if (player) onSelectPlayer(player.id);
+                }}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-xs font-heading font-black tracking-widest text-amber-300">{roleLabel}</span>
+                  <img src={ROLE_ICON_URLS[slot.role]} alt={roleLabel} className="w-5 h-5 object-contain opacity-90" />
+                </div>
+
+                {player ? (
+                  <div className="mt-3 flex items-center gap-3">
+                    {photo ? (
+                      <img src={photo} alt={player.match_name} className="w-10 h-10 object-cover rounded-full shrink-0" loading="lazy" />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-[#0f213f] border border-white/10 shrink-0" />
+                    )}
+                    <div className="min-w-0">
+                      <p className="text-lg leading-none font-heading font-bold text-white truncate">{player.match_name}</p>
+                      <p className="mt-1 text-[11px] text-blue-200/70">{t("common.ovr", { defaultValue: "OVR" })} {ovr}</p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="mt-4 rounded-lg border border-amber-400/30 bg-amber-500/10 px-3 py-2">
+                    <p className="text-xs font-heading font-bold uppercase tracking-wide text-amber-300">
+                      {t("squad.missingRoleCoverage", { defaultValue: "Missing role coverage" })}
+                    </p>
+                    <p className="mt-1 text-[11px] text-amber-100/80">
+                      {t("squad.noRoleAvailable", { defaultValue: `No ${roleLabel} available` })}
+                    </p>
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      </Card>
+
+      <Card>
+        <div className="p-4 border-b border-[#22345d] bg-[#08132a] rounded-t-xl">
+          <h3 className="text-sm font-heading font-bold text-blue-100 uppercase tracking-wide">
+            {t("squad.benchSubstitutes", { defaultValue: "Bench / Substitutes" })}
           </h3>
           <div className="mt-3 flex flex-wrap gap-2">
             {([
@@ -240,7 +317,7 @@ export default function SquadRosterView({
             const championNames = masteryTopChampionsByPlayer.get(player.id)
               ?? TOP_3_CHAMPIONS_BY_IGN.get(normalizeKey(player.match_name))
               ?? (fallbackChampion ? [fallbackChampion] : []);
-            const inXI = xiIds.has(player.id);
+            const inXI = activeIds.has(player.id);
             const currentPos = player.natural_position || player.position;
             const wrongPos = inXI && isPlayerOutOfPosition(player, currentPos);
             const annualWage = player.wage;

--- a/src/components/squad/SquadTab.helpers.test.ts
+++ b/src/components/squad/SquadTab.helpers.test.ts
@@ -3,15 +3,13 @@ import type { PlayerData } from "../../store/gameStore";
 import {
   applyLineupDrop,
   applyLineupSwap,
+  buildActiveLineupIds,
+  buildActiveLineupSlots,
   buildActivePositionMap,
-  buildPitchRows,
-  buildPitchSlotRows,
-  buildStartingXIIds,
-  getPitchSlotWidth,
   getPreferredPositions,
   isPlayerOutOfPosition,
+  LOL_ACTIVE_ROLES,
   normalisePosition,
-  parseFormationSlots,
   positionCode,
   translatePositionAbbreviation,
 } from "./SquadTab.helpers";
@@ -77,11 +75,12 @@ const makePlayer = (
 });
 
 describe("SquadTab helpers", () => {
-  it("normalises detailed positions into core roles", () => {
-    expect(normalisePosition("Center Back")).toBe("Defender");
-    expect(normalisePosition("Winger")).toBe("Forward");
-    expect(normalisePosition("Striker")).toBe("Forward");
-    expect(normalisePosition("Goalkeeper")).toBe("Goalkeeper");
+  it("normalises LoL roles without football grouping", () => {
+    expect(normalisePosition("TOP")).toBe("TOP");
+    expect(normalisePosition("JUNGLE")).toBe("JUNGLE");
+    expect(normalisePosition("MID")).toBe("MID");
+    expect(normalisePosition("ADC")).toBe("ADC");
+    expect(normalisePosition("SUPPORT")).toBe("SUPPORT");
   });
 
   it("handles missing or empty positions without crashing", () => {
@@ -89,227 +88,106 @@ describe("SquadTab helpers", () => {
     expect(positionCode(undefined)).toBe("");
   });
 
-  it("builds a full eleven-player starting XI when enough players exist", () => {
+  it("builds exactly five active LoL role ids when coverage exists", () => {
     const available = [
-      makePlayer("gk", "Goalkeeper"),
-      makePlayer("d1", "Defender"),
-      makePlayer("d2", "Defender"),
-      makePlayer("d3", "Defender"),
-      makePlayer("d4", "Defender"),
-      makePlayer("m1", "Midfielder"),
-      makePlayer("m2", "Midfielder"),
-      makePlayer("m3", "Midfielder"),
-      makePlayer("m4", "Midfielder"),
-      makePlayer("f1", "Forward"),
-      makePlayer("f2", "Forward"),
-      makePlayer("bench", "Forward"),
+      makePlayer("top", "TOP"),
+      makePlayer("jng", "JUNGLE"),
+      makePlayer("mid", "MID"),
+      makePlayer("adc", "ADC"),
+      makePlayer("sup", "SUPPORT"),
+      makePlayer("bench", "ADC"),
     ];
 
-    const ids = buildStartingXIIds(
-      available,
-      ["gk", "d1", "d2", "d3", "d4", "m1", "m2", "m3", "m4", "f1", "f2"],
-      "4-4-2",
+    const ids = buildActiveLineupIds(available, ["top", "jng", "mid", "adc", "sup", "bench"]);
+
+    expect(ids).toHaveLength(5);
+    expect(ids).toEqual(["top", "jng", "mid", "adc", "sup"]);
+  });
+
+  it("builds five active role slots and makes missing coverage explicit", () => {
+    const players = [
+      makePlayer("top", "TOP"),
+      makePlayer("jng", "JUNGLE"),
+      makePlayer("mid", "MID"),
+      makePlayer("adc", "ADC"),
+    ];
+    const slots = buildActiveLineupSlots(
+      LOL_ACTIVE_ROLES,
+      buildActiveLineupIds(players, []),
+      new Map(players.map((player) => [player.id, player])),
     );
 
-    expect(ids).toHaveLength(11);
-    expect(ids).toEqual(["gk", "d1", "d2", "d3", "d4", "m1", "m2", "m3", "m4", "f1", "f2"]);
+    expect(slots.map((slot) => slot.role)).toEqual(["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"]);
+    expect(slots).toHaveLength(5);
+    expect(slots.find((slot) => slot.role === "SUPPORT")?.player).toBeNull();
   });
 
   it("builds preferred positions using normalised natural and alternate roles", () => {
-    const player = makePlayer("p1", "Center Back", {
-      natural_position: "Center Back",
-      alternate_positions: ["Right Wing Back", "Defensive Midfielder"],
+    const player = makePlayer("p1", "TOP", {
+      natural_position: "TOP",
+      alternate_positions: ["JUNGLE", "SUPPORT"],
     });
 
-    expect(getPreferredPositions(player)).toEqual([
-      "CenterBack",
-      "RightWingBack",
-      "DefensiveMidfielder",
-    ]);
+    expect(getPreferredPositions(player)).toEqual(["TOP", "JUNGLE", "SUPPORT"]);
   });
 
-  it("detects out-of-position status using normalised roles", () => {
-    const defender = makePlayer("p1", "Center Back", {
-      natural_position: "Center Back",
-      alternate_positions: ["Right Wing Back"],
+  it("detects out-of-position status using LoL roles", () => {
+    const player = makePlayer("p1", "TOP", {
+      natural_position: "TOP",
+      alternate_positions: ["JUNGLE"],
     });
 
-    expect(isPlayerOutOfPosition(defender, "Defender")).toBe(false);
-    expect(isPlayerOutOfPosition(defender, "Midfielder")).toBe(true);
+    expect(isPlayerOutOfPosition(player, "TOP")).toBe(false);
+    expect(isPlayerOutOfPosition(player, "JUNGLE")).toBe(false);
+    expect(isPlayerOutOfPosition(player, "ADC")).toBe(true);
   });
 
-  it("parses 4-part formations correctly", () => {
-    expect(parseFormationSlots("4-2-3-1")).toEqual({ def: 4, mid: 5, fwd: 1 });
-  });
-
-  it("builds five pitch rows for 4-part formations", () => {
-    const rows = buildPitchRows("4-2-3-1");
-    expect(rows.map((row) => row.label)).toEqual(["GK", "DEF", "DM", "AM", "FWD"]);
-    expect(rows[1].positions).toHaveLength(4);
-    expect(rows[2].positions).toHaveLength(2);
-    expect(rows[3].positions).toHaveLength(3);
-    expect(rows[4].positions).toHaveLength(1);
-    expect(rows[1].positions).toEqual([
-      "LeftBack",
-      "CenterBack",
-      "CenterBack",
-      "RightBack",
-    ]);
-  });
-
-  it("keeps wide side-specific roles in left-to-right pitch order across formations", () => {
-    expect(buildPitchRows("4-4-2")[2].positions).toEqual([
-      "LeftMidfielder",
-      "CentralMidfielder",
-      "CentralMidfielder",
-      "RightMidfielder",
-    ]);
-    expect(buildPitchRows("5-3-2")[1].positions).toEqual([
-      "LeftWingBack",
-      "CenterBack",
-      "CenterBack",
-      "CenterBack",
-      "RightWingBack",
-    ]);
-    expect(buildPitchRows("4-2-3-1")[3].positions).toEqual([
-      "LeftMidfielder",
-      "AttackingMidfielder",
-      "RightMidfielder",
-    ]);
-    expect(buildPitchRows("4-3-3")[3].positions).toEqual([
-      "LeftWinger",
-      "Striker",
-      "RightWinger",
-    ]);
-  });
-
-  it("returns compact pitch widths for crowded rows", () => {
-    expect(getPitchSlotWidth(5)).toBeLessThan(getPitchSlotWidth(3));
-    expect(getPitchSlotWidth(1)).toBeGreaterThan(getPitchSlotWidth(4));
-  });
-
-  it("prefers persisted starting XI ids when enough valid players remain", () => {
+  it("prefers persisted active lineup ids by matching LoL roles", () => {
     const available = [
-      makePlayer("gk", "Goalkeeper"),
-      makePlayer("d1", "Defender"),
-      makePlayer("d2", "Defender"),
-      makePlayer("d3", "Defender"),
-      makePlayer("d4", "Defender"),
-      makePlayer("m1", "Midfielder"),
-      makePlayer("m2", "Midfielder"),
-      makePlayer("m3", "Midfielder"),
-      makePlayer("m4", "Midfielder"),
-      makePlayer("f1", "Forward"),
-      makePlayer("f2", "Forward"),
-      makePlayer("b1", "Forward"),
+      makePlayer("top-a", "TOP"),
+      makePlayer("top-b", "TOP"),
+      makePlayer("jng", "JUNGLE"),
+      makePlayer("mid", "MID"),
+      makePlayer("adc", "ADC"),
+      makePlayer("sup", "SUPPORT"),
     ];
 
-    const ids = buildStartingXIIds(
-      available,
-      ["gk", "d1", "d2", "d3", "d4", "m1", "m2", "m3", "m4", "f1", "f2"],
-      "4-4-2",
-    );
+    const ids = buildActiveLineupIds(available, ["top-b", "jng", "mid", "adc", "sup"]);
 
-    expect(ids).toEqual(["gk", "d1", "d2", "d3", "d4", "m1", "m2", "m3", "m4", "f1", "f2"]);
+    expect(ids).toEqual(["top-b", "jng", "mid", "adc", "sup"]);
   });
 
-  it("auto-selects players by formation role when persisted ids are missing", () => {
+  it("auto-selects one player per LoL role when persisted ids are missing", () => {
     const available = [
-      makePlayer("gk", "Goalkeeper"),
-      makePlayer("d1", "Defender"),
-      makePlayer("d2", "Defender"),
-      makePlayer("d3", "Defender"),
-      makePlayer("d4", "Defender"),
-      makePlayer("m1", "Midfielder"),
-      makePlayer("m2", "Midfielder"),
-      makePlayer("m3", "Midfielder"),
-      makePlayer("m4", "Midfielder"),
-      makePlayer("f1", "Forward"),
-      makePlayer("f2", "Forward"),
+      makePlayer("top", "TOP"),
+      makePlayer("jng", "JUNGLE"),
+      makePlayer("mid", "MID"),
+      makePlayer("adc", "ADC"),
+      makePlayer("sup", "SUPPORT"),
+      makePlayer("adc-bench", "ADC"),
     ];
 
-    const ids = buildStartingXIIds(available, [], "4-4-2");
+    const ids = buildActiveLineupIds(available, []);
 
-    expect(ids).toHaveLength(11);
-    expect(ids).toContain("gk");
-    expect(ids).toEqual(expect.arrayContaining(["d1", "d2", "d3", "d4"]));
+    expect(ids).toHaveLength(5);
+    expect(ids).toEqual(["top", "jng", "mid", "adc", "sup"]);
   });
 
-  it("builds pitch slot rows and active position map from xi ids", () => {
+  it("builds active position map from active role slots", () => {
     const players = [
-      makePlayer("gk", "Goalkeeper"),
-      makePlayer("d1", "LeftBack"),
-      makePlayer("d2", "CenterBack"),
-      makePlayer("d3", "CenterBack"),
-      makePlayer("d4", "RightBack"),
-      makePlayer("m1", "LeftMidfielder"),
-      makePlayer("m2", "CentralMidfielder"),
-      makePlayer("m3", "CentralMidfielder"),
-      makePlayer("m4", "RightMidfielder"),
-      makePlayer("f1", "Striker"),
-      makePlayer("f2", "Striker"),
+      makePlayer("top", "TOP"),
+      makePlayer("jng", "JUNGLE"),
+      makePlayer("mid", "MID"),
+      makePlayer("adc", "ADC"),
+      makePlayer("sup", "SUPPORT"),
     ];
-    const xiIds = players.map((player) => player.id);
-    const rows = buildPitchRows("4-4-2");
-    const slotRows = buildPitchSlotRows(rows, xiIds, new Map(players.map((p) => [p.id, p])));
-    const activeMap = buildActivePositionMap(slotRows);
+    const slots = buildActiveLineupSlots(LOL_ACTIVE_ROLES, players.map((player) => player.id), new Map(players.map((p) => [p.id, p])));
+    const activeMap = buildActivePositionMap(slots);
 
-    expect(slotRows[0].slots[0].player?.id).toBe("gk");
-    expect(activeMap.get("d1")).toBe("LeftBack");
-    expect(activeMap.get("m1")).toBe("LeftMidfielder");
-    expect(activeMap.get("f2")).toBe("Striker");
-  });
-
-  it("preserves saved xi order for side-specific wide roles", () => {
-    const available = [
-      makePlayer("gk", "Goalkeeper"),
-      makePlayer("rb", "RightBack", {
-        natural_position: "RightBack",
-        footedness: "Right",
-        weak_foot: 1,
-      }),
-      makePlayer("cb1", "CenterBack"),
-      makePlayer("cb2", "CenterBack"),
-      makePlayer("lb", "LeftBack", {
-        natural_position: "LeftBack",
-        footedness: "Left",
-        weak_foot: 1,
-      }),
-      makePlayer("rm", "RightMidfielder", {
-        natural_position: "RightMidfielder",
-        footedness: "Right",
-        weak_foot: 1,
-      }),
-      makePlayer("cm1", "CentralMidfielder"),
-      makePlayer("cm2", "CentralMidfielder"),
-      makePlayer("lm", "LeftMidfielder", {
-        natural_position: "LeftMidfielder",
-        footedness: "Left",
-        weak_foot: 1,
-      }),
-      makePlayer("st1", "Striker"),
-      makePlayer("st2", "Striker"),
-    ];
-
-    const ids = buildStartingXIIds(
-      available,
-      ["gk", "rb", "cb1", "cb2", "lb", "rm", "cm1", "cm2", "lm", "st1", "st2"],
-      "4-4-2",
-    );
-
-    expect(ids).toEqual([
-      "gk",
-      "rb",
-      "cb1",
-      "cb2",
-      "lb",
-      "rm",
-      "cm1",
-      "cm2",
-      "lm",
-      "st1",
-      "st2",
-    ]);
+    expect(slots[0].player?.id).toBe("top");
+    expect(activeMap.get("top")).toBe("TOP");
+    expect(activeMap.get("jng")).toBe("JUNGLE");
+    expect(activeMap.get("sup")).toBe("SUPPORT");
   });
 
   it("swaps XI players when dragging from one slot to another", () => {
@@ -353,18 +231,18 @@ describe("SquadTab helpers", () => {
   });
 
   it("returns core position codes", () => {
-    expect(positionCode("Center Back")).toBe("CB");
-    expect(positionCode("Striker")).toBe("ST");
+    expect(positionCode("TOP")).toBe("TOP");
+    expect(positionCode("SUPPORT")).toBe("SUP");
   });
 
   it("translates normalized position abbreviations with fallback codes", () => {
     const translate = (key: string): string => key;
 
-    expect(translatePositionAbbreviation(translate, "Center Back")).toBe(
-      "common.posAbbr.CenterBack",
+    expect(translatePositionAbbreviation(translate, "TOP")).toBe(
+      "common.posAbbr.TOP",
     );
-    expect(translatePositionAbbreviation(translate, "Striker")).toBe(
-      "common.posAbbr.Striker",
+    expect(translatePositionAbbreviation(translate, "SUPPORT")).toBe(
+      "common.posAbbr.SUPPORT",
     );
   });
 });

--- a/src/components/squad/SquadTab.helpers.ts
+++ b/src/components/squad/SquadTab.helpers.ts
@@ -1,5 +1,5 @@
 import type { PlayerData } from "../../store/gameStore";
-import { calcOvr } from "../../lib/helpers";
+import { calculateLolOvr } from "../../lib/lolPlayerStats";
 
 export type SquadSection = "xi" | "bench";
 export type DragState = {
@@ -16,6 +16,27 @@ export type PitchSlot = {
 };
 export type PitchSlotRow = PitchRow & { slots: PitchSlot[] };
 export type LolRole = "TOP" | "JUNGLE" | "MID" | "ADC" | "SUPPORT";
+export type ActiveLineupSlot = {
+  index: number;
+  role: LolRole;
+  player: PlayerData | null;
+};
+
+export const LOL_ACTIVE_ROLES: readonly LolRole[] = [
+  "TOP",
+  "JUNGLE",
+  "MID",
+  "ADC",
+  "SUPPORT",
+] as const;
+
+export const LOL_ROLE_LABELS: Record<LolRole, string> = {
+  TOP: "TOP",
+  JUNGLE: "JUNGLE",
+  MID: "MID",
+  ADC: "ADC",
+  SUPPORT: "SUPPORT",
+};
 
 export const CORE_POSITIONS = [
   "Goalkeeper",
@@ -85,6 +106,11 @@ const POSITION_GROUPS: Record<string, string> = {
 };
 
 const POSITION_LABELS: Record<string, string> = {
+  TOP: "TOP",
+  JUNGLE: "JUNGLE",
+  MID: "MID",
+  ADC: "ADC",
+  SUPPORT: "SUPPORT",
   Goalkeeper: "Goalkeeper",
   Defender: "Defender",
   Midfielder: "Midfielder",
@@ -105,6 +131,11 @@ const POSITION_LABELS: Record<string, string> = {
 };
 
 const POSITION_CODES: Record<string, string> = {
+  TOP: "TOP",
+  JUNGLE: "JNG",
+  MID: "MID",
+  ADC: "ADC",
+  SUPPORT: "SUP",
   Goalkeeper: "GK",
   Defender: "DEF",
   Midfielder: "MID",
@@ -131,6 +162,10 @@ function normaliseKey(value: string): string {
 export function canonicalPosition(position?: string | null): string {
   const trimmed = (position ?? "").trim();
   if (!trimmed) return trimmed;
+
+  if (LOL_ACTIVE_ROLES.includes(trimmed.toUpperCase() as LolRole)) {
+    return trimmed.toUpperCase();
+  }
 
   return CANONICAL_POSITION_MAP[normaliseKey(trimmed)] || trimmed;
 }
@@ -220,7 +255,7 @@ export function translatePositionAbbreviation(
  * (no mapping needed - already LolRole from backend)
  */
 export function getLolRoleForPlayer(player: PlayerData): LolRole {
-  return player.natural_position;
+  return canonicalPosition(player.natural_position) as LolRole;
 }
 
 export function getPreferredPositions(player: PlayerData): string[] {
@@ -376,59 +411,55 @@ export function buildStartingXIIds(
   const _formation = formation;
   void _formation;
 
-  const roleOrder: LolRole[] = ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"];
-  const roleTargetPosition: Record<LolRole, string> = {
-    TOP: "Defender",
-    JUNGLE: "Midfielder",
-    MID: "AttackingMidfielder",
-    ADC: "Forward",
-    SUPPORT: "DefensiveMidfielder",
-  };
+  return buildActiveLineupIds(available, savedIds);
+}
 
-  const roleFromPlayer = getLolRoleForPlayer;
-
+export function buildActiveLineupIds(
+  available: PlayerData[],
+  savedIds: string[],
+): string[] {
   const byId = new Map(available.map((player) => [player.id, player]));
-  const xi: string[] = [];
   const used = new Set<string>();
+  const activeIds: string[] = [];
 
-  for (const id of savedIds) {
-    const player = byId.get(id);
-    if (player && !used.has(id) && xi.length < 11) {
-      xi.push(id);
-      used.add(id);
+  for (const role of LOL_ACTIVE_ROLES) {
+    const savedRolePlayer = savedIds
+      .map((id) => byId.get(id))
+      .find(
+        (player): player is PlayerData =>
+          Boolean(player) && !used.has(player.id) && getLolRoleForPlayer(player) === role,
+      );
+
+    if (savedRolePlayer) {
+      activeIds.push(savedRolePlayer.id);
+      used.add(savedRolePlayer.id);
+      continue;
     }
-  }
-
-  for (const role of roleOrder) {
-    if (xi.length >= 11) break;
 
     const roleCandidates = available
-      .filter((player) => !used.has(player.id) && roleFromPlayer(player) === role)
-      .sort(
-        (a, b) =>
-          calcOvr(b, roleTargetPosition[role]) -
-          calcOvr(a, roleTargetPosition[role]),
-      );
+      .filter((player) => !used.has(player.id) && getLolRoleForPlayer(player) === role)
+      .sort((a, b) => calculateLolOvr(b) - calculateLolOvr(a));
 
     const bestRolePlayer = roleCandidates[0];
     if (bestRolePlayer) {
-      xi.push(bestRolePlayer.id);
+      activeIds.push(bestRolePlayer.id);
       used.add(bestRolePlayer.id);
     }
   }
 
-  while (xi.length < 11) {
-    const candidates = available
-      .filter((player) => !used.has(player.id))
-      .sort((a, b) => calcOvr(b, b.natural_position || b.position) - calcOvr(a, a.natural_position || a.position));
+  return activeIds.slice(0, LOL_ACTIVE_ROLES.length);
+}
 
-    const bestPlayer = candidates[0];
-    if (!bestPlayer) break;
-    xi.push(bestPlayer.id);
-    used.add(bestPlayer.id);
-  }
-
-  return xi.slice(0, 11);
+export function buildActiveLineupSlots(
+  roles: readonly LolRole[],
+  activeIds: string[],
+  playersById: Map<string, PlayerData>,
+): ActiveLineupSlot[] {
+  return roles.map((role, index) => ({
+    index,
+    role,
+    player: playersById.get(activeIds[index]) ?? null,
+  }));
 }
 
 export function buildPitchSlotRows(
@@ -452,15 +483,23 @@ export function buildPitchSlotRows(
 }
 
 export function buildActivePositionMap(
-  pitchSlotRows: PitchSlotRow[],
+  slotsOrRows: PitchSlotRow[] | ActiveLineupSlot[],
 ): Map<string, string> {
   const map = new Map<string, string>();
-  pitchSlotRows.forEach((row) => {
-    row.slots.forEach((slot) => {
-      if (slot.player) {
-        map.set(slot.player.id, canonicalPosition(slot.position));
-      }
-    });
+
+  slotsOrRows.forEach((entry) => {
+    if ("slots" in entry) {
+      entry.slots.forEach((slot) => {
+        if (slot.player) {
+          map.set(slot.player.id, canonicalPosition(slot.position));
+        }
+      });
+      return;
+    }
+
+    if (entry.player) {
+      map.set(entry.player.id, entry.role);
+    }
   });
   return map;
 }

--- a/src/components/squad/SquadTab.test.tsx
+++ b/src/components/squad/SquadTab.test.tsx
@@ -13,6 +13,9 @@ vi.mock("react-i18next", () => ({
       if (key === "finances.contractRiskWarning") return "Warning";
       if (key === "finances.contractExpiresOn")
         return `Expires ${String((fallback as Record<string, unknown> | undefined)?.date ?? "")}`;
+      if (typeof fallback === "object" && typeof fallback.defaultValue === "string") {
+        return fallback.defaultValue;
+      }
       return typeof fallback === "string" ? fallback : key;
     },
     i18n: { language: "en" },
@@ -102,17 +105,11 @@ const makeTeam = (overrides: Partial<TeamData> = {}): TeamData => ({
   founded_year: 1900,
   colors: { primary: "#00ff00", secondary: "#ffffff" },
   starting_xi_ids: [
-    "gk1",
-    "d1",
-    "d2",
-    "d3",
-    "d4",
-    "m1",
-    "m2",
-    "m3",
-    "m4",
-    "f1",
-    "f2",
+    "top1",
+    "jng1",
+    "mid1",
+    "adc1",
+    "sup1",
   ],
   form: [],
   history: [],
@@ -121,18 +118,12 @@ const makeTeam = (overrides: Partial<TeamData> = {}): TeamData => ({
 
 const makeGameState = (): GameStateData => {
   const players = [
-    makePlayer("gk1", "Goalkeeper"),
-    makePlayer("d1", "Center Back"),
-    makePlayer("d2", "Defender"),
-    makePlayer("d3", "Defender"),
-    makePlayer("d4", "Defender"),
-    makePlayer("m1", "Midfielder"),
-    makePlayer("m2", "Midfielder"),
-    makePlayer("m3", "Midfielder"),
-    makePlayer("m4", "Midfielder"),
-    makePlayer("f1", "Forward"),
-    makePlayer("f2", "Forward"),
-    makePlayer("d5", "Defender", { match_name: "Bench DEF" }),
+    makePlayer("top1", "TOP"),
+    makePlayer("jng1", "JUNGLE"),
+    makePlayer("mid1", "MID"),
+    makePlayer("adc1", "ADC"),
+    makePlayer("sup1", "SUPPORT"),
+    makePlayer("adc2", "ADC", { match_name: "Bench ADC" }),
   ];
 
   return {
@@ -163,17 +154,11 @@ const makeGameState = (): GameStateData => {
     teams: [
       makeTeam({
         starting_xi_ids: [
-          "gk1",
-          "d1",
-          "d2",
-          "d3",
-          "d4",
-          "m1",
-          "m2",
-          "m3",
-          "m4",
-          "f1",
-          "f2",
+          "top1",
+          "jng1",
+          "mid1",
+          "adc1",
+          "sup1",
         ],
       }),
     ],
@@ -188,7 +173,7 @@ const makeGameState = (): GameStateData => {
 };
 
 describe("SquadTab", () => {
-  it("renders only the full roster table and not the moved tactics controls", () => {
+  it("renders a five-role LoL active lineup and keeps bench players visible", () => {
     render(
       <SquadTab
         gameState={makeGameState()}
@@ -198,18 +183,46 @@ describe("SquadTab", () => {
       />,
     );
 
-    expect(screen.getByText("squad.title")).toBeInTheDocument();
-    expect(screen.getByText("Bench DEF")).toBeInTheDocument();
+    expect(screen.getByText("Active Lineup")).toBeInTheDocument();
+    expect(screen.getByText("Bench / Substitutes")).toBeInTheDocument();
+    expect(screen.getByText("Bench ADC")).toBeInTheDocument();
+
+    const activeLineup = screen.getByTestId("active-lineup");
+    for (const role of ["TOP", "JUNGLE", "MID", "ADC", "SUPPORT"]) {
+      expect(within(activeLineup).getByText(role)).toBeInTheDocument();
+    }
+
+    expect(screen.queryByText(/Starting XI/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/pitch/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("4-4-2")).not.toBeInTheDocument();
+    expect(screen.queryByText("GK")).not.toBeInTheDocument();
+    expect(screen.queryByText("DEF")).not.toBeInTheDocument();
+    expect(screen.queryByText("FWD")).not.toBeInTheDocument();
     expect(screen.queryByText("What this changes")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("bench-player-d5")).not.toBeInTheDocument();
     expect(screen.queryByTestId("pitch-slot-1")).not.toBeInTheDocument();
   });
 
-  it("shows contract inspection columns and renew entry points for expiring players", () => {
+  it("shows missing role coverage clearly in the active lineup", () => {
+    const gameState = makeGameState();
+    gameState.players = gameState.players.filter((player) => player.natural_position !== "SUPPORT");
+
+    render(
+      <SquadTab
+        gameState={gameState}
+        managerId="mgr1"
+        onSelectPlayer={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
+
+    const supportSlot = screen.getByTestId("active-lineup-role-SUPPORT");
+    expect(within(supportSlot).getByText("SUPPORT")).toBeInTheDocument();
+    expect(within(supportSlot).getByText("Missing role coverage")).toBeInTheDocument();
+  });
+
+  it("keeps substitute player cards usable from the bench roster", () => {
     const onSelectPlayer = vi.fn();
     const gameState = makeGameState();
-    gameState.clock.current_date = "2026-08-01";
-    gameState.players[0].contract_end = "2026-10-15";
 
     render(
       <SquadTab
@@ -220,19 +233,10 @@ describe("SquadTab", () => {
       />,
     );
 
-    expect(screen.getByText("Years Remaining")).toBeInTheDocument();
-    expect(screen.getByText("Contract Risk")).toBeInTheDocument();
-    expect(screen.getByText("Critical")).toBeInTheDocument();
+    const benchCard = screen.getByText("Bench ADC").closest("button");
+    expect(benchCard).not.toBeNull();
+    fireEvent.click(benchCard as HTMLButtonElement);
 
-    const gkRow = screen.getByText("GK1").closest("tr");
-    expect(gkRow).not.toBeNull();
-    const renewBtn = within(gkRow as HTMLTableRowElement).getByRole("button", {
-      name: "Renew Contract",
-    });
-    fireEvent.click(renewBtn);
-
-    expect(onSelectPlayer).toHaveBeenCalledWith("gk1", {
-      openRenewal: true,
-    });
+    expect(onSelectPlayer).toHaveBeenCalledWith("adc2");
   });
 });


### PR DESCRIPTION
Closes #142

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [x] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Replaces the Squad tab's football-shaped Starting XI presentation with a five-role LoL Active Lineup.
- Keeps bench/substitute players visible and selectable while surfacing missing role coverage clearly.
- Updates squad helper and component tests around LoL role lineup behavior and absence of football labels.

## Changes
| File | Change |
|------|--------|
| `src/components/squad/SquadRosterView.tsx` | Renders Active Lineup cards for TOP/JUNGLE/MID/ADC/SUPPORT and a Bench/Substitutes section. |
| `src/components/squad/SquadTab.helpers.ts` | Adds LoL active lineup helpers and maps active player positions by LoL role. |
| `src/components/squad/SquadTab.helpers.test.ts` | Replaces Starting XI/pitch tests with five-role lineup helper coverage. |
| `src/components/squad/SquadTab.test.tsx` | Verifies LoL role labels, missing role coverage, bench usability, and absence of football labels. |

## Test Plan
- [x] `npm test -- src/components/squad/SquadTab.helpers.test.ts`
- [x] `npm test -- src/components/squad/SquadTab.test.tsx`
- [x] `npm test -- src/components/squad/SquadTab.helpers.test.ts src/components/squad/SquadTab.test.tsx`
- [x] Build not run, per project workflow.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Conventional commit format.
- [x] No AI attribution or `Co-Authored-By` trailers.