### PR TITLE
fix: allow scouting own players with perfect accuracy reports

### DIFF
--- a/src-tauri/crates/ofm_core/src/scouting.rs
+++ b/src-tauri/crates/ofm_core/src/scouting.rs
@@ -76,14 +76,9 @@ pub fn send_scout(game: &mut Game, scout_id: &str, player_id: &str) -> Result<()
         return Err("Scout does not belong to your team".to_string());
     }
 
-    // Validate player exists and is not on user's team
-    let player = game
-        .players
-        .iter()
-        .find(|p| p.id == player_id)
-        .ok_or("Player not found")?;
-    if player.team_id.as_deref() == Some(user_team_id.as_str()) {
-        return Err("Cannot scout your own players".to_string());
+    // Validate player exists
+    if !game.players.iter().any(|p| p.id == player_id) {
+        return Err("Player not found".to_string());
     }
 
     // Check scout capacity: higher ability = more concurrent assignments
@@ -160,6 +155,7 @@ pub fn process_scouting(game: &mut Game) {
     game.scouting_assignments.retain(|a| a.days_remaining > 0);
 
     // Generate reports for completed assignments
+    let user_team_id = game.manager.team_id.clone();
     for assignment in &completed {
         let scout = game.staff.iter().find(|s| s.id == assignment.scout_id);
         let player = game.players.iter().find(|p| p.id == assignment.player_id);
@@ -173,6 +169,7 @@ pub fn process_scouting(game: &mut Game) {
                 .as_ref()
                 .and_then(|tid| game.teams.iter().find(|t| &t.id == tid))
                 .map(|t| t.name.clone());
+            let is_own_player = player.team_id.as_deref() == user_team_id.as_deref();
 
             let msg = build_scout_report(
                 &assignment.id,
@@ -189,6 +186,7 @@ pub fn process_scouting(game: &mut Game) {
                 judging_potential,
                 team_name.as_deref(),
                 &today,
+                is_own_player,
             );
             game.messages.push(msg);
         }
@@ -210,11 +208,15 @@ fn build_scout_report(
     judging_potential: u8,
     team_name: Option<&str>,
     date: &str,
+    is_own_player: bool,
 ) -> InboxMessage {
     let mut rng = rand::rng();
 
     // Accuracy: higher judging = less noise on reported attributes
-    let noise_range = if judging_ability >= 80 {
+    // Own players get perfect reports (no noise) since the scout knows the squad
+    let noise_range = if is_own_player {
+        0
+    } else if judging_ability >= 80 {
         2
     } else if judging_ability >= 60 {
         5

--- a/src-tauri/crates/ofm_core/tests/scouting_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/scouting_tests.rs
@@ -145,11 +145,12 @@ fn send_scout_creates_assignment() {
 }
 
 #[test]
-fn send_scout_rejects_own_player() {
+fn send_scout_accepts_own_player() {
     let mut game = make_game();
     let result = send_scout(&mut game, "scout1", "p1");
-    assert!(result.is_err());
-    assert!(result.unwrap_err().contains("own players"));
+    assert!(result.is_ok());
+    assert_eq!(game.scouting_assignments.len(), 1);
+    assert_eq!(game.scouting_assignments[0].player_id, "p1");
 }
 
 #[test]
@@ -231,6 +232,70 @@ fn report_has_scout_report_data() {
     assert_eq!(report.nationality, "BR");
     assert!(report.team_name.is_some(), "Should have team name");
     assert_eq!(report.team_name.as_deref(), Some("Rival FC"));
+}
+
+#[test]
+fn own_player_report_has_exact_attributes_no_noise() {
+    let mut game = make_game();
+    let attrs = default_attrs();
+
+    send_scout(&mut game, "scout1", "p1").unwrap();
+    complete_scouting(&mut game);
+
+    let msg = game
+        .messages
+        .iter()
+        .find(|m| m.category == MessageCategory::ScoutReport)
+        .expect("Should have a scout report for own player");
+
+    let report = msg
+        .context
+        .scout_report
+        .as_ref()
+        .expect("Should have scout_report data");
+
+    assert_eq!(report.player_id, "p1");
+    // With noise_range = 0, fuzzed values should match original exactly
+    assert_eq!(
+        report.mechanics,
+        Some(attrs.dribbling),
+        "Mechanics should be exact for own player"
+    );
+    assert_eq!(
+        report.laning,
+        Some(attrs.shooting),
+        "Laning should be exact for own player"
+    );
+    assert_eq!(
+        report.teamfighting,
+        Some(attrs.teamwork),
+        "Teamfighting should be exact for own player"
+    );
+    assert_eq!(
+        report.macro_,
+        Some(attrs.vision),
+        "Macro should be exact for own player"
+    );
+    assert_eq!(
+        report.champion_pool,
+        Some(attrs.agility),
+        "Champion pool should be exact for own player"
+    );
+    assert_eq!(
+        report.discipline,
+        Some(attrs.composure),
+        "Discipline should be exact for own player"
+    );
+    assert_eq!(
+        report.condition,
+        Some(90),
+        "Condition should be exact for own player"
+    );
+    assert_eq!(
+        report.morale,
+        Some(75),
+        "Morale should be exact for own player"
+    );
 }
 
 #[test]

--- a/src/components/playerProfile/PlayerProfileHeroCard.tsx
+++ b/src/components/playerProfile/PlayerProfileHeroCard.tsx
@@ -168,7 +168,7 @@ export default function PlayerProfileHeroCard({
           <div className="absolute inset-0 bg-linear-to-r from-navy-700 to-navy-800" />
         )}
 
-        <div className="relative z-10 flex items-center gap-6">
+        <div className="relative z-10 flex items-start gap-6">
           <div className="relative w-24 h-24 shrink-0">
             <div
               className={`w-24 h-24 rounded-2xl overflow-hidden border-2 ${
@@ -276,15 +276,15 @@ export default function PlayerProfileHeroCard({
                 <span>{teamName}</span>
               )}
             </p>
-          </div>
 
-          <div className="mt-3">
-            <PlayerProfileScoutAction
-              availability={scoutAvailability}
-              scoutStatus={scoutStatus}
-              scoutError={scoutError}
-              onScout={onScout}
-            />
+            <div className="mt-3">
+              <PlayerProfileScoutAction
+                availability={scoutAvailability}
+                scoutStatus={scoutStatus}
+                scoutError={scoutError}
+                onScout={onScout}
+              />
+            </div>
           </div>
 
           <div className="hidden md:flex items-center gap-3">

--- a/src/components/playerProfile/PlayerProfileHeroCard.tsx
+++ b/src/components/playerProfile/PlayerProfileHeroCard.tsx
@@ -278,16 +278,14 @@ export default function PlayerProfileHeroCard({
             </p>
           </div>
 
-          {!isOwnClub ? (
-            <div className="mt-3">
-              <PlayerProfileScoutAction
-                availability={scoutAvailability}
-                scoutStatus={scoutStatus}
-                scoutError={scoutError}
-                onScout={onScout}
-              />
-            </div>
-          ) : null}
+          <div className="mt-3">
+            <PlayerProfileScoutAction
+              availability={scoutAvailability}
+              scoutStatus={scoutStatus}
+              scoutError={scoutError}
+              onScout={onScout}
+            />
+          </div>
 
           <div className="hidden md:flex items-center gap-3">
             <div className="grid grid-cols-3 gap-3 flex-1">


### PR DESCRIPTION

## Approved issue
Closes #161
- [x] The linked issue has `status:approved`.
- [x] This PR targets `development`.
- [x] This PR has exactly one `type:*` label.
## Summary
- **Backend:** Removed validation that blocked scouting own players (`scouting.rs`)
- **Backend:** Own-player scout reports now generate with `noise_range = 0` (perfect accuracy, no fuzzing)
- **Frontend:** Removed `!isOwnClub` condition hiding the scout button in player profile
- **Frontend:** Fixed button layout to prevent overlap with stats
- **Tests:** Updated `send_scout_rejects_own_player` → `send_scout_accepts_own_player`
- **Tests:** Added `own_player_report_has_exact_attributes_no_noise` verifying zero noise
## How to test
1. Open any player profile from your own team
2. Click the "Scout" button
3. Advance time until the assignment completes
4. Check inbox — the scout report should have exact attributes matching the player profile
## Checks run
- [ ] `frontend-install` passed (CI).
- [ ] `rust-check` passed (CI).
- [x] Manual: verified locally with `npm run tauri dev` on Windows.
## Documentation and provenance
- [x] Changelog updated.
- [x] No docs change needed.
- [x] No provenance change needed.
- [x] No unclear third-party data included.
## Release impact
- [x] Changelog entry added.
- [ ] Version changes not needed (patch-level fix).