### PR TITLE
chore(branding): replace OpenFoot menu logo

### DIFF
--- a/src/pages/MainMenu.test.tsx
+++ b/src/pages/MainMenu.test.tsx
@@ -378,7 +378,7 @@ describe("MainMenu", () => {
 
     const logo = screen.getByRole("img", { name: /league manager/i });
     expect(logo).toBeInTheDocument();
-    expect(logo).toHaveAttribute("src", "/lec-logo.svg");
+    expect(logo).toHaveAttribute("src", "/openfootlogo.svg");
     expect(logo).toHaveAccessibleName("League Manager");
   });
 });

--- a/src/pages/MainMenu.test.tsx
+++ b/src/pages/MainMenu.test.tsx
@@ -372,4 +372,13 @@ describe("MainMenu", () => {
       );
     });
   });
+
+  it("displays LoL-neutral logo without OpenFoot/OpenFootball branding", () => {
+    render(<MainMenu />);
+
+    const logo = screen.getByRole("img", { name: /league manager/i });
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute("src", "/lec-logo.svg");
+    expect(logo).toHaveAccessibleName("League Manager");
+  });
 });

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -378,7 +378,7 @@ export default function MainMenu() {
         <div className="bg-white dark:bg-navy-800 p-8 rounded-b-2xl shadow-xl dark:shadow-2xl border border-gray-200 dark:border-navy-600 border-t-0 transition-all duration-500">
           {/* Logo */}
           <img
-            src="/lec-logo.svg"
+            src="/openfootlogo.svg"
             alt="League Manager"
             className="text-center w-full h-full object-cover"
           />

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -378,8 +378,8 @@ export default function MainMenu() {
         <div className="bg-white dark:bg-navy-800 p-8 rounded-b-2xl shadow-xl dark:shadow-2xl border border-gray-200 dark:border-navy-600 border-t-0 transition-all duration-500">
           {/* Logo */}
           <img
-            src="/openfootlogo.svg"
-            alt="OpenFootball"
+            src="/lec-logo.svg"
+            alt="League Manager"
             className="text-center w-full h-full object-cover"
           />
 


### PR DESCRIPTION
## Approved issue

Closes #144

- [x] The linked issue has `status:approved`.
- [x] This PR targets `develop` (repository base branch; equivalent to the template's development target here).
- [x] This PR has exactly one `type:*` label.

## Summary

- Replaces the main menu OpenFoot/OpenFootball logo reference with the existing LoL-neutral LEC logo asset.
- Updates the logo alt text to `League Manager`.
- Adds a focused MainMenu test to guard against reintroducing OpenFoot/OpenFootball branding in the visible logo.

## Checks run

Required/stable PR checks are intentionally lightweight and production-build-free:

- [ ] `frontend-install` passed (dependency installation validation). Not run locally for this focused UI test change.
- [ ] `rust-check` passed (`cargo fmt --check` and `cargo check`). Not applicable locally for this frontend-only change.
- [ ] Not applicable locally; docs/templates only.

Focused validation:

- [x] `npm test -- src/pages/MainMenu.test.tsx`

Manual/experimental full checks are available for maintainer-requested validation and current debt tracking:

- `frontend-full-experimental` (`npm test`, `npm run build:types`).
- `rust-full-experimental` (`cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`).

Do not mark the experimental full checks as required for this PR unless a maintainer explicitly asks.

## Documentation and provenance

- [x] Documentation was updated or no docs change is needed.
- [x] Data provenance was updated or no provenance change is needed.
- [x] No unclear third-party data, generated cache, secret, signing key, or private credential is included.

## Release impact

- [x] Changelog entry added or not needed.
- [x] Version changes are synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` when applicable.