### PR TITLE
fix(data): auto-import missing game data

### DIFF
--- a/src-tauri/src/commands/competitions.rs
+++ b/src-tauri/src/commands/competitions.rs
@@ -57,6 +57,12 @@ pub fn resolve_data_base(app_handle: &tauri::AppHandle) -> Option<PathBuf> {
     let cwd = std::env::current_dir().ok()?;
 
     let candidates: Vec<Option<PathBuf>> = vec![
+        // Imported OLMDBManager data (writable app-data dir) takes precedence.
+        app_handle
+            .path()
+            .app_data_dir()
+            .ok()
+            .map(|dir| dir.join("data")),
         app_handle
             .path()
             .resource_dir()
@@ -147,5 +153,4 @@ pub fn get_league_selection_data(
         .ok_or_else(|| "Data directory not found.".to_string())?;
     Ok(competitions::build_league_selection(&data_base))
 }
-
 

--- a/src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.test.ts
+++ b/src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.test.ts
@@ -1,0 +1,138 @@
+import { invoke } from "@tauri-apps/api/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { autoImportDatabase } from "@/lib/dataImport";
+import { loadLeagueSelectionData } from "@/ui-v2/_legacy/components/teamSelection/teamSelection.helpers";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/lib/dataImport", () => ({
+  autoImportDatabase: vi.fn(),
+}));
+
+const mockedInvoke = vi.mocked(invoke);
+const mockedAutoImportDatabase = vi.mocked(autoImportDatabase);
+
+describe("teamSelection.helpers", () => {
+  beforeEach(() => {
+    mockedInvoke.mockReset();
+    mockedAutoImportDatabase.mockReset();
+  });
+
+  it("returns existing league selection data without auto-importing", async () => {
+    const data = {
+      competitions: [
+        {
+          id: "lec",
+          name: "LEC",
+          region: "Europe",
+          logo: null,
+          tier: 1,
+          team_count: 1,
+          teams: [
+            {
+              id: "g2",
+              name: "G2 Esports",
+              short_name: "G2",
+              logo_url: null,
+              country: "Germany",
+              ovr: 80,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockedInvoke.mockResolvedValue(data);
+
+    await expect(loadLeagueSelectionData()).resolves.toBe(data);
+    expect(mockedAutoImportDatabase).not.toHaveBeenCalled();
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-imports missing league data once and retries loading", async () => {
+    const emptyData = { competitions: [] };
+    const importedData = {
+      competitions: [
+        {
+          id: "lck",
+          name: "LCK",
+          region: "Korea",
+          logo: null,
+          tier: 1,
+          team_count: 1,
+          teams: [
+            {
+              id: "t1",
+              name: "T1",
+              short_name: "T1",
+              logo_url: null,
+              country: "South Korea",
+              ovr: 85,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockedInvoke.mockResolvedValueOnce(emptyData).mockResolvedValueOnce(importedData);
+    mockedAutoImportDatabase.mockResolvedValue({
+      data_files: 4,
+      photo_files: 0,
+      player_count: 10,
+      team_count: 1,
+      staff_count: 0,
+      skipped: 0,
+    });
+
+    await expect(loadLeagueSelectionData()).resolves.toBe(importedData);
+    expect(mockedAutoImportDatabase).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows a later auto-import retry after a failed import", async () => {
+    const emptyData = { competitions: [] };
+    const importedData = {
+      competitions: [
+        {
+          id: "lec",
+          name: "LEC",
+          region: "Europe",
+          logo: null,
+          tier: 1,
+          team_count: 1,
+          teams: [
+            {
+              id: "g2",
+              name: "G2 Esports",
+              short_name: "G2",
+              logo_url: null,
+              country: "Germany",
+              ovr: 80,
+            },
+          ],
+        },
+      ],
+    };
+
+    mockedInvoke.mockResolvedValueOnce(emptyData);
+    mockedAutoImportDatabase.mockRejectedValueOnce(new Error("offline"));
+
+    await expect(loadLeagueSelectionData()).rejects.toThrow("offline");
+
+    mockedInvoke.mockResolvedValueOnce(emptyData).mockResolvedValueOnce(importedData);
+    mockedAutoImportDatabase.mockResolvedValueOnce({
+      data_files: 4,
+      photo_files: 0,
+      player_count: 10,
+      team_count: 1,
+      staff_count: 0,
+      skipped: 0,
+    });
+
+    await expect(loadLeagueSelectionData()).resolves.toBe(importedData);
+    expect(mockedAutoImportDatabase).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.ts
+++ b/src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.ts
@@ -1,5 +1,23 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { LeagueSelectionData, GameStateData } from "@/store/gameStore";
+import { autoImportDatabase } from "@/lib/dataImport";
+
+let autoImportAttempt: Promise<void> | null = null;
+
+function hasSelectableLeagueData(data: LeagueSelectionData): boolean {
+  return data.competitions.some((competition) => competition.teams.length > 0);
+}
+
+function ensureAutoImportAttempted(): Promise<void> {
+  if (!autoImportAttempt) {
+    autoImportAttempt = autoImportDatabase()
+      .then(() => undefined)
+      .finally(() => {
+        autoImportAttempt = null;
+      });
+  }
+  return autoImportAttempt;
+}
 
 export function formatFinance(val: number): string {
   if (val >= 1_000_000) return `€${(val / 1_000_000).toFixed(1)}M`;
@@ -23,6 +41,12 @@ export function getTeamLogoPath(teamId: string, logoUrl?: string | null): string
 }
 
 export async function loadLeagueSelectionData(): Promise<LeagueSelectionData> {
+  const data = await invoke<LeagueSelectionData>("get_league_selection_data");
+  if (hasSelectableLeagueData(data)) {
+    return data;
+  }
+
+  await ensureAutoImportAttempted();
   return invoke<LeagueSelectionData>("get_league_selection_data");
 }
 


### PR DESCRIPTION
Closes #296

## Type
- [x] Bug fix

## Summary
- Prefer imported app-data catalog files when resolving competition runtime data.
- Auto-import OLMDBManager data when league selection loads without selectable teams, then retry loading.
- Keep Settings import as the manual fallback and cover retry behavior with tests.
- Set English as the default game language for first launch and fallback translations.

## Changes
| File | Change |
|------|--------|
| `src-tauri/src/commands/competitions.rs` | Prefer `<app_data>/data` before bundled/dev data for runtime file loaders. |
| `src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.ts` | Adds missing-data auto-import fallback with in-flight dedupe and retry-safe cleanup. |
| `src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.test.ts` | Adds coverage for existing data, auto-import retry, and retry after failed import. |
| `src/i18n/index.ts` | Uses English as the initial and fallback i18n language. |
| `src/store/settingsStore.ts` | Uses English for default frontend settings. |
| `src-tauri/src/commands/settings.rs` | Uses English for default native settings. |

## Test Plan
- [x] `npm test -- src/ui-v2/_legacy/components/teamSelection/teamSelection.helpers.test.ts`
- [x] `npm test -- src/store/settingsStore.test.ts`
- [x] `npx tsc --noEmit`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` (passes with existing unrelated `private_interfaces` warning)
- [x] No shell scripts modified; shellcheck not applicable.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran relevant verification.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.