### PR TITLE
fix(players): calculate ages from game date

### DIFF
--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -32,6 +32,14 @@ pub struct TeamSelectionData {
 
 const ACADEMY_FALLBACK_PHOTO: &str = "/player-photos/107455908655055017.png";
 
+fn calculate_age_on_date(birth_date: chrono::NaiveDate, as_of_date: chrono::NaiveDate) -> i32 {
+    let mut age = as_of_date.year() - birth_date.year();
+    if (as_of_date.month(), as_of_date.day()) < (birth_date.month(), birth_date.day()) {
+        age -= 1;
+    }
+    age
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ExampleAcademyPlayerSeed {
     pub(crate) role: String,
@@ -1809,11 +1817,12 @@ pub async fn start_new_game(
         return Err("Nationality is required.".to_string());
     }
 
-    // Validate DOB: must be a valid date and within a sensible range
+    let start_date = chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
+
+    // Validate DOB: must be a valid date and within a sensible range for the game start date.
     let birth_date = chrono::NaiveDate::parse_from_str(&dob, "%Y-%m-%d")
         .map_err(|_| "Invalid date of birth. Use YYYY-MM-DD format.".to_string())?;
-    let today = chrono::Utc::now().date_naive();
-    let age = today.signed_duration_since(birth_date).num_days() / 365;
+    let age = calculate_age_on_date(birth_date, start_date.date_naive());
     if age > 99 {
         return Err("Invalid date of birth.".to_string());
     }
@@ -1828,8 +1837,6 @@ pub async fn start_new_game(
     manager.nickname = nickname;
     manager.avatar_path = avatar_path;
 
-    use chrono::TimeZone;
-    let start_date = chrono::Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap();
     let clock = GameClock::new(start_date);
 
     // Load world based on source
@@ -2365,4 +2372,25 @@ pub async fn update_manager_profile(
 
     info!("[cmd] update_manager_profile: completed");
     Ok(())
+}
+
+#[cfg(test)]
+mod player_age_tests {
+    use super::*;
+
+    #[test]
+    fn calculates_age_against_game_date_not_system_date() {
+        let birth_date = chrono::NaiveDate::from_ymd_opt(2000, 1, 2).unwrap();
+        let game_date = chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+
+        assert_eq!(calculate_age_on_date(birth_date, game_date), 24);
+    }
+
+    #[test]
+    fn increments_age_on_birthday() {
+        let birth_date = chrono::NaiveDate::from_ymd_opt(2000, 1, 1).unwrap();
+        let game_date = chrono::NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+
+        assert_eq!(calculate_age_on_date(birth_date, game_date), 25);
+    }
 }

--- a/src/components/playerProfile/PlayerProfile.helpers.ts
+++ b/src/components/playerProfile/PlayerProfile.helpers.ts
@@ -4,7 +4,7 @@ import type {
 } from "../../store/gameStore";
 import type { TOptions } from "i18next";
 import { annualAmountToWeeklyCommitment } from "../../lib/finance";
-import { formatWeeklyAmount } from "../../lib/helpers";
+import { calcAge, formatWeeklyAmount } from "../../lib/helpers";
 
 type TranslateFn = (key: string, options?: TOptions) => string;
 
@@ -27,19 +27,7 @@ export function getPlayerAge(
     dateOfBirth: string,
     asOfDate: string,
 ): number {
-    const birthDate = new Date(dateOfBirth);
-    const currentDate = new Date(asOfDate);
-    let age = currentDate.getFullYear() - birthDate.getFullYear();
-
-    if (
-        currentDate.getMonth() < birthDate.getMonth() ||
-        (currentDate.getMonth() === birthDate.getMonth() &&
-            currentDate.getDate() < birthDate.getDate())
-    ) {
-        age -= 1;
-    }
-
-    return age;
+    return calcAge(dateOfBirth, asOfDate);
 }
 
 export function formatPlayerMarketValue(value: number): string {

--- a/src/components/players/PlayersListTab.test.tsx
+++ b/src/components/players/PlayersListTab.test.tsx
@@ -158,10 +158,10 @@ function createGameState(): GameStateData {
       createPlayer(),
       createPlayer({
         id: "player-2",
-        match_name: "A. Keeper",
-        full_name: "Alex Keeper",
-        position: "Goalkeeper",
-        natural_position: "Goalkeeper",
+        match_name: "A. Support",
+        full_name: "Alex Support",
+        position: "SUPPORT",
+        natural_position: "SUPPORT",
         team_id: "team-2",
       }),
       createPlayer({
@@ -184,7 +184,7 @@ function createGameState(): GameStateData {
 }
 
 describe("PlayersListTab", () => {
-  it("filters by search and position before selecting a player", () => {
+  it("filters by search and LoL role before selecting a player", () => {
     const onSelectPlayer = vi.fn();
 
     render(
@@ -196,14 +196,14 @@ describe("PlayersListTab", () => {
     );
 
     fireEvent.change(screen.getByPlaceholderText("Search players"), {
-      target: { value: "keeper" },
+      target: { value: "support" },
     });
 
-    expect(screen.getByText("Alex Keeper")).toBeInTheDocument();
+    expect(screen.getByText("Alex Support")).toBeInTheDocument();
     expect(screen.queryByText("John Smith")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "SUPPORT" }));
-    fireEvent.click(screen.getByText("Alex Keeper"));
+    fireEvent.click(screen.getByText("Alex Support"));
 
     expect(onSelectPlayer).toHaveBeenCalledWith("player-2");
   });

--- a/src/components/players/PlayersListTab.tsx
+++ b/src/components/players/PlayersListTab.tsx
@@ -134,7 +134,7 @@ export default function PlayersListTab({
         cmp = posOrder[getLolRoleForPlayer(a)] - posOrder[getLolRoleForPlayer(b)];
         break;
       case "age":
-        cmp = calcAge(a.date_of_birth) - calcAge(b.date_of_birth);
+        cmp = calcAge(a.date_of_birth, gameState.clock.current_date) - calcAge(b.date_of_birth, gameState.clock.current_date);
         break;
       case "ovr":
         cmp = calculateLolOvr(a) - calculateLolOvr(b);
@@ -306,7 +306,7 @@ export default function PlayersListTab({
                   .slice((page - 1) * pageSize, page * pageSize)
                   .map((player) => {
                     const ovr = calculateLolOvr(player);
-                    const age = calcAge(player.date_of_birth);
+                    const age = calcAge(player.date_of_birth, gameState.clock.current_date);
                     const photoSrc = resolvePlayerPhoto(player.id, player.match_name);
                     return (
                       <tr

--- a/src/components/scouting/ScoutingPlayerSearchCard.test.tsx
+++ b/src/components/scouting/ScoutingPlayerSearchCard.test.tsx
@@ -136,6 +136,7 @@ describe("ScoutingPlayerSearchCard", () => {
           createTeam(),
           createTeam({ id: "team-2", name: "Beta FC", manager_id: "manager-2" }),
         ]}
+        currentDate="2026-08-01T00:00:00Z"
         posFilter="All"
         searchQuery=""
         alreadyScoutingIds={new Set<string>()}

--- a/src/components/scouting/ScoutingPlayerSearchCard.tsx
+++ b/src/components/scouting/ScoutingPlayerSearchCard.tsx
@@ -20,6 +20,7 @@ const LOL_ROLE_BADGE_VARIANT: Record<LolRole, "accent" | "primary" | "success" |
 interface ScoutingPlayerSearchCardProps {
   players: PlayerData[];
   teams: TeamData[];
+  currentDate: string;
   posFilter: string;
   searchQuery: string;
   alreadyScoutingIds: Set<string>;
@@ -40,6 +41,7 @@ interface ScoutingPlayerSearchCardProps {
 export default function ScoutingPlayerSearchCard({
   players,
   teams,
+  currentDate,
   posFilter,
   searchQuery,
   alreadyScoutingIds,
@@ -146,7 +148,7 @@ export default function ScoutingPlayerSearchCard({
                       </Badge>
                     </td>
                     <td className="text-center py-2 px-1 text-gray-600 dark:text-gray-400">
-                      {calcAge(player.date_of_birth)}
+                      {calcAge(player.date_of_birth, currentDate)}
                     </td>
                     <td className="py-2 px-1 text-gray-600 dark:text-gray-400 text-xs truncate max-w-[120px]">
                       {team}

--- a/src/components/scouting/ScoutingTab.tsx
+++ b/src/components/scouting/ScoutingTab.tsx
@@ -182,6 +182,7 @@ export default function ScoutingTab({
         <ScoutingPlayerSearchCard
           players={scoutablePlayers}
           teams={gameState.teams}
+          currentDate={gameState.clock.current_date}
           posFilter={posFilter}
           searchQuery={searchQuery}
           alreadyScoutingIds={alreadyScoutingIds}

--- a/src/components/squad/SquadRosterView.tsx
+++ b/src/components/squad/SquadRosterView.tsx
@@ -176,13 +176,13 @@ export default function SquadRosterView({
         case "morale":
           return a.morale - b.morale;
         case "age":
-          return calcAge(a.date_of_birth) - calcAge(b.date_of_birth);
+          return calcAge(a.date_of_birth, gameState.clock.current_date) - calcAge(b.date_of_birth, gameState.clock.current_date);
         default:
           return 0;
       }
     });
     return sortDir === "desc" ? sorted.reverse() : sorted;
-  }, [roster, sortDir, sortKey]);
+  }, [gameState.clock.current_date, roster, sortDir, sortKey]);
 
   const masteryTopChampionsByPlayer = useMemo(() => {
     const grouped = new Map<string, Array<{ champion: string; mastery: number }>>();

--- a/src/components/staff/StaffTab.tsx
+++ b/src/components/staff/StaffTab.tsx
@@ -305,7 +305,7 @@ export default function StaffTab({ gameState, onGameUpdate }: StaffTabProps) {
           {filtered.map((staff) => {
             const roleIcon = ROLE_ICONS[staff.role] || ROLE_ICONS.Coach;
             const roleColor = ROLE_COLORS[staff.role] || ROLE_COLORS.Coach;
-            const age = calcAge(staff.date_of_birth);
+            const age = calcAge(staff.date_of_birth, gameState.clock.current_date);
             const ovr = ovrRating(staff);
             const best = bestAttr(staff);
             const impactRows = getStaffImpactRows(staff);

--- a/src/components/tactics/TacticsTab.helpers.ts
+++ b/src/components/tactics/TacticsTab.helpers.ts
@@ -47,6 +47,7 @@ const POSITION_ORDER: Record<string, number> = {
 };
 
 interface TacticsPlayerSortContext {
+  currentDate: string;
   section: SquadSection;
   sortDir: SortDirection;
   sortKey: SortKey;
@@ -139,7 +140,7 @@ export function sortTacticsPlayers(
   players: PlayerData[],
   context: TacticsPlayerSortContext,
 ): PlayerData[] {
-  const { section, sortDir, sortKey, xiActivePosition } = context;
+  const { currentDate, section, sortDir, sortKey, xiActivePosition } = context;
   const sortedPlayers = [...players].sort((leftPlayer, rightPlayer) => {
     const leftPosition = getSectionPlayerPosition(leftPlayer, section, xiActivePosition);
     const rightPosition = getSectionPlayerPosition(rightPlayer, section, xiActivePosition);
@@ -154,7 +155,7 @@ export function sortTacticsPlayers(
       case "name":
         return leftPlayer.full_name.localeCompare(rightPlayer.full_name);
       case "age":
-        return calcAge(leftPlayer.date_of_birth) - calcAge(rightPlayer.date_of_birth);
+        return calcAge(leftPlayer.date_of_birth, currentDate) - calcAge(rightPlayer.date_of_birth, currentDate);
       case "condition":
         return leftPlayer.condition - rightPlayer.condition;
       case "morale":

--- a/src/components/tactics/TacticsTab.test.tsx
+++ b/src/components/tactics/TacticsTab.test.tsx
@@ -3,7 +3,6 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
@@ -114,8 +113,8 @@ const makeTeam = (overrides: Partial<TeamData> = {}): TeamData => ({
 
 const makeGameState = (): GameStateData => {
   const players = [
-    makePlayer("gk1", "Goalkeeper"),
-    makePlayer("d1", "Center Back", {
+    makePlayer("top1", "TOP", {
+      match_name: "Top Starter",
       attributes: {
         pace: 50,
         stamina: 60,
@@ -138,10 +137,9 @@ const makeGameState = (): GameStateData => {
         aerial: 15,
       },
     }),
-    makePlayer("d2", "Defender"),
-    makePlayer("d3", "Defender"),
-    makePlayer("d4", "Defender"),
-    makePlayer("m1", "Midfielder", {
+    makePlayer("jng1", "JUNGLE", { match_name: "Jungle Starter" }),
+    makePlayer("mid1", "MID", {
+      match_name: "Mid Starter",
       attributes: {
         pace: 70,
         stamina: 74,
@@ -164,12 +162,9 @@ const makeGameState = (): GameStateData => {
         aerial: 10,
       },
     }),
-    makePlayer("m2", "Midfielder"),
-    makePlayer("m3", "Midfielder"),
-    makePlayer("m4", "Midfielder"),
-    makePlayer("f1", "Forward"),
-    makePlayer("f2", "Forward"),
-    makePlayer("d5", "Defender", { match_name: "Bench DEF" }),
+    makePlayer("adc1", "ADC", { match_name: "ADC Starter" }),
+    makePlayer("sup1", "SUPPORT", { match_name: "Support Starter" }),
+    makePlayer("bench1", "TOP", { match_name: "Bench Top" }),
   ];
 
   return {
@@ -200,17 +195,11 @@ const makeGameState = (): GameStateData => {
     teams: [
       makeTeam({
         starting_xi_ids: [
-          "gk1",
-          "d1",
-          "d2",
-          "d3",
-          "d4",
-          "m1",
-          "m2",
-          "m3",
-          "m4",
-          "f1",
-          "f2",
+          "top1",
+          "jng1",
+          "mid1",
+          "adc1",
+          "sup1",
         ],
       }),
     ],
@@ -224,25 +213,13 @@ const makeGameState = (): GameStateData => {
   };
 };
 
-const createDataTransfer = () => {
-  const data = new Map<string, string>();
-  return {
-    effectAllowed: "move",
-    dropEffect: "move",
-    setData: (type: string, value: string) => {
-      data.set(type, value);
-    },
-    getData: (type: string) => data.get(type) ?? "",
-  };
-};
-
 describe("TacticsTab", () => {
   beforeEach(() => {
     mockedInvoke.mockReset();
     mockedInvoke.mockResolvedValue(makeGameState());
   });
 
-  it("renders play style guidance plus bench cards inside the pitch view", () => {
+  it("renders the current LoL game-plan controls and role impact panel", () => {
     render(
       <TacticsTab
         gameState={makeGameState()}
@@ -251,261 +228,73 @@ describe("TacticsTab", () => {
       />,
     );
 
-    expect(screen.getByText("What this changes")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "Keeps your team measured in and out of possession, with a steady shape and fewer extremes.",
-      ),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText("Substitutes").length).toBeGreaterThan(0);
-    expect(screen.getByTestId("bench-player-d5")).toBeInTheDocument();
-    expect(screen.getByTestId("pitch-bench-player-d5")).toBeInTheDocument();
+    expect(screen.getByText("tactics.lol.gamePlan")).toBeInTheDocument();
+    expect(screen.getByText("Game timing")).toBeInTheDocument();
+    expect(screen.getByText("Strong side")).toBeInTheDocument();
+    expect(screen.getByText("Jungle style")).toBeInTheDocument();
+    expect(screen.getByText("Support roaming")).toBeInTheDocument();
+    expect(screen.getByText("tactics.lol.impactAndCoherence")).toBeInTheDocument();
+    expect(screen.getByText("Top Starter")).toBeInTheDocument();
+    expect(screen.getByText("Support Starter")).toBeInTheDocument();
   });
 
-  it("sends the correct starting xi order when a pitch-view bench defender is dropped onto a defensive slot", async () => {
+  it("persists game timing changes through the LoL tactics command", async () => {
+    const onGameUpdate = vi.fn();
+
     render(
       <TacticsTab
         gameState={makeGameState()}
         onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
+        onGameUpdate={onGameUpdate}
       />,
     );
 
-    const benchPlayer = screen.getByTestId("pitch-bench-player-d5");
-    const pitchSlot = screen.getByTestId("pitch-slot-1");
-    const dataTransfer = createDataTransfer();
-
-    fireEvent.dragStart(benchPlayer, { dataTransfer });
-    fireEvent.drop(pitchSlot, { dataTransfer });
+    fireEvent.click(screen.getByRole("button", { name: /Early game/ }));
 
     await waitFor(() => {
-      expect(mockedInvoke).toHaveBeenCalledWith("set_starting_xi", {
-        playerIds: [
-          "gk1",
-          "d5",
-          "d2",
-          "d3",
-          "d4",
-          "m1",
-          "m2",
-          "m3",
-          "m4",
-          "f1",
-          "f2",
-        ],
-      });
-    });
-  });
-
-  it("does not render drag handles in the lineup tables", () => {
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    expect(
-      screen.queryByTestId("bench-player-drag-handle-d5"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("xi-player-drag-handle-d1"),
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("pitch-bench-player-d5")).toHaveAttribute(
-      "draggable",
-      "true",
-    );
-  });
-
-  it("shows a bench player's natural position on the pitch bench cards when it differs from position", () => {
-    const gameState = makeGameState();
-    gameState.players = gameState.players.map((player) =>
-      player.id === "d5"
-        ? {
-            ...player,
-            position: "Midfielder",
-            natural_position: "Defender",
-          }
-        : player,
-    );
-
-    render(
-      <TacticsTab
-        gameState={gameState}
-        onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    const benchCard = screen.getByTestId("pitch-bench-player-d5");
-
-    expect(
-      within(benchCard).getByText("common.posAbbr.Defender"),
-    ).toBeInTheDocument();
-    expect(
-      within(benchCard).queryByText("common.posAbbr.Midfielder"),
-    ).not.toBeInTheDocument();
-  });
-
-  it("localizes the selected player position in the comparison panel", () => {
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("pitch-player-f1"));
-
-    expect(screen.getByText("common.positions.Forward")).toBeInTheDocument();
-    expect(screen.queryByText("Forward")).not.toBeInTheDocument();
-  });
-
-  it("allows selecting a bench player from the pitch view and swapping them with a starter", async () => {
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("pitch-bench-player-d5"));
-
-    expect(screen.getByText("Selected player")).toBeInTheDocument();
-    expect(screen.getAllByText("Player d5").length).toBeGreaterThan(0);
-
-    fireEvent.click(screen.getByTestId("pitch-player-d2"));
-
-    expect(mockedInvoke).not.toHaveBeenCalled();
-    expect(screen.getByText("Comparison player")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Confirm swap" }));
-
-    await waitFor(() => {
-      expect(mockedInvoke).toHaveBeenCalledWith("set_starting_xi", {
-        playerIds: [
-          "gk1",
-          "d1",
-          "d5",
-          "d3",
-          "d4",
-          "m1",
-          "m2",
-          "m3",
-          "m4",
-          "f1",
-          "f2",
-        ],
-      });
-    });
-  });
-
-  it("uses pitch clicks for selection and swap instead of opening the player profile", async () => {
-    const onSelectPlayer = vi.fn();
-
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={onSelectPlayer}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("pitch-player-d1"));
-
-    expect(onSelectPlayer).not.toHaveBeenCalled();
-    expect(screen.getByText("Selected player")).toBeInTheDocument();
-    expect(screen.getAllByText("Player d1").length).toBeGreaterThan(0);
-
-    fireEvent.click(screen.getByTestId("pitch-player-d2"));
-
-    expect(onSelectPlayer).not.toHaveBeenCalled();
-    expect(mockedInvoke).not.toHaveBeenCalled();
-    expect(screen.getByText("Comparison player")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: "Confirm swap" }));
-
-    await waitFor(() => {
-      expect(mockedInvoke).toHaveBeenCalledWith("set_starting_xi", {
-        playerIds: [
-          "gk1",
-          "d2",
-          "d1",
-          "d3",
-          "d4",
-          "m1",
-          "m2",
-          "m3",
-          "m4",
-          "f1",
-          "f2",
-        ],
-      });
-    });
-  });
-
-  it("shows a comparison panel after selecting a second pitch player", () => {
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("pitch-player-d1"));
-    fireEvent.click(screen.getByTestId("pitch-player-m1"));
-
-    expect(screen.getByText("Comparison player")).toBeInTheDocument();
-    expect(screen.getAllByText("Player m1").length).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText("common.attributes.vision").length,
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getByRole("button", { name: "Confirm swap" }),
-    ).toBeInTheDocument();
-  });
-
-  it("only opens profiles from the lineup tables", () => {
-    const onSelectPlayer = vi.fn();
-
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={onSelectPlayer}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("xi-player-d1"));
-
-    expect(onSelectPlayer).toHaveBeenCalledWith("d1");
-  });
-
-  it("persists default set piece and team role assignments from the roles tab", async () => {
-    render(
-      <TacticsTab
-        gameState={makeGameState()}
-        onSelectPlayer={vi.fn()}
-        onGameUpdate={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Set pieces & roles" }));
-    fireEvent.click(
-      screen.getByRole("button", { name: "Auto-select defaults" }),
-    );
-
-    await waitFor(() => {
-      expect(mockedInvoke).toHaveBeenCalledWith("set_team_roles", {
-        teamRoles: expect.objectContaining({
-          captain: expect.any(String),
-          shotcaller: expect.any(String),
+      expect(mockedInvoke).toHaveBeenCalledWith("set_lol_tactics", {
+        lolTactics: expect.objectContaining({
+          game_timing: "Early",
         }),
       });
     });
+
+    await waitFor(() => {
+      expect(onGameUpdate).toHaveBeenCalledWith(makeGameState());
+    });
+  });
+
+  it("persists support roaming changes with the current tactics payload", async () => {
+    render(
+      <TacticsTab
+        gameState={makeGameState()}
+        onSelectPlayer={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Roam mid/ }));
+
+    await waitFor(() => {
+      expect(mockedInvoke).toHaveBeenCalledWith("set_lol_tactics", {
+        lolTactics: expect.objectContaining({
+          support_roaming: "RoamMid",
+        }),
+      });
+    });
+  });
+
+  it("does not expose the legacy pitch and set-piece controls in the LoL tactics view", () => {
+    render(
+      <TacticsTab
+        gameState={makeGameState()}
+        onSelectPlayer={vi.fn()}
+        onGameUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Game timing")).toBeInTheDocument();
+    expect(screen.queryByTestId("pitch-player-top1")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Set pieces & roles" })).not.toBeInTheDocument();
   });
 });

--- a/src/components/teamProfile/TeamProfile.tsx
+++ b/src/components/teamProfile/TeamProfile.tsx
@@ -62,6 +62,7 @@ export default function TeamProfile({
 
         <TeamProfileRosterCard
           roster={viewModel.roster}
+          currentDate={gameState.clock.current_date}
           isOwnTeam={isOwnTeam}
           locale={i18n.language}
           t={t}

--- a/src/components/teamProfile/TeamProfileRosterCard.tsx
+++ b/src/components/teamProfile/TeamProfileRosterCard.tsx
@@ -11,6 +11,7 @@ import type { TeamProfileTranslate } from "./TeamProfile.types";
 
 interface TeamProfileRosterCardProps {
   roster: PlayerData[];
+  currentDate: string;
   isOwnTeam: boolean;
   locale: string;
   t: TeamProfileTranslate;
@@ -19,6 +20,7 @@ interface TeamProfileRosterCardProps {
 
 export default function TeamProfileRosterCard({
   roster,
+  currentDate,
   isOwnTeam,
   locale,
   t,
@@ -62,7 +64,7 @@ export default function TeamProfileRosterCard({
             <tbody className="divide-y divide-gray-100 dark:divide-navy-600">
               {roster.map((player) => {
                 const ovr = calculateLolOvr(player);
-                const age = calcAge(player.date_of_birth);
+                const age = calcAge(player.date_of_birth, currentDate);
                 const lolRole = getLolRoleForPlayer(player);
 
                 return (

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -626,7 +626,7 @@ export default function TransfersTab({
                 <tbody className="divide-y divide-gray-100 dark:divide-navy-600">
                   {filteredList.map((player) => {
                     const ovr = calculateLolOvr(player);
-                    const age = calcAge(player.date_of_birth);
+                    const age = calcAge(player.date_of_birth, gameState.clock.current_date);
                     const offersForThisPlayer = player.transfer_offers;
                     const lolRole = getLolRoleForPlayer(player);
                     const photoSrc = resolvePlayerPhoto(player.id, player.match_name);

--- a/src/components/worldEditor/WorldEditorTab.tsx
+++ b/src/components/worldEditor/WorldEditorTab.tsx
@@ -3,12 +3,15 @@ import type { ReactNode } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { ArrowLeft, Database, FileSpreadsheet, Image, Plus, Save, Search, Trash2, Upload, User, UserCog } from "lucide-react";
 import type { PlayerData, StaffData, TeamData } from "../../store/gameStore";
+import { calcAge } from "../../lib/helpers";
 import { calculateLolOvr } from "../../lib/lolPlayerStats";
 import { resolvePlayerPhoto, resolveStaffPhoto } from "../../lib/playerPhotos";
 import { Card, CardBody, ThemeToggle } from "../ui";
 
 type EditorMode = "players" | "staff";
 type PlayerListScope = "all" | "main" | "academy" | "freeAgents";
+
+const WORLD_EDITOR_REFERENCE_DATE = "2026-07-01T00:00:00Z";
 
 type ExcelImportField = PlayerAttributeKey | "potential_base";
 
@@ -122,13 +125,8 @@ function normalizeOptionalUrl(value: string): string | null {
 }
 
 function getAgeFromDob(dateOfBirth: string): number {
-  const birth = new Date(`${dateOfBirth}T00:00:00`);
-  if (Number.isNaN(birth.getTime())) return 24;
-  const today = new Date();
-  let age = today.getFullYear() - birth.getFullYear();
-  const birthdayPassed = today.getMonth() > birth.getMonth()
-    || (today.getMonth() === birth.getMonth() && today.getDate() >= birth.getDate());
-  if (!birthdayPassed) age -= 1;
+  const age = calcAge(dateOfBirth, WORLD_EDITOR_REFERENCE_DATE);
+  if (!Number.isFinite(age)) return 24;
   return Math.max(16, Math.min(45, age));
 }
 

--- a/src/components/youthAcademy/YouthAcademyTab.tsx
+++ b/src/components/youthAcademy/YouthAcademyTab.tsx
@@ -89,7 +89,7 @@ export default function YouthAcademyTab({ gameState, onSelectPlayer, onGameUpdat
         .map((player) => {
           const role = resolvePlayerLolRole(player);
           const ovr = getLolOvr(player);
-          const age = calcAge(player.date_of_birth);
+          const age = calcAge(player.date_of_birth, gameState.clock.current_date);
           const potential = player.potential_revealed ?? null;
           return { ...player, role, age, ovr, potential };
         })
@@ -100,7 +100,7 @@ export default function YouthAcademyTab({ gameState, onSelectPlayer, onGameUpdat
           if (byOvr !== 0) return byOvr;
           return (a.match_name || a.full_name).localeCompare(b.match_name || b.full_name);
         }),
-    [gameState.players, gameState.teams, myTeam],
+    [gameState.clock.current_date, gameState.players, gameState.teams, myTeam],
   );
 
   const avgOvr = youthPlayers.length > 0 ? Math.round(youthPlayers.reduce((sum, player) => sum + player.ovr, 0) / youthPlayers.length) : 0;

--- a/src/lib/helpers.test.ts
+++ b/src/lib/helpers.test.ts
@@ -155,9 +155,9 @@ describe("findNextFixture", () => {
 });
 
 describe("season helpers", () => {
-  it("computes the expected double round-robin fixture count for even-sized leagues", () => {
-    expect(expectedFixtureCount(16)).toBe(240);
-    expect(expectedFixtureCount(4)).toBe(12);
+  it("computes the expected single round-robin fixture count for even-sized leagues", () => {
+    expect(expectedFixtureCount(16)).toBe(120);
+    expect(expectedFixtureCount(4)).toBe(6);
   });
 
   it("treats odd-sized or undersized leagues as incomplete schedules", () => {
@@ -409,9 +409,9 @@ describe("calcOvr", () => {
 });
 
 describe("calcAge", () => {
-  it("calculates age relative to 2026", () => {
-    expect(calcAge("1996-01-15")).toBe(30);
-    expect(calcAge("2000-06-01")).toBe(26);
+  it("calculates age relative to the provided as-of date", () => {
+    expect(calcAge("1996-01-15", "2026-07-01T00:00:00Z")).toBe(30);
+    expect(calcAge("2000-06-01", "2026-07-01T00:00:00Z")).toBe(26);
   });
 });
 

--- a/src/lib/valueFormatting.test.ts
+++ b/src/lib/valueFormatting.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { calcAge } from "./valueFormatting";
+
+describe("calcAge", () => {
+  it("calculates age relative to the provided in-game date", () => {
+    expect(calcAge("2000-07-02", "2026-07-01T00:00:00Z")).toBe(25);
+    expect(calcAge("2000-07-01", "2026-07-01T00:00:00Z")).toBe(26);
+  });
+
+  it("uses the as-of year instead of the real current year", () => {
+    expect(calcAge("2000-01-01", "2025-01-01T00:00:00Z")).toBe(25);
+    expect(calcAge("2000-01-01", "2027-01-01T00:00:00Z")).toBe(27);
+  });
+});

--- a/src/lib/valueFormatting.ts
+++ b/src/lib/valueFormatting.ts
@@ -1,5 +1,17 @@
-export function calcAge(dob: string): number {
-    return 2026 - new Date(dob).getFullYear();
+export function calcAge(dob: string, asOfDate: string): number {
+    const birthDate = new Date(dob);
+    const currentDate = new Date(asOfDate);
+    let age = currentDate.getUTCFullYear() - birthDate.getUTCFullYear();
+
+    if (
+        currentDate.getUTCMonth() < birthDate.getUTCMonth() ||
+        (currentDate.getUTCMonth() === birthDate.getUTCMonth() &&
+            currentDate.getUTCDate() < birthDate.getUTCDate())
+    ) {
+        age -= 1;
+    }
+
+    return age;
 }
 
 export function formatVal(value: number): string {


### PR DESCRIPTION
Closes #188

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Makes player age calculations deterministic by deriving ages from the in-game date instead of wall-clock time or fixed years.
- Aligns age usage across player profile, roster, scouting, transfers, team, youth academy, staff, tactics helpers, world editor, and Rust validation.
- Refreshes stale frontend tests that were asserting legacy schedule/player/tactics behavior.

## Changes
| File | Change |
|------|--------|
| `src/lib/valueFormatting.ts` | Updates `calcAge` to require an explicit as-of date. |
| `src/components/**` | Passes game/current date through player age display and sorting paths. |
| `src/components/worldEditor/WorldEditorTab.tsx` | Replaces wall-clock age behavior with a fixed editor reference date. |
| `src-tauri/src/commands/game.rs` | Uses game-date based age validation helper. |
| `src/**/*.test.*` | Adds age coverage and updates stale focused tests to current product behavior. |

## Test Plan
- [x] `npm test -- src/lib/valueFormatting.test.ts src/components/playerProfile/PlayerProfile.helpers.test.ts src/components/scouting/ScoutingPlayerSearchCard.test.tsx src/lib/helpers.test.ts src/components/players/PlayersListTab.test.tsx src/components/tactics/TacticsTab.test.tsx`
- [x] `git diff --check`
- [ ] Rust focused tests are intentionally deferred to a separate PR because current Rust test targets are blocked by unrelated existing infrastructure/compile failures.
- [ ] Production build not run by project instruction.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Docs updated if behavior changed, or not applicable.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.