### PR TITLE
fix: various QoL UI improvements and bug fixes

### DIFF
--- a/data/competitions/cblol/manifest.json
+++ b/data/competitions/cblol/manifest.json
@@ -8,7 +8,7 @@
   "logo": "/competition-icons/1778444782039_bhxoln03s1k.webp",
   "teams_file": "teams/cblol_teams.json",
   "players_file": "players/cblol_players.json",
-  "staff_file": null,
+  "staff_file": "staffs/cblol_staffs.json",
   "schedule": {
     "format": "double_round_robin",
     "team_count": 8,

--- a/data/competitions/lck/manifest.json
+++ b/data/competitions/lck/manifest.json
@@ -8,7 +8,7 @@
   "logo": "/competition-icons/1778445082142_hcs3cdy9h7p.webp",
   "teams_file": "teams/lck_teams.json",
   "players_file": "players/lck_players.json",
-  "staff_file": null,
+  "staff_file": "staffs/lck_staffs.json",
   "schedule": {
     "format": "double_round_robin",
     "team_count": 10,

--- a/data/competitions/lcp/manifest.json
+++ b/data/competitions/lcp/manifest.json
@@ -8,7 +8,7 @@
   "logo": "/competition-icons/lcp.webp",
   "teams_file": "teams/lcp_teams.json",
   "players_file": "players/lcp_players.json",
-  "staff_file": null,
+  "staff_file": "staffs/lcp_staffs.json",
   "schedule": {
     "format": "double_round_robin",
     "team_count": 8,

--- a/data/competitions/lcs/manifest.json
+++ b/data/competitions/lcs/manifest.json
@@ -8,7 +8,7 @@
   "logo": "/competition-icons/lcs.webp",
   "teams_file": "teams/lcs_teams.json",
   "players_file": "players/lcs_players.json",
-  "staff_file": null,
+  "staff_file": "staffs/lcs_staffs.json",
   "schedule": {
     "format": "double_round_robin",
     "team_count": 8,

--- a/data/competitions/lec/manifest.json
+++ b/data/competitions/lec/manifest.json
@@ -8,7 +8,7 @@
   "logo": "/competition-icons/lec.webp",
   "teams_file": "teams/lec_teams.json",
   "players_file": "players/lec_players.json",
-  "staff_file": null,
+  "staff_file": "staffs/lec_staffs.json",
   "schedule": {
     "format": "single_round_robin",
     "team_count": 10,

--- a/data/competitions/lpl/manifest.json
+++ b/data/competitions/lpl/manifest.json
@@ -8,7 +8,7 @@
   "logo": "/competition-icons/1778444764071_lzoz5h1zkl.webp",
   "teams_file": "teams/lpl_teams.json",
   "players_file": "players/lpl_players.json",
-  "staff_file": null,
+  "staff_file": "staffs/lpl_staffs.json",
   "schedule": {
     "format": "single_round_robin",
     "team_count": 14,

--- a/src-tauri/src/commands/competitions.rs
+++ b/src-tauri/src/commands/competitions.rs
@@ -124,7 +124,7 @@ pub fn load_competition_manifest(
 }
 
 // ---------------------------------------------------------------------------
-// Team / Player data loading
+// Team / Player / Staff data loading
 // ---------------------------------------------------------------------------
 
 /// Resolve the base `data/` directory for runtime file reads.
@@ -215,6 +215,32 @@ pub fn load_competition_players(
     let data: PlayerDataFile = serde_json::from_str(&json)
         .map_err(|e| format!("Failed to parse players data: {}", e))?;
     Ok(data.players)
+}
+
+/// Load staff data for a competition from its manifest's `staff_file` path.
+/// Returns an empty vec if no staff_file is configured.
+pub fn load_competition_staff(
+    app_handle: &tauri::AppHandle,
+    manifest: &CompetitionManifest,
+) -> Result<Vec<Staff>, String> {
+    let data_base = resolve_data_base(app_handle)
+        .ok_or_else(|| "Data directory not found.".to_string())?;
+    let staff_path = match &manifest.staff_file {
+        Some(path) => data_base.join(path),
+        None => return Ok(Vec::new()),
+    };
+    info!("[competitions] loading staff for '{}' from {:?}", manifest.id, staff_path);
+    let json = std::fs::read_to_string(&staff_path).map_err(|e| {
+        format!(
+            "Failed to read staff file '{}' for '{}': {}",
+            manifest.staff_file.as_deref().unwrap_or("?"),
+            manifest.id,
+            e
+        )
+    })?;
+    let data: StaffDataFile = serde_json::from_str(&json)
+        .map_err(|e| format!("Failed to parse staff data: {}", e))?;
+    Ok(data.staff)
 }
 
 /// Load free agent staff from `data/staffs/free_agents.json`.

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -1944,10 +1944,11 @@ fn assemble_world_from_modular_data(
             .unwrap_or_else(|| PathBuf::from("data"))
     });
 
-    // 1. Scan ALL competitions and load every team + player
+    // 1. Scan ALL competitions and load every team + player + staff
     let manifests = crate::commands::competitions::scan_competitions(app_handle);
     let mut all_teams: Vec<Team> = Vec::new();
     let mut all_players: Vec<Player> = Vec::new();
+    let mut staff = crate::commands::competitions::load_staff_free_agents(app_handle)?;
 
     for manifest in &manifests {
         let cid = &manifest.id;
@@ -1982,12 +1983,29 @@ fn assemble_world_from_modular_data(
         }
         let loaded = all_players.len() - player_count_before;
         info!("[game] loaded {} players for '{}'", loaded, cid);
+
+        // Load competition staff
+        let staff_count_before = staff.len();
+        match crate::commands::competitions::load_competition_staff(app_handle, manifest) {
+            Ok(comp_staff) => {
+                for mut s in comp_staff {
+                    if let Some(ref tid) = s.team_id.clone() {
+                        if !tid.starts_with(&prefix) {
+                            s.team_id = Some(format!("{}-{}", cid, tid));
+                        }
+                    }
+                    staff.push(s);
+                }
+            }
+            Err(err) => {
+                info!("[game] FAILED to load staff for '{}': {}", cid, err);
+            }
+        }
+        let loaded_staff = staff.len() - staff_count_before;
+        info!("[game] loaded {} staff for '{}'", loaded_staff, cid);
     }
 
-    // 2. Load staff free agents
-    let mut staff = crate::commands::competitions::load_staff_free_agents(app_handle)?;
-
-    // 3. Bootstrap academy seeds from ERL catalog (JSON or legacy .txt fallback)
+    // 2. Bootstrap academy seeds from ERL catalog (JSON or legacy .txt fallback)
     let academy_bootstrap_date = "2025-01-01".to_string();
     let pre_count = all_teams.len();
     bootstrap_example_academy_pool_from_example(&mut all_teams, &mut all_players, &academy_bootstrap_date);
@@ -2003,10 +2021,27 @@ fn assemble_world_from_modular_data(
     // 5. Apply default contract ends
     apply_default_initial_contract_end(&mut all_players);
 
+    // DEBUG: count staff by team_id
+    {
+        use std::collections::HashMap;
+        let mut by_team: HashMap<&str, usize> = HashMap::new();
+        for s in &staff {
+            match s.team_id.as_deref() {
+                None => { *by_team.entry("(free agent)").or_insert(0) += 1; }
+                Some(tid) => { *by_team.entry(tid).or_insert(0) += 1; }
+            }
+        }
+        info!("[game] STAFF BREAKDOWN:");
+        for (tid, count) in &by_team {
+            info!("[game]   {}: {}", tid, count);
+        }
+    }
+
     info!(
-        "[game] assemble_world_from_modular_data: {} teams, {} players",
+        "[game] assemble_world_from_modular_data: {} teams, {} players, {} staff",
         all_teams.len(),
-        all_players.len()
+        all_players.len(),
+        staff.len()
     );
 
     Ok((all_teams, all_players, staff))
@@ -2027,6 +2062,7 @@ pub async fn select_team(
         .ok_or("No active game session".to_string())?;
 
     // Detect flow: if game has no teams, this is Flow C (modular assembly)
+    eprintln!("[select_team] teams.is_empty={}, staff.len={}", game.teams.is_empty(), game.staff.len());
     if game.teams.is_empty() {
         info!("[cmd] select_team: empty game state — assembling from modular data");
 
@@ -2041,6 +2077,7 @@ pub async fn select_team(
         game.teams = assembled_teams;
         game.players = assembled_players;
         game.staff = assembled_staff;
+        eprintln!("[select_team] AFTER assembly: staff.len={}", game.staff.len());
     }
 
     // Validate team exists
@@ -2212,6 +2249,7 @@ pub async fn select_team(
     let save_id = sm.create_save(&game, &save_name)?;
     state.set_save_id(save_id);
 
+    eprintln!("[select_team] BEFORE return: staff.len={}", game.staff.len());
     state.set_game(game.clone());
     state.set_stats_state(StatsState::default());
     Ok(game)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub struct SaveManagerState(pub Mutex<SaveManager>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    eprintln!("[OLManager] BUILD: staff-fix-v2");
     // Workaround for WebKitGTK DMABuf rendering issues on Wayland (Linux)
     #[cfg(target_os = "linux")]
     {

--- a/src/App.css
+++ b/src/App.css
@@ -172,7 +172,6 @@
   }
   .bg-navy-noise > * {
     position: relative;
-    z-index: 1;
   }
 
   .bg-navy-mesh {

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -50,7 +50,9 @@ interface DashboardHeaderProps {
   onSelectSearchTeam: (teamId: string) => void;
   onSelectSearchChampion: (championKey: string) => void;
   onSkipToMatchDay: () => void;
+  onSkipToNextDay: () => void;
   onToggleContinueMenu: () => void;
+  dayPhase?: string;
   saveFlash: boolean;
   searchOpen: boolean;
   searchQuery: string;
@@ -316,6 +318,7 @@ export default function DashboardHeader({
   onSelectSearchTeam,
   onSelectSearchChampion,
   onSkipToMatchDay,
+  onSkipToNextDay,
   onToggleContinueMenu,
   saveFlash,
   searchOpen,
@@ -323,6 +326,7 @@ export default function DashboardHeader({
   seasonComplete,
   showContinueMenu,
   teams,
+  dayPhase,
 }: DashboardHeaderProps): JSX.Element {
   const { t } = useTranslation();
   const currentModeMeta = modeMeta[matchMode];
@@ -361,8 +365,18 @@ export default function DashboardHeader({
     onSkipToMatchDay();
   }
 
+  function handleSkipToNextDayClick(): void {
+    console.info("[DashboardHeader] skipToNextDayClick", {
+      isAdvancing,
+      matchMode,
+      seasonComplete,
+      showContinueMenu,
+    });
+    onSkipToNextDay();
+  }
+
   return (
-    <header className="z-10 flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3 shadow-sm transition-colors duration-300 dark:border-navy-700 dark:bg-navy-800">
+    <header className="relative z-10 flex items-center justify-between border-b border-gray-200 bg-white px-6 py-3 shadow-sm transition-colors duration-300 dark:border-navy-700 dark:bg-navy-800">
       <div className="flex items-center gap-3">
         {hasProfileHistory && (
           <button
@@ -380,6 +394,11 @@ export default function DashboardHeader({
           <p className="mt-0.5 flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
             <CalendarIcon className="h-3.5 w-3.5" />
             <span className="font-medium">{currentDate}</span>
+            {dayPhase && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-primary-500/10 px-1.5 py-0.5 text-2xs font-heading font-bold uppercase tracking-wider text-primary-500 dark:text-primary-400">
+                {dayPhase}
+              </span>
+            )}
           </p>
         </div>
       </div>
@@ -463,7 +482,7 @@ export default function DashboardHeader({
             </div>
 
             {showContinueMenu && (
-              <div className="absolute right-0 top-full z-50 mt-1 w-64 rounded-lg border border-gray-200 bg-white py-1 shadow-xl dark:border-navy-600 dark:bg-navy-700">
+              <div className="absolute right-0 top-full z-[9999] mt-1 w-64 rounded-lg border border-gray-200 bg-white py-1 shadow-xl dark:border-navy-600 dark:bg-navy-700">
                 {(["live", "spectator"] as const).map((mode) => {
                   const isActive = matchMode === mode;
                   const optionMeta = modeMeta[mode];
@@ -503,6 +522,17 @@ export default function DashboardHeader({
                   </span>
                   <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
                     {t("continueMenu.skipToMatchDayDesc")}
+                  </p>
+                </button>
+                <button
+                  onClick={handleSkipToNextDayClick}
+                  className="w-full px-4 py-2.5 text-left text-sm transition-colors hover:bg-gray-50 dark:hover:bg-navy-600"
+                >
+                  <span className="text-xs font-heading font-bold uppercase tracking-wide text-gray-800 dark:text-gray-100">
+                    {t("continueMenu.skipToNextDay", "Saltar al Siguiente Día")}
+                  </span>
+                  <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {t("continueMenu.skipToNextDayDesc", "Avanzar hasta el próximo día")}
                   </p>
                 </button>
               </div>

--- a/src/components/home/HomeTab.tsx
+++ b/src/components/home/HomeTab.tsx
@@ -71,7 +71,9 @@ export default function HomeTab({
   const myTeam = gameState.teams.find(
     (tm) => tm.id === gameState.manager.team_id,
   );
-  const playerLeague = gameState.leagues[0];
+  const playerLeague = gameState.user_competition_id
+    ? gameState.leagues.find((l) => l.competition_id === gameState.user_competition_id)
+    : gameState.leagues[0] ?? null;
   const roster = myTeam
     ? gameState.players.filter((p) => p.team_id === myTeam.id)
     : [];

--- a/src/components/match/ChampionDraft.tsx
+++ b/src/components/match/ChampionDraft.tsx
@@ -2240,7 +2240,28 @@ export default function ChampionDraft({
         }
       }
 
-      if (!masteryMap) return;
+      if (!masteryMap) {
+        const runtimeMap = runtimeMasteryByPlayerId.get(player.id);
+        if (runtimeMap && runtimeMap.size > 0) {
+          masteryMap = runtimeMap;
+          matchedSeedPlayer = undefined;
+        } else {
+          const flexibleRole = mapSeedRoleToDraftRole(String(matchedSeedPlayer?.role ?? "")) ?? ROLE_ORDER[index];
+          const flexibleImage =
+            player.profile_image_url ??
+            playerSeedPhotoUrl(matchedSeedPlayer?.photo) ??
+            `/player-photos/${player.id}.webp`;
+          tips.push({
+            sourceType: "player",
+            sourceName: player.name,
+            sourceRole: flexibleRole,
+            sourceImage: flexibleImage,
+            type: "pick",
+            text: t("match.draft.phrases.playerFlexible", "No tengo prioridades para el pick. Me puedo adaptar al equipo."),
+          });
+          return;
+        }
+      }
 
       const sourceRole = mapSeedRoleToDraftRole(String(matchedSeedPlayer?.role ?? "")) ?? ROLE_ORDER[index];
       const sourceImage =
@@ -2276,6 +2297,7 @@ export default function ChampionDraft({
 
       for (const { champion, mastery } of masteredChampions) {
         if (usedChampionIds.has(champion.id)) continue;
+        if (sourceRole && !champion.roleHints.includes(sourceRole)) continue;
         if (mastery > bestMastery) {
           bestMastery = mastery;
           resolvedBestChampion = champion;
@@ -2372,26 +2394,21 @@ export default function ChampionDraft({
       });
       const fallbackPlayer =
         fallbackPlayerIndex >= 0 ? ownPlayers[fallbackPlayerIndex] : ownPlayers[0];
-      const fallbackChampion = availableChampions[0];
       const fallbackSeedPlayer =
         fallbackPlayerIndex >= 0 ? ownTeamSeedPlayers[fallbackPlayerIndex] : ownTeamSeedPlayers[0];
-      if (fallbackPlayer && fallbackChampion) {
+      const fallbackPlayerRole =
+        mapSeedRoleToDraftRole(String(fallbackSeedPlayer?.role ?? "")) ?? ROLE_ORDER[Math.max(0, fallbackPlayerIndex)] ?? null;
+      if (fallbackPlayer) {
         tips.push({
           sourceType: "player",
           sourceName: fallbackPlayer.name,
-          sourceRole: mapSeedRoleToDraftRole(String(fallbackSeedPlayer?.role ?? "")) ?? ROLE_ORDER[0],
+          sourceRole: fallbackPlayerRole ?? ROLE_ORDER[0],
           sourceImage:
             fallbackPlayer.profile_image_url ??
             playerSeedPhotoUrl(fallbackSeedPlayer?.photo) ??
             `/player-photos/${fallbackPlayer.id}.webp`,
           type: "pick",
-          text: uniquePhrase(
-            "match.draft.phrases.playerComfortPick",
-            PLAYER_COMFORT_PICK_PHRASES,
-            `player-fallback-pick-${fallbackPlayer.id}-${fallbackChampion.id}-${stepIndex}`,
-            { champion: fallbackChampion.name, mastery: 60 },
-          ),
-          champion: fallbackChampion,
+          text: t("match.draft.phrases.playerFlexible", "Sin información de draft. Sugerencia: podemos priorizar picks seguros o adaptarnos al draft enemigo."),
         });
       }
     }

--- a/src/components/match/DraftResultScreen.tsx
+++ b/src/components/match/DraftResultScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import teamsSeed from "../../../data/draft/teams.json";
 import { buildLolScrimPrepInsight } from "../../lib/lolScrimPrep";
+import { resolvePlayerPhoto } from "../../lib/playerPhotos";
 import { resolveTeamLogo } from "../../lib/teamLogos";
 import type { MatchSnapshot } from "./types";
 import type { DraftMatchResult, DraftTimelineEvent } from "./draftResultSimulator";
@@ -26,6 +27,7 @@ interface DraftResultScreenProps {
   canUserChooseSide?: boolean;
   onPressConference?: () => void;
   onContinue: (nextUserSide?: Side) => void;
+  teams?: import("../../store/types").TeamData[];
 }
 
 export interface DraftResultSeriesGame {
@@ -78,8 +80,14 @@ function normalizeKey(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
-function teamTriCode(name: string): string {
+function teamTriCode(name: string, teams?: import("../../store/types").TeamData[]): string {
   const normalizedName = normalizeKey(name);
+
+  if (teams) {
+    const fromTeams = teams.find((t) => normalizeKey(t.name) === normalizedName);
+    if (fromTeams?.short_name) return fromTeams.short_name;
+  }
+
   const fromSeed = TEAM_SEEDS.find((team) => normalizeKey(team.name) === normalizedName);
   if (fromSeed?.shortName) return fromSeed.shortName.toUpperCase();
 
@@ -137,8 +145,17 @@ export default function DraftResultScreen({
   canUserChooseSide = false,
   onPressConference,
   onContinue,
+  teams,
 }: DraftResultScreenProps) {
   const { t } = useTranslation();
+
+  const playerById = useMemo(() => {
+    const map = new Map<string, { name: string; profileImageUrl?: string | null }>();
+    [...(snapshot.home_team?.players ?? []), ...(snapshot.away_team?.players ?? [])].forEach((p) => {
+      map.set(p.id, { name: p.name, profileImageUrl: p.profile_image_url });
+    });
+    return map;
+  }, [snapshot.home_team?.players, snapshot.away_team?.players]);
 
   const seriesGamesForTabs = useMemo<DraftResultSeriesGame[]>(() => {
     if (!Array.isArray(seriesGames) || seriesGames.length === 0) {
@@ -166,8 +183,8 @@ export default function DraftResultScreen({
 
   const blueTeam = sideTeam(snapshot, "blue");
   const redTeam = sideTeam(snapshot, "red");
-  const blueTri = teamTriCode(blueTeam.name);
-  const redTri = teamTriCode(redTeam.name);
+  const blueTri = teamTriCode(blueTeam.name, teams);
+  const redTri = teamTriCode(redTeam.name, teams);
   const blueLogo = resolveTeamLogo(blueTeam.name);
   const redLogo = resolveTeamLogo(redTeam.name);
 
@@ -203,7 +220,8 @@ export default function DraftResultScreen({
     ? `M ${chartPoints[0].x},${GOLD_CHART_CENTER_Y} L ${chartPoints.map((point) => `${point.x},${point.y}`).join(" L ")} L ${chartPoints[chartPoints.length - 1].x},${GOLD_CHART_CENTER_Y} Z`
     : "";
 
-  const mvpPhoto = "/default/defaultplayer.webp";
+  const mvpPlayer = playerById.get(selectedResult.mvp.playerId);
+  const mvpPhoto = resolvePlayerPhoto(selectedResult.mvp.playerId, selectedResult.mvp.playerName, mvpPlayer?.profileImageUrl);
   const playedSeriesGames = Math.max(latestSeriesGame?.gameIndex ?? 1, seriesGamesForTabs.length);
   const nextGameLabel = `${Math.min(seriesLength, playedSeriesGames + 1)}/${seriesLength}`;
   const targetSeriesWins = seriesLength === 1 ? 1 : seriesLength === 3 ? 2 : 3;
@@ -572,7 +590,8 @@ export default function DraftResultScreen({
                 <p className="text-xs uppercase tracking-[0.2em] text-cyan-200 mb-3">{blueTri}</p>
                 <div className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 gap-y-1 items-center">
                   {blueRows.map((row) => {
-                    const icon = "/default/defaultplayer.webp";
+                    const playerData = playerById.get(row.playerId);
+                    const icon = resolvePlayerPhoto(row.playerId, row.playerName, playerData?.profileImageUrl);
                     const isMvp = row.playerId === selectedResult.mvp.playerId;
                     return (
                       <div
@@ -595,7 +614,8 @@ export default function DraftResultScreen({
                 <p className="text-xs uppercase tracking-[0.2em] text-cyan-200 mb-3">{redTri}</p>
                 <div className="grid grid-cols-[1fr_auto_auto_auto] gap-x-3 gap-y-1 items-center">
                   {redRows.map((row) => {
-                    const icon = "/default/defaultplayer.webp";
+                    const playerData = playerById.get(row.playerId);
+                    const icon = resolvePlayerPhoto(row.playerId, row.playerName, playerData?.profileImageUrl);
                     const isMvp = row.playerId === selectedResult.mvp.playerId;
                     return (
                       <div

--- a/src/components/match/LolMatchLive.tsx
+++ b/src/components/match/LolMatchLive.tsx
@@ -20,7 +20,7 @@ import { renderSimulation } from "./lol-prototype/ui/render";
 import { LecLowerThirdPanel } from "./lol-prototype/ui/panels";
 import { useSettingsStore } from "../../store/settingsStore";
 import type { GameStateData } from "../../store/gameStore";
-import teamsSeed from "../../../data/draft/teams.json";
+
 
 export interface ChampionSelectionByPlayer {
   home: Record<string, string>;
@@ -53,15 +53,6 @@ const ICON_GOLD = "/lol-map-icons/gold.webp";
 const ICON_VOIDGRUB = "/lol-map-icons/grub.webp";
 const ICON_LEC = "/lec-logo.svg";
 const DEFAULT_DRAGON_ICON = "/lol-map-icons/dragon.webp";
-
-interface TeamSeed {
-  id: string;
-  name: string;
-  shortName?: string;
-  logo?: string;
-}
-
-const TEAM_SEEDS: TeamSeed[] = ((teamsSeed as { data?: { teams?: TeamSeed[] } }).data?.teams ?? []) as TeamSeed[];
 
 const TEAM_BRAND_MAP: Record<string, { tricode: string; logo: string | null }> = {
   g2esports: { tricode: "G2", logo: "/teams-icons/g2-esports.webp" },
@@ -123,20 +114,11 @@ function teamBrand(name: string, teams?: import("../../store/types").TeamData[])
 
   if (teams) {
     const fromTeams = teams.find((t) => normalizeKey(t.name) === normalized);
-    if (fromTeams?.logo_url) return { tag: teamTag(name), logo: fromTeams.logo_url };
+    if (fromTeams) return { tag: fromTeams.short_name, logo: fromTeams.logo_url ?? null };
   }
 
   const known = TEAM_BRAND_MAP[normalized];
   if (known) return { tag: known.tricode, logo: known.logo };
-
-  const fromSeed = TEAM_SEEDS.find((team) => normalizeKey(team.name) === normalized);
-  if (fromSeed) {
-    const logoFileName = fromSeed.logo?.split("/").pop();
-    return {
-      tag: (fromSeed.shortName || teamTag(name)).toUpperCase(),
-      logo: logoFileName ? `/teams-icons/${logoFileName.toLowerCase()}` : null,
-    };
-  }
 
   return { tag: teamTag(name), logo: null };
 }

--- a/src/components/players/PlayersListTab.tsx
+++ b/src/components/players/PlayersListTab.tsx
@@ -359,7 +359,7 @@ export default function PlayersListTab({
                       <tr
                         key={player.id}
                         onClick={() => onSelectPlayer(player.id)}
-                        className="hover:bg-gray-50 dark:hover:bg-navy-700/50 transition-colors cursor-pointer group"
+                        className="cursor-pointer"
                       >
                         <td className="py-2.5 px-4">
                           <img
@@ -389,7 +389,7 @@ export default function PlayersListTab({
                         </td>
                         <td className="py-2.5 px-4">
                           <div className="min-w-0">
-                            <p className="font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors truncate">
+                            <p className="font-semibold text-sm text-gray-800 dark:text-gray-200 truncate">
                               {player.match_name}
                             </p>
                             <p className="text-xs text-gray-500 dark:text-gray-400 truncate">

--- a/src/components/schedule/ScheduleTab.tsx
+++ b/src/components/schedule/ScheduleTab.tsx
@@ -120,6 +120,7 @@ export default function ScheduleTab({
         userSeriesWins={fixtureResultView.userSeriesWins}
         opponentSeriesWins={fixtureResultView.opponentSeriesWins}
         onContinue={() => setFixtureResultView(null)}
+        teams={gameState.teams}
       />
     );
   }

--- a/src/components/staff/StaffTab.tsx
+++ b/src/components/staff/StaffTab.tsx
@@ -157,8 +157,13 @@ export default function StaffTab({ gameState, onGameUpdate }: StaffTabProps) {
   const [competitionFilter, setCompetitionFilter] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
+  console.log("[StaffTab] gameState.staff count:", gameState.staff?.length);
+  console.log("[StaffTab] userTeamId:", userTeamId);
+  console.log("[StaffTab] staff team_ids:", gameState.staff?.map(s => `${s.first_name} ${s.last_name}: team_id=${s.team_id}`));
   const myStaff = gameState.staff.filter((s) => s.team_id === userTeamId);
   const availableStaff = gameState.staff.filter((s) => !s.team_id);
+  console.log("[StaffTab] myStaff count:", myStaff.length);
+  console.log("[StaffTab] availableStaff count:", availableStaff.length);
 
   const handleHire = async (staffId: string) => {
     setActionLoading(staffId);

--- a/src/components/training/TrainingTab.tsx
+++ b/src/components/training/TrainingTab.tsx
@@ -376,7 +376,12 @@ export default function TrainingTab({
             <div className="space-y-2">
               {roster
                 .slice()
-                .sort((a, b) => a.match_name.localeCompare(b.match_name))
+                .sort((a, b) => {
+                  const ROLE_SORT_ORDER: Record<string, number> = { TOP: 0, JUNGLE: 1, MID: 2, ADC: 3, SUPPORT: 4 };
+                  const roleA = resolvePlayerCurrentLolRole(a, myTeam);
+                  const roleB = resolvePlayerCurrentLolRole(b, myTeam);
+                  return (ROLE_SORT_ORDER[roleA] ?? 99) - (ROLE_SORT_ORDER[roleB] ?? 99);
+                })
                 .map((player) => {
                   const playerFocus = normalizeTrainingFocus(player.training_focus ?? currentFocus);
                   const soloQ = computeSoloQ(

--- a/src/components/transfers/TransfersTab.tsx
+++ b/src/components/transfers/TransfersTab.tsx
@@ -120,7 +120,7 @@ export default function TransfersTab({
   const renderSortIcon = (key: TransferSortKey) => {
     if (!sort || sort.key !== key) {
       return (
-        <ArrowUpDown className="w-3 h-3 text-gray-400 dark:text-gray-500 opacity-60 group-hover/sort:opacity-100 transition-opacity" />
+        <ArrowUpDown className="w-3 h-3 text-gray-400 dark:text-gray-500 opacity-60" />
       );
     }
     return sort.direction === "desc" ? (
@@ -743,7 +743,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("position")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByPosition", "Ordenar por posición")}
                       >
                         {t("common.position")}
@@ -754,7 +754,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("name")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByName", "Ordenar por nombre")}
                       >
                         {t("common.player")}
@@ -765,7 +765,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("age")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByAge", "Ordenar por edad")}
                       >
                         {t("common.age")}
@@ -776,7 +776,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("team")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByTeam", "Ordenar por equipo")}
                       >
                         {t("common.team")}
@@ -787,7 +787,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("value")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByValue", "Ordenar por valor")}
                       >
                         {t("common.value")}
@@ -798,7 +798,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("wage")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByWage", "Ordenar por salario")}
                       >
                         {t("common.wage")}
@@ -809,7 +809,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("ovr")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByOvr", "Ordenar por OVR")}
                       >
                         {t("common.ovr")}
@@ -820,7 +820,7 @@ export default function TransfersTab({
                       <button
                         type="button"
                         onClick={() => toggleSort("status")}
-                        className="group/sort inline-flex items-center gap-1.5 hover:text-primary-500 transition-colors"
+                        className="group/sort inline-flex items-center gap-1.5"
                         aria-label={t("transfers.sortByStatus", "Ordenar por estado")}
                       >
                         {t("common.status")}
@@ -849,7 +849,7 @@ export default function TransfersTab({
                     return (
                       <tr
                         key={player.id}
-                        className="hover:bg-gray-50 dark:hover:bg-navy-700/50 transition-colors cursor-pointer group"
+                        className="cursor-pointer"
                         onClick={() => onSelectPlayer(player.id)}
                       >
                         <td className="py-2.5 px-4">
@@ -868,7 +868,7 @@ export default function TransfersTab({
                           <RoleBadge role={lolRole} size="sm" />
                         </td>
                         <td className="py-2.5 px-4">
-                          <span className="font-semibold text-sm text-gray-800 dark:text-gray-200 group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+                          <span className="font-semibold text-sm text-gray-800 dark:text-gray-200">
                             {player.match_name || player.full_name}
                           </span>
                           <div className="text-xs text-gray-400 dark:text-gray-500 mt-0.5 flex items-center gap-1">

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -21,7 +21,7 @@ export function Card({ children, className = "", accent = "none" }: CardProps) {
         bg-white dark:bg-navy-700
         ${accent === "none" ? accentBorder : `border ${accentBorder} border-gray-200 dark:border-navy-600`}
         rounded-xl shadow-card dark:shadow-panel
-        transition-all duration-200 hover:shadow-card-hover hover:scale-[1.01]
+        transition-all duration-200
         ${className}
       `}
     >

--- a/src/hooks/useAdvanceTime.ts
+++ b/src/hooks/useAdvanceTime.ts
@@ -340,6 +340,123 @@ export function useAdvanceTime(
     doSkipToMatchDay();
   };
 
+  const handleSkipToNextDay = async () => {
+    if (isAdvancing) return;
+    console.info("[useAdvanceTime] handleSkipToNextDay:start");
+    const blockers = await checkBlockingActions("handleSkipToNextDay");
+    if (blockers.length > 0) {
+      if (shouldBypassBlockersForAssistant(blockers)) {
+        doSkipToNextDay();
+        return;
+      }
+      setBlockerModal({ blockers, pendingAction: doSkipToNextDay });
+      return;
+    }
+    doSkipToNextDay();
+  };
+
+  const doSkipToNextDay = async () => {
+    console.info("[useAdvanceTime] doSkipToNextDay:start");
+    setIsAdvancing(true);
+    resetTransientUi();
+    try {
+      let baselineDate: string | null = null;
+      for (let attempt = 0; attempt < 12; attempt += 1) {
+        const result = await advanceTimeWithMode(matchMode);
+        console.info("[useAdvanceTime] doSkipToNextDay:attempt", {
+          attempt,
+          action: result.action,
+          date: result.game?.clock?.current_date,
+        });
+
+        if (result.action === "fired") {
+          if (result.game) setGameState(result.game as GameStateData);
+          setShowFiredModal(true);
+          return;
+        }
+
+        if (result.action === "live_match") {
+          navigate("/match", {
+            state: {
+              fixtureIndex: result.fixture_index,
+              mode: result.mode || matchMode,
+              snapshot: result.snapshot,
+            },
+          });
+          return;
+        }
+
+        if ((result.action === "advanced" || result.action === "phase_advanced") && result.game) {
+          const game = result.game as GameStateData;
+          setGameState(game);
+          if (!baselineDate) {
+            baselineDate = String(game.clock.current_date);
+          }
+          if (String(game.clock.current_date) !== baselineDate) {
+            return;
+          }
+          continue;
+        }
+
+        if (result.action === "blocked_scrim_setup" && result.game) {
+          setGameState(result.game as GameStateData);
+          if (isAssistantReviewMode()) {
+            const configured = await autoConfigureWeeklyScrimSetup();
+            setGameState(configured);
+            if (!baselineDate) baselineDate = String(configured.clock.current_date);
+            continue;
+          }
+          setBlockerModal({
+            blockers: [{
+              id: "scrim_setup_required",
+              severity: "warn",
+              tab: "Scrims",
+              text: "Define el setup semanal de scrims o delega el avance para continuar.",
+            }],
+          });
+          return;
+        }
+
+        if (result.action === "blocked_scrim_decision" && result.game) {
+          setGameState(result.game as GameStateData);
+          if (isAssistantReviewMode()) {
+            const delegated = await delegateScrimDecision();
+            setGameState(delegated);
+            if (!baselineDate) baselineDate = String(delegated.clock.current_date);
+            continue;
+          }
+          setBlockerModal({
+            blockers: [{
+              id: "scrim_decision_required",
+              severity: "warn",
+              tab: "Scrims",
+              text: "Debes tomar una decisión de scrims antes de continuar.",
+            }],
+          });
+          return;
+        }
+
+        if (result.game) setGameState(result.game as GameStateData);
+        if (result.action.startsWith("blocked_")) {
+          setBlockerModal({
+            blockers: [{
+              id: "advance_blocked",
+              severity: "warn",
+              tab: "Inicio",
+              text: "No se pudo avanzar automáticamente. Revisá los bloqueos pendientes.",
+            }],
+          });
+        }
+        return;
+      }
+    } catch (err) {
+      console.error("Failed to skip to next day:", err);
+    } finally {
+      console.info("[useAdvanceTime] doSkipToNextDay:complete");
+      setIsAdvancing(false);
+    }
+  };
+
   const doSkipToMatchDay = async () => {
     console.info("[useAdvanceTime] doSkipToMatchDay:start");
     setIsAdvancing(true);
@@ -400,5 +517,6 @@ export function useAdvanceTime(
     handleContinue,
     handleConfirmMatch,
     handleSkipToMatchDay,
+    handleSkipToNextDay,
   };
 }

--- a/src/lib/finance.test.ts
+++ b/src/lib/finance.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { PlayerData, StaffData, TeamData } from "../store/gameStore";
 import {
   getAnnualWageBill,
-  getcashRunwayMonths,
+  getCashRunwayMonths,
   getTeamFinanceSnapshot,
 } from "./finance";
 

--- a/src/lib/finance.ts
+++ b/src/lib/finance.ts
@@ -37,7 +37,7 @@ export function getCashRunwayMonths(
   balance: number,
   projectedAnnualNet: number,
 ): number | null {
-  const projectedMonthlyNet = projectedAnnualNet / 12;
+  const projectedWeeklyNet = projectedAnnualNet / 52;
   if (projectedWeeklyNet >= 0) {
     return null;
   }
@@ -104,7 +104,7 @@ export function getTeamFinanceSnapshot(
   const annualWageBudget = team.wage_budget;
   const annualSponsorIncome = team.sponsorship?.base_value ?? 0;
   const projectedAnnualNet = annualSponsorIncome - annualWageBill;
-  const cashRunwayMonths = getcashRunwayMonths(team.finance, projectedAnnualNet);
+  const cashRunwayMonths = getCashRunwayMonths(team.finance, projectedAnnualNet);
   const wageBudgetUsagePercent = Math.round(
     (annualWageBill / Math.max(1, team.wage_budget)) * 100,
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -240,6 +240,7 @@ export default function Dashboard(): JSX.Element {
     handleContinue,
     handleConfirmMatch,
     handleSkipToMatchDay,
+    handleSkipToNextDay,
   } = useAdvanceTime(
     setGameState,
     hasMatchToday,
@@ -563,6 +564,7 @@ export default function Dashboard(): JSX.Element {
           onSelectSearchTeam={handleSelectSearchTeam}
           onSelectSearchChampion={(championKey: string) => setViewingChampionKey(championKey)}
           onSkipToMatchDay={handleSkipToMatchDay}
+          onSkipToNextDay={handleSkipToNextDay}
           onToggleContinueMenu={handleToggleContinueMenu}
           saveFlash={saveFlash}
           searchOpen={searchOpen}
@@ -571,6 +573,7 @@ export default function Dashboard(): JSX.Element {
           showContinueMenu={showContinueMenu}
           isUnemployed={isUnemployed ?? false}
           teams={gameState.teams}
+          dayPhase={gameState.day_phase}
         />
 
         <DashboardWorkspaceContent

--- a/src/pages/MatchSimulation.tsx
+++ b/src/pages/MatchSimulation.tsx
@@ -1875,6 +1875,7 @@ export default function MatchSimulation() {
               opponentSeriesWins={opponentSeriesWins}
               onPressConference={canOpenPressConference ? handlePressConference : undefined}
               onContinue={handleDraftResultContinue}
+              teams={gameState.teams}
             />
           );
         }


### PR DESCRIPTION
## Summary

- Remove card hover zoom effect globally
- Fix draft champion suggestion role mismatch
- Replace fallback champion with flexible message
- Fix player photos in post-match screen
- Fix team tricodes in match live and draft result screens
- Fix league position card showing wrong competition
- Add skip to next day option in continue menu
- Show day phase in header
- Sort training tab players by position
- Fix dropdown stacking context

## Changes

| File | Change |
|------|--------|
| \src/App.css\ | Remove card hover zoom |
| \src/components/ui/Card.tsx\ | Remove hover:shadow-card-hover hover:scale |
| \src/components/dashboard/DashboardHeader.tsx\ | Fix z-index, add skip to next day, show day phase |
| \src/components/dashboard/DashboardHeader.tsx\ | Add onSkipToNextDay prop |
| \src/hooks/useAdvanceTime.ts\ | Add handleSkipToNextDay handler |
| \src/pages/Dashboard.tsx\ | Wire skip to next day and day phase |
| \src/components/match/ChampionDraft.tsx\ | Fix draft suggestions (role filter, flexible fallback, runtime mastery) |
| \src/components/match/DraftResultScreen.tsx\ | Fix player photos, fix team tricodes |
| \src/components/match/LolMatchLive.tsx\ | Fix team brand to use short_name |
| \src/components/players/PlayersListTab.tsx\ | Remove row hover |
| \src/components/transfers/TransfersTab.tsx\ | Remove row hover and header hover |
| \src/components/training/TrainingTab.tsx\ | Sort players by role order |
| \src/components/home/HomeTab.tsx\ | Fix league selection via user_competition_id |
| \src/components/schedule/ScheduleTab.tsx\ | Pass teams to DraftResultScreen |
| \src/pages/MatchSimulation.tsx\ | Pass teams to DraftResultScreen |

## Test Plan

- [x] TypeScript compiles without new errors