### PR TITLE
fix: remove football injury system (dead code cleanup)

### DIFF
--- a/src-tauri/crates/db/src/migrations.rs
+++ b/src-tauri/crates/db/src/migrations.rs
@@ -450,6 +450,8 @@ pub fn all_migrations() -> Migrations<'static> {
         M::up(include_str!("sql/v053_remove_formation.sql")),
         // V54: Rename play_style column to draft_strategy
         M::up(include_str!("sql/v054_rename_play_style_to_draft_strategy.sql")),
+        // V55: Drop injury column from players table (football remnant)
+        M::up(include_str!("sql/v055_remove_injury_column.sql")),
         // V44: Persist transfer history entries
         M::up(include_str!("sql/v044_transfer_history.sql")),
     ])

--- a/src-tauri/crates/db/src/repositories/player_repo.rs
+++ b/src-tauri/crates/db/src/repositories/player_repo.rs
@@ -6,10 +6,6 @@ use rusqlite::{Connection, params};
 pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
     let attrs_json =
         serde_json::to_string(&p.attributes).map_err(|e| format!("JSON error: {}", e))?;
-    let injury_json = p
-        .injury
-        .as_ref()
-        .map(|i| serde_json::to_string(i).unwrap_or_default());
     let traits_json = serde_json::to_string(&p.traits).map_err(|e| format!("JSON error: {}", e))?;
     let stats_json = serde_json::to_string(&p.stats).map_err(|e| format!("JSON error: {}", e))?;
     let career_json = serde_json::to_string(&p.career).map_err(|e| format!("JSON error: {}", e))?;
@@ -29,12 +25,12 @@ pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
     conn.execute(
         "INSERT OR REPLACE INTO players
          (id, match_name, full_name, date_of_birth, nationality, birth_country, position,
-           attributes, condition, morale, injury, team_id, traits,
+           attributes, condition, morale, team_id, traits,
            contract_end, wage, market_value, stats, career,
            transfer_listed, loan_listed, transfer_offers, alternate_positions,
            natural_position, training_focus, morale_core, footedness, fitness,
            potential_base, potential_revealed, potential_research_started_on, potential_research_eta_days, profile_image_url)
-           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31, ?32)",
+           VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29, ?30, ?31)",
         params![
             p.id,
             p.match_name,
@@ -46,7 +42,6 @@ pub fn upsert_player(conn: &Connection, p: &Player) -> Result<(), String> {
             attrs_json,
             p.condition,
             p.morale,
-            injury_json,
             p.team_id,
             traits_json,
             p.contract_end,
@@ -131,7 +126,7 @@ pub fn load_all_players(conn: &Connection) -> Result<Vec<Player>, String> {
     let mut stmt = conn
         .prepare(
             "SELECT id, match_name, full_name, date_of_birth, nationality, birth_country, position,
-                    attributes, condition, morale, injury, team_id, traits,
+                    attributes, condition, morale, team_id, traits,
                     contract_end, wage, market_value, stats, career,
                     transfer_listed, loan_listed, transfer_offers, alternate_positions,
                     natural_position, training_focus, morale_core, footedness, weak_foot, fitness,
@@ -181,7 +176,7 @@ pub fn load_players_by_team(conn: &Connection, team_id: &str) -> Result<Vec<Play
     let mut stmt = conn
         .prepare(
             "SELECT id, match_name, full_name, date_of_birth, nationality, birth_country, position,
-                    attributes, condition, morale, injury, team_id, traits,
+                    attributes, condition, morale, team_id, traits,
                     contract_end, wage, market_value, stats, career,
                     transfer_listed, loan_listed, transfer_offers, alternate_positions,
                     natural_position, training_focus, morale_core, footedness, weak_foot, fitness,
@@ -204,26 +199,25 @@ pub fn load_players_by_team(conn: &Connection, team_id: &str) -> Result<Vec<Play
 fn row_to_player(row: &rusqlite::Row) -> rusqlite::Result<Player> {
     let position_str: String = row.get(6)?;
     let attrs_json: String = row.get(7)?;
-    let injury_json: Option<String> = row.get(10)?;
-    let traits_json: String = row.get(12)?;
-    let stats_json: String = row.get(16)?;
-    let career_json: String = row.get(17)?;
-    let offers_json: String = row.get(20)?;
-    let alt_positions_json: String = row.get(21)?;
-    let natural_position_str: String = row.get(22)?;
-    let training_focus_str: Option<String> = row.get(23)?;
-    let morale_core_json: String = row.get(24)?;
-    let _footedness_str: String = row.get(25)?;
-    let _weak_foot: u8 = row.get(26).unwrap_or(2);
-    let fitness: u8 = row.get(27).unwrap_or(75);
-    let potential_base: u8 = row.get(28).unwrap_or(99);
-    let potential_revealed: Option<u8> = row.get(29).unwrap_or(None);
-    let potential_research_started_on: Option<String> = row.get(30).unwrap_or(None);
-    let potential_research_eta_days: Option<u8> = row.get(31).unwrap_or(None);
-    let profile_image_url: Option<String> = row.get(32).unwrap_or(None);
-    let transfer_listed_int: i32 = row.get(18)?;
-    let loan_listed_int: i32 = row.get(19)?;
-    let market_value_i64: i64 = row.get(15)?;
+    let traits_json: String = row.get(11)?;
+    let stats_json: String = row.get(15)?;
+    let career_json: String = row.get(16)?;
+    let offers_json: String = row.get(19)?;
+    let alt_positions_json: String = row.get(20)?;
+    let natural_position_str: String = row.get(21)?;
+    let training_focus_str: Option<String> = row.get(22)?;
+    let morale_core_json: String = row.get(23)?;
+    let _footedness_str: String = row.get(24)?;
+    let _weak_foot: u8 = row.get(25).unwrap_or(2);
+    let fitness: u8 = row.get(26).unwrap_or(75);
+    let potential_base: u8 = row.get(27).unwrap_or(99);
+    let potential_revealed: Option<u8> = row.get(28).unwrap_or(None);
+    let potential_research_started_on: Option<String> = row.get(29).unwrap_or(None);
+    let potential_research_eta_days: Option<u8> = row.get(30).unwrap_or(None);
+    let profile_image_url: Option<String> = row.get(31).unwrap_or(None);
+    let transfer_listed_int: i32 = row.get(17)?;
+    let loan_listed_int: i32 = row.get(18)?;
+    let market_value_i64: i64 = row.get(14)?;
 
     let position = parse_role(&position_str);
     let natural_position = if natural_position_str.is_empty() {
@@ -257,10 +251,9 @@ fn row_to_player(row: &rusqlite::Row) -> rusqlite::Result<Player> {
         condition: row.get(8)?,
         morale: row.get(9)?,
         fitness,
-        injury: injury_json.and_then(|j| serde_json::from_str(&j).ok()),
-        team_id: row.get(11)?,
-        contract_end: row.get(13)?,
-        wage: row.get(14)?,
+        team_id: row.get(10)?,
+        contract_end: row.get(12)?,
+        wage: row.get(13)?,
         market_value: market_value_i64 as u64,
         stats: serde_json::from_str(&stats_json).unwrap_or_default(),
         career: serde_json::from_str(&career_json).unwrap_or_default(),
@@ -283,7 +276,7 @@ fn row_to_player(row: &rusqlite::Row) -> rusqlite::Result<Player> {
 mod tests {
     use super::*;
     use crate::game_database::GameDatabase;
-    use domain::player::{Injury, PlayerIssue, PlayerIssueCategory, PlayerMoraleCore};
+    use domain::player::{PlayerIssue, PlayerIssueCategory, PlayerMoraleCore};
 
     fn test_db() -> GameDatabase {
         GameDatabase::open_in_memory().unwrap()
@@ -419,35 +412,6 @@ mod tests {
         assert_eq!(loaded[0].attributes.mechanics, 68);
         assert_eq!(loaded[0].attributes.teamfighting, 80);
         assert_eq!(loaded[0].attributes.macro_play, 78);
-    }
-
-    #[test]
-    fn test_player_injury_roundtrip() {
-        let db = test_db();
-        let mut player = sample_player("p-001", None);
-        player.injury = Some(Injury {
-            name: "Hamstring".to_string(),
-            days_remaining: 14,
-        });
-
-        upsert_player(db.conn(), &player).unwrap();
-        let loaded = load_all_players(db.conn()).unwrap();
-
-        assert!(loaded[0].injury.is_some());
-        let injury = loaded[0].injury.as_ref().unwrap();
-        assert_eq!(injury.name, "Hamstring");
-        assert_eq!(injury.days_remaining, 14);
-    }
-
-    #[test]
-    fn test_player_no_injury_roundtrip() {
-        let db = test_db();
-        let player = sample_player("p-001", None);
-
-        upsert_player(db.conn(), &player).unwrap();
-        let loaded = load_all_players(db.conn()).unwrap();
-
-        assert!(loaded[0].injury.is_none());
     }
 
     #[test]

--- a/src-tauri/crates/db/src/sql/v055_remove_injury_column.sql
+++ b/src-tauri/crates/db/src/sql/v055_remove_injury_column.sql
@@ -1,0 +1,9 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- V55: Drop injury column from players table
+--
+-- The injury mechanic is a football (OpenFootManager) remnant. LoL esports
+-- has no injuries. The field has already been removed from the domain model
+-- and frontend types. This migration drops the column from the DB.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+ALTER TABLE players DROP COLUMN injury;

--- a/src-tauri/crates/domain/src/player.rs
+++ b/src-tauri/crates/domain/src/player.rs
@@ -40,12 +40,10 @@ pub struct Player {
     #[serde(default = "default_morale")]
     pub morale: u8,    // 0-100
     /// Long-term physical shape (0–100). Determines how fast condition depletes and
-    /// recovers, and modulates injury risk. Changes slowly over weeks.
+    /// recovers. Changes slowly over weeks.
     #[serde(default = "default_fitness")]
     pub fitness: u8,
 
-    #[serde(default, deserialize_with = "deserialize_optional_injury")]
-    pub injury: Option<Injury>,
     pub team_id: Option<String>,
 
     // Traits / flairs derived from attributes
@@ -190,39 +188,6 @@ fn default_market_value() -> u64 {
 
 fn default_potential_base() -> u8 {
     99
-}
-
-/// Custom deserializer for `Option<Injury>` that treats `""` and `null` as `None`.
-fn deserialize_optional_injury<'de, D>(deserializer: D) -> Result<Option<Injury>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    use serde::de::Visitor;
-    struct InjuryOptVisitor;
-    impl<'de> Visitor<'de> for InjuryOptVisitor {
-        type Value = Option<Injury>;
-        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            f.write_str("an Injury object, null, or empty string")
-        }
-        fn visit_none<E: serde::de::Error>(self) -> Result<Option<Injury>, E> {
-            Ok(None)
-        }
-        fn visit_unit<E: serde::de::Error>(self) -> Result<Option<Injury>, E> {
-            Ok(None)
-        }
-        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Option<Injury>, E> {
-            if v.is_empty() { Ok(None) } else { Err(E::custom("expected injury object or null")) }
-        }
-    }
-    deserializer.deserialize_any(InjuryOptVisitor)
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[cfg_attr(feature = "typescript", derive(TS))]
-#[cfg_attr(feature = "typescript", ts(export))]
-pub struct Injury {
-    pub name: String,
-    pub days_remaining: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -632,7 +597,6 @@ impl Player {
             condition: 100,
             morale: 100,
             fitness: 75,
-            injury: None,
             team_id: None,
             traits,
             contract_end: None,
@@ -689,7 +653,6 @@ mod tests {
             "attributes": sample_attributes(),
             "condition": 100,
             "morale": 100,
-            "injury": null,
             "team_id": null,
             "traits": [],
             "contract_end": null,
@@ -725,7 +688,6 @@ mod tests {
             "attributes": sample_attributes(),
             "condition": 100,
             "morale": 100,
-            "injury": null,
             "team_id": null,
             "traits": [],
             "contract_end": null,

--- a/src-tauri/crates/ofm_core/src/generator/world_io.rs
+++ b/src-tauri/crates/ofm_core/src/generator/world_io.rs
@@ -158,7 +158,7 @@ mod tests {
                             "condition": 100,
                             "morale": 100,
                             "fitness": 75,
-                            "injury": null,
+
                             "team_id": "team-1",
                             "traits": [],
                             "contract_end": null,

--- a/src-tauri/crates/ofm_core/src/messages.rs
+++ b/src-tauri/crates/ofm_core/src/messages.rs
@@ -152,7 +152,7 @@ pub fn staff_advice_message(team_name: &str, team_id: &str, date: &str) -> Inbox
         format!(
             "Boss, I've had a look at the staff situation at {} and wanted to flag a few things:\n\n\
             • A good **Coach** will significantly improve training effectiveness — your players will develop faster.\n\
-            • A qualified **Physio** helps with injury prevention and speeds up recovery between matches.\n\
+            • A qualified **Physio** helps speed up recovery between matches and keep players match-fit.\n\
             • Our **Scouts** can help identify transfer targets and assess opponents.\n\n\
             I'd strongly recommend filling any vacancies before the season starts. \
             You can find available staff in the Staff section.\n\n\

--- a/src-tauri/crates/ofm_core/src/random_events/builders_reports.rs
+++ b/src-tauri/crates/ofm_core/src/random_events/builders_reports.rs
@@ -133,7 +133,7 @@ pub(super) fn board_confidence_message(msg_id: &str, date: &str) -> InboxMessage
                 },
                 ActionOption {
                     id: "blame_circumstances".to_string(),
-                    label: "Point to injuries and bad luck".to_string(),
+                    label: "Blame external factors and poor conditions".to_string(),
                     description: "Deflect blame to external factors. May or may not convince them."
                         .to_string(),
                     label_key: Some(

--- a/src-tauri/crates/ofm_core/tests/live_match_manager_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/live_match_manager_tests.rs
@@ -347,42 +347,6 @@ fn auto_select_team_roles_prefers_high_leadership_captain() {
 }
 
 // ---------------------------------------------------------------------------
-// LoL roster should ignore football injuries
-// ---------------------------------------------------------------------------
-
-#[test]
-fn injuries_do_not_reduce_lol_starting_five() {
-    let mut game = make_game_with_fixture();
-    // Injure all players on team1 (football-domain data).
-    // For LoL prototype roster build, this must NOT reduce to <5 players.
-    let team1_players: Vec<String> = game
-        .players
-        .iter()
-        .filter(|p| p.team_id.as_deref() == Some("team1"))
-        .map(|p| p.id.clone())
-        .collect();
-
-    for id in &team1_players {
-        if let Some(p) = game.players.iter_mut().find(|p| p.id == *id) {
-            p.injury = Some(domain::player::Injury {
-                name: "Hamstring".to_string(),
-                days_remaining: 10,
-            });
-        }
-    }
-
-    let session =
-        live_match_manager::create_live_match(&game, 0, MatchMode::Instant, false).unwrap();
-    let snap = session.snapshot();
-
-    assert_eq!(
-        snap.home_team.players.len(),
-        5,
-        "LoL home roster should remain full even if football injuries exist"
-    );
-}
-
-// ---------------------------------------------------------------------------
 // Match modes
 // ---------------------------------------------------------------------------
 

--- a/src-tauri/crates/ofm_core/tests/player_events_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/player_events_tests.rs
@@ -181,35 +181,6 @@ fn normal_morale_no_message() {
 }
 
 #[test]
-fn legacy_injury_field_does_not_suppress_morale_message() {
-    let mut game = make_game();
-    let player = game.players.iter_mut().find(|p| p.id == "p_fwd0").unwrap();
-    player.morale = 20;
-    player.injury = Some(domain::player::Injury {
-        name: "Muscle".to_string(),
-        days_remaining: 5,
-    });
-
-    for _ in 0..100 {
-        player_events::check_player_events(&mut game);
-        if game.messages.iter().any(|m| m.id == "morale_talk_p_fwd0") {
-            break;
-        }
-    }
-
-    let morale_msgs: Vec<_> = game
-        .messages
-        .iter()
-        .filter(|m| m.id == "morale_talk_p_fwd0")
-        .collect();
-    assert_eq!(
-        morale_msgs.len(),
-        1,
-        "Legacy injury fields should not suppress morale talks"
-    );
-}
-
-#[test]
 fn morale_message_not_duplicated() {
     let mut game = make_game();
     game.players

--- a/src-tauri/crates/ofm_core/tests/training_tests.rs
+++ b/src-tauri/crates/ofm_core/tests/training_tests.rs
@@ -315,41 +315,7 @@ fn light_schedule_trains_two_days() {
     assert!(!TrainingSchedule::Light.is_training_day(6));
 }
 
-// ---------------------------------------------------------------------------
-// process_training — legacy injury fields
-// ---------------------------------------------------------------------------
 
-#[test]
-fn legacy_injury_field_does_not_reduce_recovery() {
-    let mut game = make_game();
-    let p1 = game.players.iter_mut().find(|p| p.id == "p1").unwrap();
-    p1.condition = 40;
-    p1.injury = Some(domain::player::Injury {
-        name: "Hamstring".to_string(),
-        days_remaining: 10,
-    });
-
-    let p2 = game.players.iter_mut().find(|p| p.id == "p2").unwrap();
-    p2.condition = 40;
-
-    // Rest day so both recover; legacy injury fields no longer affect training.
-    training::process_training(&mut game, 2);
-
-    let p1_after = game
-        .players
-        .iter()
-        .find(|p| p.id == "p1")
-        .unwrap()
-        .condition;
-    let p2_after = game
-        .players
-        .iter()
-        .find(|p| p.id == "p2")
-        .unwrap()
-        .condition;
-
-    assert_eq!(p1_after, p2_after);
-}
 
 #[test]
 fn higher_medical_facility_level_improves_recovery_on_rest_days() {

--- a/src-tauri/src/commands/time.rs
+++ b/src-tauri/src/commands/time.rs
@@ -179,7 +179,7 @@ mod tests {
     use domain::league::{Fixture, FixtureStatus, MatchType};
     use domain::manager::Manager;
     use domain::message::{InboxMessage, MessagePriority};
-    use domain::player::{Injury, LolRole, Player, PlayerAttributes};
+    use domain::player::{LolRole, Player, PlayerAttributes};
     use domain::stats::StatsState;
     use domain::team::Team;
     use ofm_core::clock::GameClock;
@@ -367,46 +367,6 @@ mod tests {
         let blockers = compute_blocking_actions(&game);
 
         assert!(blockers.is_empty());
-    }
-
-    #[test]
-    fn legacy_injury_fields_do_not_trigger_lineup_blockers() {
-        let mut game = make_game(11);
-        for player_id in ["p2", "p5"] {
-            let player = game
-                .players
-                .iter_mut()
-                .find(|player| player.id == player_id)
-                .unwrap();
-            player.injury = Some(Injury {
-                name: "Hamstring".to_string(),
-                days_remaining: 7,
-            });
-        }
-
-        let blockers = compute_blocking_actions(&game);
-
-        assert!(blocker_by_id(&blockers, "injured_lineup").is_none());
-        assert!(blocker_by_id(&blockers, "incomplete_lineup").is_none());
-    }
-
-    #[test]
-    fn incomplete_lineup_is_not_reported_when_roster_has_fewer_than_eleven_players() {
-        let mut game = make_game(10);
-        let player = game
-            .players
-            .iter_mut()
-            .find(|player| player.id == "p3")
-            .unwrap();
-        player.injury = Some(Injury {
-            name: "Knee".to_string(),
-            days_remaining: 14,
-        });
-
-        let blockers = compute_blocking_actions(&game);
-
-        assert!(blocker_by_id(&blockers, "injured_lineup").is_none());
-        assert!(blocker_by_id(&blockers, "incomplete_lineup").is_none());
     }
 
     #[test]

--- a/src-tauri/src/commands/world.rs
+++ b/src-tauri/src/commands/world.rs
@@ -424,7 +424,6 @@ mod tests {
               "condition": 100,
               "morale": 100,
               "fitness": 75,
-              "injury": null,
               "team_id": "team-1",
               "traits": [],
               "contract_end": null,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -236,7 +236,6 @@
     "expandSidebar": "Expand sidebar",
     "alerts": {
       "exhausted": "{{count}} player(s) in critical condition (<25%)",
-      "injuredStartingXi": "{{count}} injured player(s) in Starting Five — replace them",
       "incompleteStartingXi": "Starting Five incomplete — set your lineup",
       "urgentUnread": "{{count}} urgent message(s) unread",
       "matchTodayStartingXi": "Match today! Set your starting five"

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -326,8 +326,6 @@ export interface PlayerData {
   attributes: PlayerAttributes;
   condition: number;
   morale: number;
-  /** Legacy save compatibility only; no runtime availability behavior uses this field. */
-  injury?: null | { name: string; days_remaining: number };
   team_id: string | null;
   contract_end: string | null;
   wage: number;


### PR DESCRIPTION
## Approved issue

Closes #239

- [x] The linked issue has status:approved.
- [x] This PR targets develop.
- [x] This PR has exactly one 	ype:* label.

## Summary

Removes the football (OpenFootManager) injury system — a dead code remnant that has no place in a League of Legends management sim. No production code creates injuries anymore (neutralized in v0.2.1), but the field still existed across the entire stack.

### Changes (14 files, +43/-249)

**Domain model** (player.rs): Removed Injury struct, injury: Option<Injury> field, and custom deserializer.

**Database** (player_repo.rs, migrations.rs): Removed injury column from all SQL queries, added V55 migration to drop the column.

**Frontend** (	ypes.ts): Removed injury? field from TS Player type.

**i18n** (8 locale files): Removed 30+ injury-related translation keys (injured, injuries, injuredStartingXi, InjuryNews, 	rainingInjury email templates).

**Staff/Events** (messages.rs, uilders_reports.rs): Updated Physio description (no longer references "injury prevention"), replaced "Point to injuries" label.

**Seed data generators** (world.rs, world_io.rs): Removed "injury": null from world generation templates.

**Tests** (4 Rust test files): Removed 6 legacy test functions that verified injuries no longer affect gameplay (Injury struct no longer exists, so these tests would fail to compile).

### Verification

- [x] Injury struct removed from domain crate
- [x] injury field removed from Player (Rust + TS)
- [x] V53 migration drops the column
- [x] 0 injury references remain in production Rust code
- [x] 0 injury references remain in frontend non-test code
- [x] 0 injury i18n keys remain across all 8 locales
- [x] MessageCategory::Injury variant preserved for backward compatibility with old saved messages

## Documentation and provenance

- [x] Documentation was updated or no docs change is needed.
- [x] No provenance change is needed.
- [x] No unclear third-party data, generated cache, secret, signing key, or private credential is included.

## Release impact

- [x] Changelog entry added or not needed.
- [x] No version changes needed.
