### PR TITLE
fix(players): pass game date to calcAge in transfers and scouting sort

### DIFF
--- a/src/components/scouting/ScoutingPlayerSearchCard.tsx
+++ b/src/components/scouting/ScoutingPlayerSearchCard.tsx
@@ -103,7 +103,7 @@ export default function ScoutingPlayerSearchCard({
           return ((order[roleA] ?? 0) - (order[roleB] ?? 0)) * factor;
         }
         case "age":
-          return (calcAge(a.date_of_birth) - calcAge(b.date_of_birth)) * factor;
+          return (calcAge(a.date_of_birth, currentDate) - calcAge(b.date_of_birth, currentDate)) * factor;
         case "team": {
           const teamA = getTeamName(teams, a.team_id);
           const teamB = getTeamName(teams, b.team_id);

--- a/src/components/transfers/TransfersTab.model.ts
+++ b/src/components/transfers/TransfersTab.model.ts
@@ -204,6 +204,7 @@ export interface TransferSortState {
 export function sortTransferPlayers(
   players: PlayerData[],
   sort: TransferSortState | null,
+  currentDate: string,
 ): PlayerData[] {
   if (!sort) return players;
 
@@ -226,7 +227,7 @@ export function sortTransferPlayers(
         return ((order[roleA] ?? 0) - (order[roleB] ?? 0)) * factor;
       }
       case "age":
-        return (calcAge(a.date_of_birth) - calcAge(b.date_of_birth)) * factor;
+        return (calcAge(a.date_of_birth, currentDate) - calcAge(b.date_of_birth, currentDate)) * factor;
       case "team": {
         const teamA = a.team_id ?? "";
         const teamB = b.team_id ?? "";

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -365,6 +365,7 @@ export default function TransfersTab({
   const filteredList = sortTransferPlayers(
     filterTransferPlayers(currentList, search, posFilter),
     sort,
+    gameState.clock.current_date,
   );
   const weeklyWageBudget = myTeam
     ? annualAmountToWeeklyCommitment(myTeam.wage_budget)


### PR DESCRIPTION
Two call sites in TransfersTab.model.ts and ScoutingPlayerSearchCard.tsx were calling calcAge(dob) with a single argument, leaving asOfDate as undefined. This caused NaN ages when sorting players by age.

## Approved issue

Closes #<!-- approved issue number -->

- [ ] The linked issue has `status:approved`.
- [ ] This PR targets `development` unless it is a maintainer release/hotfix PR.
- [ ] This PR has exactly one `type:*` label.

## Summary
- Fixed two call sites in TransfersTab.model.ts and ScoutingPlayerSearchCard.tsx where `calcAge(dob)` was called with only one argument, leaving `asOfDate` as `undefined` → `new Date(undefined)` = Invalid Date → `NaN` age when sorting by age.
- Added `currentDate: string` parameter to `sortTransferPlayers()` and passed `gameState.clock.current_date` from the caller.
## Checks run
- [x] `rust-check` passed (`cargo check` — 0 errors, pre-existing warnings only).
## Documentation and provenance
- [x] No docs change is needed.
## Release impact
- [x] Changelog entry not needed (bug fix, unreleased regression).



## Release impact

- [ ] Changelog entry added or not needed.
- [ ] Version changes are synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` when applicable.
