### PR TITLE
fix(settings): default language to English

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -25,7 +25,7 @@ pub struct AppSettings {
 }
 
 fn default_language() -> String {
-    "es".to_string()
+    "en".to_string()
 }
 fn default_ui_scale() -> String {
     "normal".to_string()
@@ -41,7 +41,7 @@ impl Default for AppSettings {
     fn default() -> Self {
         Self {
             theme: "dark".to_string(),
-            language: "es".to_string(),
+            language: "en".to_string(),
             currency: "EUR".to_string(),
             default_match_mode: "live".to_string(),
             auto_save: true,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -30,8 +30,8 @@ i18n.use(initReactI18next).init({
     "pt-BR": { translation: ptBR },
     tr: { translation: tr },
   },
-  lng: "es",
-  fallbackLng: "es",
+  lng: "en",
+  fallbackLng: "en",
   interpolation: {
     escapeValue: false, // React already escapes
   },

--- a/src/store/settingsStore.test.ts
+++ b/src/store/settingsStore.test.ts
@@ -8,7 +8,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 
 const DEFAULT_SETTINGS = {
   theme: "dark",
-  language: "es",
+  language: "en",
   currency: "EUR",
   default_match_mode: "live",
   scrim_review_mode: "manual",
@@ -41,7 +41,7 @@ describe("useSettingsStore", () => {
 
   it("loads settings from the backend and merges missing fields with defaults", async () => {
     vi.mocked(invoke).mockResolvedValue({
-      language: "es",
+      language: "en",
       confirm_advance: true,
     });
 
@@ -51,7 +51,7 @@ describe("useSettingsStore", () => {
     expect(useSettingsStore.getState().loaded).toBe(true);
     expect(useSettingsStore.getState().settings).toEqual({
       ...DEFAULT_SETTINGS,
-      language: "es",
+      language: "en",
       confirm_advance: true,
     });
   });

--- a/src/store/settingsStore.ts
+++ b/src/store/settingsStore.ts
@@ -20,7 +20,7 @@ export interface AppSettings {
 
 const DEFAULT_SETTINGS: AppSettings = {
   theme: "dark",
-  language: "es",
+  language: "en",
   currency: "EUR",
   default_match_mode: "live",
   scrim_review_mode: "manual",


### PR DESCRIPTION
Closes #298

## Type
- [x] Bug fix

## Summary
- Set English as the initial and fallback i18n language.
- Set English as the default frontend settings language.
- Set English as the default native Tauri settings language for first launch/no settings file.

## Changes
| File | Change |
|------|--------|
| `src/i18n/index.ts` | Uses `en` for initial and fallback language. |
| `src/store/settingsStore.ts` | Uses `en` in default frontend settings. |
| `src/store/settingsStore.test.ts` | Updates settings defaults expectations. |
| `src-tauri/src/commands/settings.rs` | Uses `en` in native settings defaults/deserialization fallback. |

## Test Plan
- [x] `npm test -- src/store/settingsStore.test.ts`
- [x] `npx tsc --noEmit`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` (passes with existing unrelated `private_interfaces` warning)
- [x] No shell scripts modified; shellcheck not applicable.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran relevant verification.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.