### PR TITLE
feat(economy): implement stronger ledger, mail hooks, v2 UI, and dynamic simulation

### DIFF
--- a/src-tauri/crates/olm_core/src/academy.rs
+++ b/src-tauri/crates/olm_core/src/academy.rs
@@ -708,8 +708,11 @@ pub fn acquire_academy(
             kind: FinancialTransactionKind::AcademyAcquisition,
             budget_impact: BudgetImpact::None,
             affects_season_totals: true,
+            source: "academy".to_string(),
+            source_id: Some(source_team_id.to_string()),
+            correlation_id: Some(format!("academy-acquisition:{parent_team_id}:{source_team_id}")),
         },
-    );
+    ).map_err(|err| format!("Failed to record academy acquisition: {err:?}"))?;
     game.teams[pidx].academy_team_id = Some(source_team_id.to_string());
 
     if let Some(idx) = game.teams.iter().position(|t| t.id == source_team_id && t.team_kind == TeamKind::Academy) {

--- a/src-tauri/crates/olm_core/src/club.rs
+++ b/src-tauri/crates/olm_core/src/club.rs
@@ -55,7 +55,7 @@ pub fn next_main_hub_expansion_cost(team: &Team) -> i64 {
     i64::from(team.facilities.as_main_facility_hub().level) * BASE_MAIN_HUB_EXPANSION_COST
 }
 
-pub fn expand_main_facility_hub(team: &mut Team) -> Result<i64, String> {
+pub fn expand_main_facility_hub(team: &mut Team, date: &str) -> Result<i64, String> {
     let cost = next_main_hub_expansion_cost(team);
     if team.finance < cost {
         return Err(format!(
@@ -67,14 +67,17 @@ pub fn expand_main_facility_hub(team: &mut Team) -> Result<i64, String> {
     record_transaction(
         team,
         FinanceTransactionInput {
-            date: String::new(),
+            date: date.to_string(),
             description: "Main facility hub expansion".to_string(),
             amount: -cost,
             kind: FinancialTransactionKind::FacilityUpgrade,
             budget_impact: BudgetImpact::None,
             affects_season_totals: true,
+            source: "facility".to_string(),
+            source_id: Some("main-hub".to_string()),
+            correlation_id: Some(format!("facility:{}:{date}:main-hub", team.id)),
         },
-    );
+    ).map_err(|err| format!("Failed to record facility expansion: {err:?}"))?;
     team.facilities.main_hub_level = team
         .facilities
         .as_main_facility_hub()
@@ -87,6 +90,7 @@ pub fn expand_main_facility_hub(team: &mut Team) -> Result<i64, String> {
 pub fn upgrade_main_facility_module(
     team: &mut Team,
     module: MainFacilityModuleKind,
+    date: &str,
 ) -> Result<i64, String> {
     if !team.facilities.can_upgrade_main_facility_module(module) {
         return Err("Main facility hub must be expanded before upgrading this module".to_string());
@@ -104,14 +108,17 @@ pub fn upgrade_main_facility_module(
     record_transaction(
         team,
         FinanceTransactionInput {
-            date: String::new(),
+            date: date.to_string(),
             description: format!("Facility module upgrade: {module:?}"),
             amount: -cost,
             kind: FinancialTransactionKind::FacilityUpgrade,
             budget_impact: BudgetImpact::None,
             affects_season_totals: true,
+            source: "facility".to_string(),
+            source_id: Some(format!("{module:?}")),
+            correlation_id: Some(format!("facility:{}:{date}:{module:?}", team.id)),
         },
-    );
+    ).map_err(|err| format!("Failed to record facility module upgrade: {err:?}"))?;
     set_module_level(
         &mut team.facilities,
         module,
@@ -121,7 +128,7 @@ pub fn upgrade_main_facility_module(
     Ok(cost)
 }
 
-pub fn upgrade_facility(team: &mut Team, facility_type: FacilityType) -> Result<i64, String> {
+pub fn upgrade_facility(team: &mut Team, facility_type: FacilityType, date: &str) -> Result<i64, String> {
     let cost = next_upgrade_cost(team, &facility_type);
     if team.finance < cost {
         return Err(format!(
@@ -139,14 +146,17 @@ pub fn upgrade_facility(team: &mut Team, facility_type: FacilityType) -> Result<
     record_transaction(
         team,
         FinanceTransactionInput {
-            date: String::new(),
+            date: date.to_string(),
             description: format!("Facility upgrade: {facility_type:?}"),
             amount: -cost,
             kind: FinancialTransactionKind::FacilityUpgrade,
             budget_impact: BudgetImpact::None,
             affects_season_totals: true,
+            source: "facility".to_string(),
+            source_id: Some(format!("{facility_type:?}")),
+            correlation_id: Some(format!("facility:{}:{date}:{facility_type:?}", team.id)),
         },
-    );
+    ).map_err(|err| format!("Failed to record facility upgrade: {err:?}"))?;
 
     match facility_type {
         FacilityType::Training => {

--- a/src-tauri/crates/olm_core/src/domain/team.rs
+++ b/src-tauri/crates/olm_core/src/domain/team.rs
@@ -781,11 +781,27 @@ impl Default for FinancialTransactionKind {
 #[cfg_attr(feature = "typescript", derive(TS))]
 #[cfg_attr(feature = "typescript", ts(export))]
 pub struct FinancialTransaction {
+    #[serde(default)]
+    pub id: String,
     pub date: String,
     pub description: String,
     pub amount: i64,
     #[serde(default)]
     pub kind: FinancialTransactionKind,
+    #[serde(default)]
+    pub balance_before: i64,
+    #[serde(default)]
+    pub balance_after: i64,
+    #[serde(default = "default_financial_transaction_source")]
+    pub source: String,
+    #[serde(default)]
+    pub source_id: Option<String>,
+    #[serde(default)]
+    pub correlation_id: Option<String>,
+}
+
+fn default_financial_transaction_source() -> String {
+    "legacy".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/src-tauri/crates/olm_core/src/end_of_season.rs
+++ b/src-tauri/crates/olm_core/src/end_of_season.rs
@@ -1,17 +1,20 @@
-use crate::game::Game;
-use crate::finances::{record_transaction, BudgetImpact, FinanceTransactionInput};
-use crate::generator::definitions::ScheduleConfig;
-use crate::schedule::{
-    LecSplit, append_fixtures, generate_preseason_friendlies,
-    generate_schedule_from_config, generate_single_round_league_with_offsets_and_bo_with_id,
-    parse_lec_split, regular_best_of,
-};
-use crate::season_awards::compute_season_awards;
-use chrono::{Datelike, TimeZone, Utc};
-use crate::domain::league::{MatchType, FixtureStatus, League};
+use crate::domain::league::{FixtureStatus, League, MatchType};
 use crate::domain::message::*;
 use crate::domain::player::PlayerSeasonStats;
 use crate::domain::team::{FinancialTransactionKind, TeamSeasonRecord};
+use crate::finances::{
+    push_board_financial_health_mail, push_prize_payout_mail, record_transaction, BudgetImpact,
+    FinanceTransactionInput,
+};
+use crate::game::Game;
+use crate::generator::definitions::ScheduleConfig;
+use crate::schedule::{
+    append_fixtures, generate_preseason_friendlies, generate_schedule_from_config,
+    generate_single_round_league_with_offsets_and_bo_with_id, parse_lec_split, regular_best_of,
+    LecSplit,
+};
+use crate::season_awards::compute_season_awards;
+use chrono::{Datelike, TimeZone, Utc};
 use std::collections::HashMap;
 
 pub fn expected_fixture_count(team_count: usize) -> Option<usize> {
@@ -164,10 +167,7 @@ pub fn process_end_of_season_with_config(
 /// Records team history for completed bg leagues and generates next season via
 /// the competition manifest's ScheduleConfig (looked up by competition_id).
 /// Skips bg leagues that are not complete, or have no competition_id.
-pub fn process_background_seasons(
-    game: &mut Game,
-    configs: &HashMap<String, ScheduleConfig>,
-) {
+pub fn process_background_seasons(game: &mut Game, configs: &HashMap<String, ScheduleConfig>) {
     // First pass: identify complete bg leagues (avoiding borrow conflicts)
     let complete_indices: Vec<usize> = (1..game.leagues.len())
         .filter(|i| is_league_complete(&game.leagues[*i]))
@@ -230,7 +230,11 @@ fn process_end_of_season_inner(
         None => return EndOfSeasonSummary::default(),
     };
 
-    let league_id = league.competition_id.as_deref().unwrap_or(&league.id).to_string();
+    let league_id = league
+        .competition_id
+        .as_deref()
+        .unwrap_or(&league.id)
+        .to_string();
     let season = league.season;
     let league_name = league.name.clone();
     let today = game.clock.current_date.format("%Y-%m-%d").to_string();
@@ -360,8 +364,12 @@ fn process_end_of_season_inner(
                         kind: FinancialTransactionKind::PrizeMoney,
                         budget_impact: BudgetImpact::None,
                         affects_season_totals: true,
+                        source: "prize".to_string(),
+                        source_id: Some(format!("season-{season}-position-{position}")),
+                        correlation_id: Some(format!("prize:{}:{}:{}", team.id, season, position)),
                     },
-                );
+                )
+                .ok();
             }
 
             refresh_hiring_cycle_budgets(team);
@@ -512,7 +520,9 @@ fn process_end_of_season_inner(
                     next_season_num as i32,
                     split.season_start.month,
                     split.season_start.day,
-                    0, 0, 0,
+                    0,
+                    0,
+                    0,
                 )
                 .unwrap();
             let friendlies = generate_preseason_friendlies(
@@ -682,6 +692,33 @@ fn process_end_of_season_inner(
         .with_sender_i18n("be.sender.boardOfDirectors", "be.role.chairman");
         game.messages.push(payout_message);
     }
+    if user_prize_money > 0 && !user_team_id.is_empty() {
+        push_prize_payout_mail(
+            game,
+            &user_team_id,
+            season,
+            user_position,
+            user_prize_money,
+            &last_fixture_date,
+        );
+    }
+
+    if let Some(user_team) = game.teams.iter().find(|team| team.id == user_team_id) {
+        let monthly_net = (user_team.season_income - user_team.season_expenses) / 12;
+        let months_left = if monthly_net < 0 {
+            Some((user_team.finance / monthly_net.abs()).max(0))
+        } else {
+            None
+        };
+        push_board_financial_health_mail(
+            game,
+            &user_team_id,
+            user_team.finance,
+            monthly_net,
+            months_left,
+            &last_fixture_date,
+        );
+    }
 
     let msg_id = format!("season_end_{}", season);
     if !existing_ids.contains(&msg_id) {
@@ -787,7 +824,10 @@ pub struct EndOfSeasonSummary {
     pub total_teams: u32,
 }
 
-fn contract_days_remaining(contract_end: Option<&str>, current_date: chrono::NaiveDate) -> Option<i64> {
+fn contract_days_remaining(
+    contract_end: Option<&str>,
+    current_date: chrono::NaiveDate,
+) -> Option<i64> {
     let end_str = contract_end?;
     let end_date = chrono::NaiveDate::parse_from_str(end_str, "%Y-%m-%d").ok()?;
     Some((end_date - current_date).num_days())
@@ -804,7 +844,11 @@ fn renew_contracts_for_retained_players(game: &mut Game) {
         let Some(team_id) = &player.team_id else {
             continue;
         };
-        let Some(team) = game.teams.iter().find(|t| t.id.as_str() == team_id.as_str()) else {
+        let Some(team) = game
+            .teams
+            .iter()
+            .find(|t| t.id.as_str() == team_id.as_str())
+        else {
             continue;
         };
 
@@ -825,7 +869,10 @@ fn renew_contracts_for_retained_players(game: &mut Game) {
         let wage = crate::contracts::expected_wage(player, team, current_date);
         let contract_end = current_date
             .checked_add_months(chrono::Months::new(base_years * 12))
-            .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(next_season_year + base_years as i32, 11, 30).unwrap());
+            .unwrap_or_else(|| {
+                chrono::NaiveDate::from_ymd_opt(next_season_year + base_years as i32, 11, 30)
+                    .unwrap()
+            });
 
         player.contract_end = Some(contract_end.format("%Y-%m-%d").to_string());
         player.wage = wage;
@@ -841,13 +888,22 @@ fn replenish_depleted_rosters(game: &mut Game) {
     let team_ids: Vec<String> = game.teams.iter().map(|t| t.id.clone()).collect();
 
     for team_id in team_ids {
-        let roster_count = game.players.iter().filter(|p| p.team_id.as_ref().map(|id| id.as_str()) == Some(team_id.as_str())).count();
+        let roster_count = game
+            .players
+            .iter()
+            .filter(|p| p.team_id.as_ref().map(|id| id.as_str()) == Some(team_id.as_str()))
+            .count();
 
         if roster_count >= 5 {
             continue;
         }
 
-        let Some(team_name) = game.teams.iter().find(|t| t.id == team_id).map(|t| t.name.clone()) else {
+        let Some(team_name) = game
+            .teams
+            .iter()
+            .find(|t| t.id == team_id)
+            .map(|t| t.name.clone())
+        else {
             continue;
         };
 
@@ -881,7 +937,9 @@ fn replenish_depleted_rosters(game: &mut Game) {
             agent.contract_end = Some(
                 current_date
                     .checked_add_months(chrono::Months::new(contract_years * 12))
-                    .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(next_season_year, 11, 30).unwrap())
+                    .unwrap_or_else(|| {
+                        chrono::NaiveDate::from_ymd_opt(next_season_year, 11, 30).unwrap()
+                    })
                     .format("%Y-%m-%d")
                     .to_string(),
             );
@@ -906,7 +964,11 @@ fn replenish_depleted_rosters(game: &mut Game) {
             )
             .with_category(crate::domain::message::MessageCategory::Transfer)
             .with_priority(crate::domain::message::MessagePriority::Normal)
-            .with_i18n("be.msg.freeAgentSigned.subject", "be.msg.freeAgentSigned.body", params);
+            .with_i18n(
+                "be.msg.freeAgentSigned.subject",
+                "be.msg.freeAgentSigned.body",
+                params,
+            );
             game.messages.push(msg);
 
             let user_team_id = game.manager.team_id.clone().unwrap_or_default();
@@ -934,7 +996,7 @@ fn replenish_depleted_rosters(game: &mut Game) {
 mod tests {
     use super::*;
     use crate::clock::GameClock;
-    use crate::generator::definitions::{ScheduleConfig, SplitConfig, SeasonStart};
+    use crate::generator::definitions::{ScheduleConfig, SeasonStart, SplitConfig};
 
     fn make_team(id: &str) -> crate::domain::team::Team {
         let team = crate::domain::team::Team::new(
@@ -949,7 +1011,13 @@ mod tests {
         team
     }
 
-    fn make_completed_fixture(id: &str, matchday: u32, date: &str, home: &str, away: &str) -> crate::domain::league::Fixture {
+    fn make_completed_fixture(
+        id: &str,
+        matchday: u32,
+        date: &str,
+        home: &str,
+        away: &str,
+    ) -> crate::domain::league::Fixture {
         crate::domain::league::Fixture {
             id: id.to_string(),
             matchday,
@@ -985,9 +1053,7 @@ mod tests {
     /// Create a game with an active league (index 0) and a bg league (index 1).
     /// The bg league can be set to complete or incomplete.
     fn bg_eos_test_game(bg_complete: bool) -> Game {
-        let clock = GameClock::new(
-            chrono::Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap(),
-        );
+        let clock = GameClock::new(chrono::Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap());
         let manager = crate::domain::manager::Manager::new(
             "mgr".to_string(),
             "Test".to_string(),
@@ -995,7 +1061,12 @@ mod tests {
             "1980-01-01".to_string(),
             "ES".to_string(),
         );
-        let teams = vec![make_team("team_a"), make_team("team_b"), make_team("team_c"), make_team("team_d")];
+        let teams = vec![
+            make_team("team_a"),
+            make_team("team_b"),
+            make_team("team_c"),
+            make_team("team_d"),
+        ];
 
         let mut game = crate::game::Game::new(clock, manager, teams, vec![], vec![], vec![]);
 
@@ -1022,8 +1093,20 @@ mod tests {
         if bg_complete {
             // Add 2 completed fixtures and update standings so season_has_started is true
             if let Some(league) = game.leagues.get_mut(1) {
-                league.fixtures.push(make_completed_fixture("bg-fix-1", 1, "2025-01-15", "team_c", "team_d"));
-                league.fixtures.push(make_completed_fixture("bg-fix-2", 2, "2025-01-22", "team_d", "team_c"));
+                league.fixtures.push(make_completed_fixture(
+                    "bg-fix-1",
+                    1,
+                    "2025-01-15",
+                    "team_c",
+                    "team_d",
+                ));
+                league.fixtures.push(make_completed_fixture(
+                    "bg-fix-2",
+                    2,
+                    "2025-01-22",
+                    "team_d",
+                    "team_c",
+                ));
                 // Mark standings as having played (so season_has_started returns true)
                 for entry in league.standings.iter_mut() {
                     entry.played = 10; // Any positive value works
@@ -1045,14 +1128,34 @@ mod tests {
         let mut configs = HashMap::new();
         configs.insert("lck".to_string(), sample_schedule_config());
 
-        let team_c_history_before = game.teams.iter().find(|t| t.id == "team_c").map(|t| t.history.len()).unwrap_or(0);
-        let team_d_history_before = game.teams.iter().find(|t| t.id == "team_d").map(|t| t.history.len()).unwrap_or(0);
+        let team_c_history_before = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_c")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
+        let team_d_history_before = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_d")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
 
         process_background_seasons(&mut game, &configs);
 
         // TeamSeasonRecord should be pushed for both teams
-        let team_c_history_after = game.teams.iter().find(|t| t.id == "team_c").map(|t| t.history.len()).unwrap_or(0);
-        let team_d_history_after = game.teams.iter().find(|t| t.id == "team_d").map(|t| t.history.len()).unwrap_or(0);
+        let team_c_history_after = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_c")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
+        let team_d_history_after = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_d")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
         assert_eq!(team_c_history_after, team_c_history_before + 1);
         assert_eq!(team_d_history_after, team_d_history_before + 1);
 
@@ -1073,12 +1176,22 @@ mod tests {
         let mut configs = HashMap::new();
         configs.insert("lck".to_string(), sample_schedule_config());
 
-        let team_c_history_before = game.teams.iter().find(|t| t.id == "team_c").map(|t| t.history.len()).unwrap_or(0);
+        let team_c_history_before = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_c")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
 
         process_background_seasons(&mut game, &configs);
 
         // No history should have been recorded
-        let team_c_history_after = game.teams.iter().find(|t| t.id == "team_c").map(|t| t.history.len()).unwrap_or(0);
+        let team_c_history_after = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_c")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
         assert_eq!(team_c_history_after, team_c_history_before);
 
         // BG league should be unchanged (no fixtures regenerated)
@@ -1095,12 +1208,22 @@ mod tests {
         let mut configs = HashMap::new();
         configs.insert("lck".to_string(), sample_schedule_config());
 
-        let team_c_history_before = game.teams.iter().find(|t| t.id == "team_c").map(|t| t.history.len()).unwrap_or(0);
+        let team_c_history_before = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_c")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
 
         process_background_seasons(&mut game, &configs);
 
         // History IS still recorded
-        let team_c_history_after = game.teams.iter().find(|t| t.id == "team_c").map(|t| t.history.len()).unwrap_or(0);
+        let team_c_history_after = game
+            .teams
+            .iter()
+            .find(|t| t.id == "team_c")
+            .map(|t| t.history.len())
+            .unwrap_or(0);
         assert_eq!(team_c_history_after, team_c_history_before + 1);
 
         // But no schedule regeneration — fixtures should remain unchanged (the original ones)

--- a/src-tauri/crates/olm_core/src/finances.rs
+++ b/src-tauri/crates/olm_core/src/finances.rs
@@ -4,8 +4,9 @@ use crate::domain::team::{
     MainFacilityModuleKind, Sponsorship, SponsorshipBonusCriterion, Team,
 };
 use crate::game::Game;
-use chrono::Datelike;
+use chrono::{Datelike, NaiveDate};
 use rand::RngExt;
+use std::collections::{HashMap, HashSet};
 
 const MAIN_HUB_UPKEEP_PER_EXTRA_LEVEL: i64 = 20_000;
 const ESPORTS_SPONSOR_THEME_MULTIPLIER: f64 = 1.15;
@@ -23,6 +24,32 @@ struct MonthlyTeamExpenses {
     facility_upkeep: i64,
 }
 
+enum MonthlyFinanceMailEvent {
+    SponsorPayout {
+        team_id: String,
+        sponsor_name: String,
+        amount: i64,
+    },
+    SponsorBonus {
+        team_id: String,
+        sponsor_name: String,
+        bonus_amount: i64,
+        total_amount: i64,
+    },
+    SponsorExpired {
+        team_id: String,
+        sponsor_name: String,
+    },
+    FacilityUpkeepSummary {
+        team_id: String,
+        amount: i64,
+    },
+    FacilityUpkeepSpike {
+        team_id: String,
+        amount: i64,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BudgetImpact {
     None,
@@ -38,14 +65,40 @@ pub struct FinanceTransactionInput {
     pub kind: FinancialTransactionKind,
     pub budget_impact: BudgetImpact,
     pub affects_season_totals: bool,
+    pub source: String,
+    pub source_id: Option<String>,
+    pub correlation_id: Option<String>,
 }
 
-pub fn record_transaction(team: &mut Team, input: FinanceTransactionInput) {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FinanceTransactionError {
+    InvalidDate,
+    BlankDescription,
+    BlankSource,
+    ZeroAmount,
+    SignKindMismatch,
+}
+
+pub fn record_transaction(
+    team: &mut Team,
+    input: FinanceTransactionInput,
+) -> Result<FinancialTransaction, FinanceTransactionError> {
+    validate_transaction_input(&input)?;
+
+    let balance_before = team.finance;
+    let balance_after = balance_before + input.amount;
+    let ledger_len = team.financial_ledger.len();
+    let source_id_part = input.source_id.as_deref().unwrap_or("none");
+    let id = format!(
+        "tx:{}:{}:{}:{}:{}:{}",
+        team.id, input.date, input.source, source_id_part, input.amount, ledger_len
+    );
+
     if input.amount == 0 {
-        return;
+        return Err(FinanceTransactionError::ZeroAmount);
     }
 
-    team.finance += input.amount;
+    team.finance = balance_after;
 
     if input.affects_season_totals {
         if input.amount > 0 {
@@ -61,12 +114,290 @@ pub fn record_transaction(team: &mut Team, input: FinanceTransactionInput) {
         BudgetImpact::Wage(delta) => team.wage_budget += delta,
     }
 
-    team.financial_ledger.push(FinancialTransaction {
+    let transaction = FinancialTransaction {
+        id,
         date: input.date,
         description: input.description,
         amount: input.amount,
         kind: input.kind,
-    });
+        balance_before,
+        balance_after,
+        source: input.source,
+        source_id: input.source_id,
+        correlation_id: input.correlation_id,
+    };
+    team.financial_ledger.push(transaction.clone());
+    Ok(transaction)
+}
+
+fn validate_transaction_input(
+    input: &FinanceTransactionInput,
+) -> Result<(), FinanceTransactionError> {
+    if NaiveDate::parse_from_str(&input.date, "%Y-%m-%d").is_err() {
+        return Err(FinanceTransactionError::InvalidDate);
+    }
+    if input.description.trim().is_empty() {
+        return Err(FinanceTransactionError::BlankDescription);
+    }
+    if input.source.trim().is_empty() {
+        return Err(FinanceTransactionError::BlankSource);
+    }
+    if input.amount == 0 {
+        return Err(FinanceTransactionError::ZeroAmount);
+    }
+    if !kind_matches_amount_sign(input.kind.clone(), input.amount) {
+        return Err(FinanceTransactionError::SignKindMismatch);
+    }
+    Ok(())
+}
+
+fn kind_matches_amount_sign(kind: FinancialTransactionKind, amount: i64) -> bool {
+    match kind {
+        FinancialTransactionKind::Salary
+        | FinancialTransactionKind::StaffWage
+        | FinancialTransactionKind::FacilityUpkeep
+        | FinancialTransactionKind::FacilityUpgrade
+        | FinancialTransactionKind::TransferPurchase
+        | FinancialTransactionKind::ReleasePenalty
+        | FinancialTransactionKind::AcademyAcquisition => amount < 0,
+        FinancialTransactionKind::TransferSale
+        | FinancialTransactionKind::Sponsorship
+        | FinancialTransactionKind::MatchdayRevenue
+        | FinancialTransactionKind::PrizeMoney
+        | FinancialTransactionKind::BudgetRefresh => amount > 0,
+        FinancialTransactionKind::Other => true,
+    }
+}
+
+pub fn push_finance_mail_once(
+    game: &mut Game,
+    team_id: &str,
+    correlation_id: &str,
+    event: &str,
+    subject_key: &str,
+    body_key: &str,
+    params: HashMap<String, String>,
+    date: &str,
+) -> bool {
+    let id = format!("finance:{correlation_id}:{event}");
+    if game.messages.iter().any(|message| message.id == id) {
+        return false;
+    }
+
+    let mut message = InboxMessage::new(
+        id,
+        "Finance update".to_string(),
+        "A finance update is available.".to_string(),
+        "Financial Director".to_string(),
+        date.to_string(),
+    )
+    .with_category(MessageCategory::Finance)
+    .with_priority(MessagePriority::Normal)
+    .with_sender_role("Financial Director")
+    .with_i18n(subject_key, body_key, params)
+    .with_sender_i18n("be.sender.financialDirector", "be.role.financialDirector")
+    .with_action(action(
+        "view_finances",
+        "View Finances",
+        "be.msg.event.ack",
+        ActionType::NavigateTo {
+            route: "/dashboard?tab=Finances".to_string(),
+        },
+    ));
+    message.context.team_id = Some(team_id.to_string());
+    game.messages.push(message);
+    true
+}
+
+pub fn push_sponsor_accepted_mail(
+    game: &mut Game,
+    team_id: &str,
+    sponsor_name: &str,
+    annual_amount: i64,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("sponsor-accepted:{team_id}:{sponsor_name}:{date}"),
+        "sponsorAccepted",
+        "be.msg.finance.sponsorAccepted.subject",
+        "be.msg.finance.sponsorAccepted.body",
+        params(&[
+            ("sponsorName", sponsor_name.to_string()),
+            ("amount", format_money(annual_amount.unsigned_abs())),
+        ]),
+        date,
+    )
+}
+
+pub fn push_sponsor_payout_mail(
+    game: &mut Game,
+    team_id: &str,
+    sponsor_name: &str,
+    amount: i64,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("sponsor-payout:{team_id}:{date}"),
+        "sponsorPayout",
+        "be.msg.finance.sponsorPayout.subject",
+        "be.msg.finance.sponsorPayout.body",
+        params(&[
+            ("sponsorName", sponsor_name.to_string()),
+            ("amount", format_money(amount.unsigned_abs())),
+        ]),
+        date,
+    )
+}
+
+pub fn push_sponsor_bonus_mail(
+    game: &mut Game,
+    team_id: &str,
+    sponsor_name: &str,
+    bonus_amount: i64,
+    total_amount: i64,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("sponsor-bonus:{team_id}:{sponsor_name}:{date}"),
+        "sponsorBonus",
+        "be.msg.finance.sponsorBonus.subject",
+        "be.msg.finance.sponsorBonus.body",
+        params(&[
+            ("sponsorName", sponsor_name.to_string()),
+            ("bonusAmount", format_money(bonus_amount.unsigned_abs())),
+            ("totalAmount", format_money(total_amount.unsigned_abs())),
+        ]),
+        date,
+    )
+}
+
+pub fn push_sponsor_expired_mail(
+    game: &mut Game,
+    team_id: &str,
+    sponsor_name: &str,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("sponsor-expired:{team_id}:{sponsor_name}:{date}"),
+        "sponsorExpired",
+        "be.msg.finance.sponsorExpired.subject",
+        "be.msg.finance.sponsorExpired.body",
+        params(&[("sponsorName", sponsor_name.to_string())]),
+        date,
+    )
+}
+
+pub fn push_facility_upkeep_summary_mail(
+    game: &mut Game,
+    team_id: &str,
+    amount: i64,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("facility-upkeep:{team_id}:{date}"),
+        "facilityUpkeepSummary",
+        "be.msg.finance.facilityUpkeepSummary.subject",
+        "be.msg.finance.facilityUpkeepSummary.body",
+        params(&[("amount", format_money(amount.unsigned_abs()))]),
+        date,
+    )
+}
+
+pub fn push_facility_upkeep_spike_mail(
+    game: &mut Game,
+    team_id: &str,
+    amount: i64,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("facility-upkeep-spike:{team_id}:{date}"),
+        "facilityUpkeepSpike",
+        "be.msg.finance.facilityUpkeepSpike.subject",
+        "be.msg.finance.facilityUpkeepSpike.body",
+        params(&[("amount", format_money(amount.unsigned_abs()))]),
+        date,
+    )
+}
+
+pub fn push_prize_payout_mail(
+    game: &mut Game,
+    team_id: &str,
+    season: u32,
+    position: u32,
+    amount: i64,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("prize:{team_id}:{season}:{position}"),
+        "prizePayout",
+        "be.msg.finance.prizePayout.subject",
+        "be.msg.finance.prizePayout.body",
+        params(&[
+            ("season", season.to_string()),
+            ("position", position.to_string()),
+            ("amount", format_money(amount.unsigned_abs())),
+        ]),
+        date,
+    )
+}
+
+pub fn push_board_financial_health_mail(
+    game: &mut Game,
+    team_id: &str,
+    balance: i64,
+    monthly_net: i64,
+    months_left: Option<i64>,
+    date: &str,
+) -> bool {
+    push_finance_mail_once(
+        game,
+        team_id,
+        &format!("board-health:{team_id}:{date}"),
+        "boardFinancialHealth",
+        "be.msg.finance.boardFinancialHealth.subject",
+        "be.msg.finance.boardFinancialHealth.body",
+        params(&[
+            ("balance", format_money(balance.unsigned_abs())),
+            ("monthlyNet", signed_money(monthly_net)),
+            (
+                "monthsLeft",
+                months_left
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "stable".to_string()),
+            ),
+        ]),
+        date,
+    )
+}
+
+fn params(pairs: &[(&str, String)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(key, value)| ((*key).to_string(), value.clone()))
+        .collect()
+}
+
+fn signed_money(amount: i64) -> String {
+    let formatted = format_money(amount.unsigned_abs());
+    if amount < 0 {
+        format!("-{formatted}")
+    } else {
+        formatted
+    }
 }
 
 fn action(id: &str, label: &str, label_key: &str, action_type: ActionType) -> MessageAction {
@@ -272,6 +603,8 @@ pub fn process_monthly_finances(game: &mut Game) {
     }
 
     let today = game.clock.current_date.format("%Y-%m-%d").to_string();
+    let user_team_id = game.manager.team_id.clone();
+    let mut mail_events = Vec::new();
     let team_expenses: Vec<MonthlyTeamExpenses> = game
         .teams
         .iter()
@@ -325,8 +658,12 @@ pub fn process_monthly_finances(game: &mut Game) {
                     kind: FinancialTransactionKind::Salary,
                     budget_impact: BudgetImpact::None,
                     affects_season_totals: true,
+                    source: "monthly".to_string(),
+                    source_id: Some("player-wages".to_string()),
+                    correlation_id: Some(format!("monthly:{}:{}:player-wages", team.id, today)),
                 },
-            );
+            )
+            .ok();
             record_transaction(
                 team,
                 FinanceTransactionInput {
@@ -336,8 +673,12 @@ pub fn process_monthly_finances(game: &mut Game) {
                     kind: FinancialTransactionKind::StaffWage,
                     budget_impact: BudgetImpact::None,
                     affects_season_totals: true,
+                    source: "monthly".to_string(),
+                    source_id: Some("staff-wages".to_string()),
+                    correlation_id: Some(format!("monthly:{}:{}:staff-wages", team.id, today)),
                 },
-            );
+            )
+            .ok();
             record_transaction(
                 team,
                 FinanceTransactionInput {
@@ -347,8 +688,25 @@ pub fn process_monthly_finances(game: &mut Game) {
                     kind: FinancialTransactionKind::FacilityUpkeep,
                     budget_impact: BudgetImpact::None,
                     affects_season_totals: true,
+                    source: "facility".to_string(),
+                    source_id: Some("monthly-upkeep".to_string()),
+                    correlation_id: Some(format!("facility-upkeep:{}:{}", team.id, today)),
                 },
-            );
+            )
+            .ok();
+
+            if expenses.facility_upkeep > 0 && Some(team.id.as_str()) == user_team_id.as_deref() {
+                mail_events.push(MonthlyFinanceMailEvent::FacilityUpkeepSummary {
+                    team_id: team.id.clone(),
+                    amount: expenses.facility_upkeep,
+                });
+                if expenses.facility_upkeep >= 100_000 {
+                    mail_events.push(MonthlyFinanceMailEvent::FacilityUpkeepSpike {
+                        team_id: team.id.clone(),
+                        amount: expenses.facility_upkeep,
+                    });
+                }
+            }
         }
 
         let current_position = team_positions
@@ -356,16 +714,24 @@ pub fn process_monthly_finances(game: &mut Game) {
             .find(|(team_id, _)| team_id == &team.id)
             .and_then(|(_, position)| *position);
 
-        let sponsorship_income = team
-            .sponsorship
+        let sponsorship_context = team.sponsorship.as_ref().map(|sponsorship| {
+            let base_income = calc_sponsorship_income(current_position, &team.form, sponsorship);
+            let bonus_income =
+                evaluate_sponsorship_bonus(current_position, &team.form, sponsorship);
+            let facility_mult = facility_module_sponsorship_multiplier(&team.facilities);
+            // base_value is annual, divide by 12 for monthly payment
+            let monthly_income = ((base_income as f64 * facility_mult) / 12.0).round() as i64;
+            let monthly_bonus = ((bonus_income as f64 * facility_mult) / 12.0).round() as i64;
+            (
+                sponsorship.sponsor_name.clone(),
+                monthly_income,
+                monthly_bonus,
+                sponsorship.remaining_months,
+            )
+        });
+        let sponsorship_income = sponsorship_context
             .as_ref()
-            .map(|sponsorship| {
-                let base_income =
-                    calc_sponsorship_income(current_position, &team.form, sponsorship);
-                let facility_mult = facility_module_sponsorship_multiplier(&team.facilities);
-                // base_value is annual, divide by 12 for monthly payment
-                ((base_income as f64 * facility_mult) / 12.0).round() as i64
-            })
+            .map(|(_, monthly_income, _, _)| *monthly_income)
             .unwrap_or(0);
 
         if sponsorship_income > 0 {
@@ -378,14 +744,82 @@ pub fn process_monthly_finances(game: &mut Game) {
                     kind: FinancialTransactionKind::Sponsorship,
                     budget_impact: BudgetImpact::None,
                     affects_season_totals: true,
+                    source: "sponsor".to_string(),
+                    source_id: team.sponsorship.as_ref().map(|s| s.sponsor_name.clone()),
+                    correlation_id: Some(format!("sponsor-payout:{}:{}", team.id, today)),
                 },
-            );
+            )
+            .ok();
+            if Some(team.id.as_str()) == user_team_id.as_deref() {
+                if let Some((sponsor_name, monthly_income, monthly_bonus, _)) = &sponsorship_context
+                {
+                    mail_events.push(MonthlyFinanceMailEvent::SponsorPayout {
+                        team_id: team.id.clone(),
+                        sponsor_name: sponsor_name.clone(),
+                        amount: *monthly_income,
+                    });
+                    if *monthly_bonus > 0 {
+                        mail_events.push(MonthlyFinanceMailEvent::SponsorBonus {
+                            team_id: team.id.clone(),
+                            sponsor_name: sponsor_name.clone(),
+                            bonus_amount: *monthly_bonus,
+                            total_amount: *monthly_income,
+                        });
+                    }
+                }
+            }
         }
 
         if let Some(sponsorship) = team.sponsorship.as_mut() {
+            let sponsor_name = sponsorship.sponsor_name.clone();
             sponsorship.remaining_months = sponsorship.remaining_months.saturating_sub(1);
             if sponsorship.remaining_months == 0 {
                 team.sponsorship = None;
+                if Some(team.id.as_str()) == user_team_id.as_deref() {
+                    mail_events.push(MonthlyFinanceMailEvent::SponsorExpired {
+                        team_id: team.id.clone(),
+                        sponsor_name,
+                    });
+                }
+            }
+        }
+    }
+
+    for event in mail_events {
+        match event {
+            MonthlyFinanceMailEvent::SponsorPayout {
+                team_id,
+                sponsor_name,
+                amount,
+            } => {
+                push_sponsor_payout_mail(game, &team_id, &sponsor_name, amount, &today);
+            }
+            MonthlyFinanceMailEvent::SponsorBonus {
+                team_id,
+                sponsor_name,
+                bonus_amount,
+                total_amount,
+            } => {
+                push_sponsor_bonus_mail(
+                    game,
+                    &team_id,
+                    &sponsor_name,
+                    bonus_amount,
+                    total_amount,
+                    &today,
+                );
+            }
+            MonthlyFinanceMailEvent::SponsorExpired {
+                team_id,
+                sponsor_name,
+            } => {
+                push_sponsor_expired_mail(game, &team_id, &sponsor_name, &today);
+            }
+            MonthlyFinanceMailEvent::FacilityUpkeepSummary { team_id, amount } => {
+                push_facility_upkeep_summary_mail(game, &team_id, amount, &today);
+            }
+            MonthlyFinanceMailEvent::FacilityUpkeepSpike { team_id, amount } => {
+                push_facility_upkeep_spike_mail(game, &team_id, amount, &today);
             }
         }
     }
@@ -425,8 +859,12 @@ pub fn process_monthly_finances(game: &mut Game) {
                         kind: FinancialTransactionKind::MatchdayRevenue,
                         budget_impact: BudgetImpact::None,
                         affects_season_totals: true,
+                        source: "monthly".to_string(),
+                        source_id: Some("matchday".to_string()),
+                        correlation_id: Some(format!("matchday:{}:{}", team.id, today)),
                     },
-                );
+                )
+                .ok();
             }
         }
     }
@@ -447,8 +885,7 @@ fn generate_financial_warnings(game: &mut Game, today: &str) {
         None => return,
     };
 
-    let existing_ids: std::collections::HashSet<String> =
-        game.messages.iter().map(|m| m.id.clone()).collect();
+    let existing_ids: HashSet<String> = game.messages.iter().map(|m| m.id.clone()).collect();
 
     let mut new_messages: Vec<InboxMessage> = Vec::new();
 

--- a/src-tauri/crates/olm_core/src/random_events/responses.rs
+++ b/src-tauri/crates/olm_core/src/random_events/responses.rs
@@ -1,4 +1,5 @@
 use super::format_money;
+use crate::finances::push_sponsor_accepted_mail;
 use crate::game::Game;
 use crate::domain::team::{Sponsorship, SponsorshipBonusCriterion};
 use rand::RngExt;
@@ -55,7 +56,7 @@ pub fn apply_event_response(
                     .unwrap_or_else(|| "Sponsor".to_string());
                 if let Some(team) = game.teams.iter_mut().find(|t| t.id == user_team_id) {
                     team.sponsorship = Some(Sponsorship {
-                        sponsor_name,
+                        sponsor_name: sponsor_name.clone(),
                         base_value: amount as i64,
                         remaining_months: 3,
                         bonus_criteria: vec![SponsorshipBonusCriterion::UnbeatenRun {
@@ -64,6 +65,14 @@ pub fn apply_event_response(
                         }],
                     });
                 }
+                let today = game.clock.current_date.format("%Y-%m-%d").to_string();
+                push_sponsor_accepted_mail(
+                    game,
+                    &user_team_id,
+                    &sponsor_name,
+                    amount as i64,
+                    &today,
+                );
                 // Mark resolved
                 if let Some(msg) = game.messages.iter_mut().find(|m| m.id == message_id) {
                     for a in msg.actions.iter_mut() {
@@ -212,4 +221,3 @@ pub fn apply_event_response(
         None
     }
 }
-

--- a/src-tauri/crates/olm_core/src/transfers.rs
+++ b/src-tauri/crates/olm_core/src/transfers.rs
@@ -1485,8 +1485,11 @@ fn execute_free_agent_signing_with_payer(
                 kind: FinancialTransactionKind::TransferPurchase,
                 budget_impact: BudgetImpact::Transfer(-(fee as i64)),
                 affects_season_totals: false,
+                source: "transfer".to_string(),
+                source_id: Some(player_id.to_string()),
+                correlation_id: Some(format!("transfer:{payer_team_id}:{player_id}:free-agent")),
             },
-        );
+        ).ok();
     }
 
     let players_snapshot = game.players.clone();
@@ -2285,8 +2288,11 @@ fn complete_transfer_with_wage(
                 kind: FinancialTransactionKind::TransferPurchase,
                 budget_impact: BudgetImpact::Transfer(-(fee as i64)),
                 affects_season_totals: false,
+                source: "transfer".to_string(),
+                source_id: Some(player_id.to_string()),
+                correlation_id: Some(format!("transfer:{payer_team_id}:{player_id}:{date}:purchase")),
             },
-        );
+        ).ok();
     }
 
     if let Some(from_id) = from_team_id {
@@ -2305,8 +2311,11 @@ fn complete_transfer_with_wage(
                         (fee as i64 * TRANSFER_BUDGET_SELLING_REALLOCATION_PCT) / 100,
                     ),
                     affects_season_totals: false,
+                    source: "transfer".to_string(),
+                    source_id: Some(player_id.to_string()),
+                    correlation_id: Some(format!("transfer:{from_id}:{player_id}:{date}:sale")),
                 },
-            );
+            ).ok();
         }
     }
 
@@ -2681,8 +2690,11 @@ pub fn release_player_contract(game: &mut Game, player_id: &str) -> Result<i64, 
             kind: FinancialTransactionKind::ReleasePenalty,
             budget_impact: BudgetImpact::None,
             affects_season_totals: true,
+            source: "transfer".to_string(),
+            source_id: Some(player_id.to_string()),
+            correlation_id: Some(format!("release:{owning_team_id}:{player_id}:{today}")),
         },
-    );
+    ).map_err(|err| format!("Failed to record release penalty: {err:?}"))?;
     remove_player_from_team_references(team, player_id);
 
     if let Some(player) = game
@@ -2956,8 +2968,11 @@ fn execute_transfer_with_payer(
                 kind: FinancialTransactionKind::TransferPurchase,
                 budget_impact: BudgetImpact::Transfer(-(fee as i64)),
                 affects_season_totals: false,
+                source: "transfer".to_string(),
+                source_id: Some(player_id.to_string()),
+                correlation_id: Some(format!("transfer:{payer_team_id}:{player_id}:{today}:purchase")),
             },
-        );
+        ).ok();
     }
 
     let players_snapshot = game.players.clone();
@@ -2986,8 +3001,11 @@ fn execute_transfer_with_payer(
                     (fee as i64 * TRANSFER_BUDGET_SELLING_REALLOCATION_PCT) / 100,
                 ),
                 affects_season_totals: false,
+                source: "transfer".to_string(),
+                source_id: Some(player_id.to_string()),
+                correlation_id: Some(format!("transfer:{credit_target_id}:{player_id}:{today}:sale")),
             },
-        );
+        ).ok();
     }
 
     if selling_team_is_academy {

--- a/src-tauri/crates/olm_core/tests/academy_tests.rs
+++ b/src-tauri/crates/olm_core/tests/academy_tests.rs
@@ -1,9 +1,13 @@
+use chrono::{TimeZone, Utc};
 use olm_core::academy::{
-    eligible_academy_acquisition_options, validate_academy_acquisition,
-    validate_parent_academy_link, AcademyAcquisitionOption, AcademyError, ErlAcademyCandidate,
-    ErlAssignmentRule, ErlLeagueDefinition,
+    acquire_academy, eligible_academy_acquisition_options, get_acquisition_options,
+    validate_academy_acquisition, validate_parent_academy_link, AcademyAcquisitionOption,
+    AcademyError, ErlAcademyCandidate, ErlAssignmentRule, ErlLeagueDefinition,
 };
-use olm_core::domain::team::{Team, TeamKind};
+use olm_core::clock::GameClock;
+use olm_core::domain::manager::Manager;
+use olm_core::domain::team::{FinancialTransactionKind, Team, TeamKind};
+use olm_core::game::Game;
 
 fn team(id: &str, country: &str, finance: i64) -> Team {
     let mut team = Team::new(
@@ -172,5 +176,52 @@ fn unrelated_parent_academy_movement_is_rejected() {
             parent_team_id: "lec-team".to_string(),
             academy_team_id: "other-academy".to_string(),
         })
+    );
+}
+
+#[test]
+fn academy_acquisition_records_canonical_ledger_date_and_source() {
+    let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("repo root should be above olm_core crate");
+    std::env::set_current_dir(repo_root).expect("test can use repo data catalog");
+
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 3, 15, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "manager-1".to_string(),
+        "Jane".to_string(),
+        "Doe".to_string(),
+        "1980-01-01".to_string(),
+        "FR".to_string(),
+    );
+    manager.hire("lec-team".to_string());
+    let parent = team("lec-team", "FR", 2_000_000);
+    let mut game = Game::new(clock, manager, vec![parent], vec![], vec![], vec![]);
+    let (options, _) = get_acquisition_options(&game, "lec-team");
+    let source_team_id = options
+        .first()
+        .expect("at least one academy option should be available")
+        .source_team_id
+        .clone();
+
+    acquire_academy(&mut game, "lec-team", &source_team_id, None, None)
+        .expect("academy acquisition succeeds");
+
+    let parent = game
+        .teams
+        .iter()
+        .find(|team| team.id == "lec-team")
+        .expect("parent team exists");
+    assert_eq!(parent.financial_ledger.len(), 1);
+    let entry = &parent.financial_ledger[0];
+    assert_eq!(entry.date, "2026-03-15");
+    assert_eq!(entry.kind, FinancialTransactionKind::AcademyAcquisition);
+    assert_eq!(entry.source, "academy");
+    assert_eq!(entry.source_id.as_deref(), Some(source_team_id.as_str()));
+    let expected_correlation = format!("academy-acquisition:lec-team:{source_team_id}");
+    assert_eq!(
+        entry.correlation_id.as_deref(),
+        Some(expected_correlation.as_str())
     );
 }

--- a/src-tauri/crates/olm_core/tests/club_tests.rs
+++ b/src-tauri/crates/olm_core/tests/club_tests.rs
@@ -43,7 +43,7 @@ fn upgrade_facility_deducts_funds_and_increments_level() {
     let mut game = make_game();
     let initial_finance = game.teams[0].finance;
 
-    let cost = club::upgrade_facility(&mut game.teams[0], FacilityType::Medical).unwrap();
+    let cost = club::upgrade_facility(&mut game.teams[0], FacilityType::Medical, "2025-06-16").unwrap();
 
     assert_eq!(cost, 250_000);
     assert_eq!(game.teams[0].finance, initial_finance - cost);
@@ -54,6 +54,8 @@ fn upgrade_facility_deducts_funds_and_increments_level() {
         FinancialTransactionKind::FacilityUpgrade
     );
     assert_eq!(game.teams[0].financial_ledger[0].amount, -cost);
+    assert_eq!(game.teams[0].financial_ledger[0].date, "2025-06-16");
+    assert_eq!(game.teams[0].financial_ledger[0].source, "facility");
     assert_eq!(game.teams[0].facilities.medical, 2);
 }
 
@@ -69,7 +71,7 @@ fn upgrade_facility_rejects_when_funds_are_insufficient() {
         ..Default::default()
     };
 
-    let result = club::upgrade_facility(&mut game.teams[0], FacilityType::Training);
+    let result = club::upgrade_facility(&mut game.teams[0], FacilityType::Training, "2025-06-16");
 
     assert!(result.is_err());
     assert_eq!(game.teams[0].finance, 100_000);
@@ -81,7 +83,7 @@ fn expand_main_facility_hub_deducts_funds_and_unlocks_next_module_level() {
     let mut game = make_game();
     let initial_finance = game.teams[0].finance;
 
-    let cost = club::expand_main_facility_hub(&mut game.teams[0]).unwrap();
+    let cost = club::expand_main_facility_hub(&mut game.teams[0], "2025-06-16").unwrap();
 
     assert_eq!(cost, 500_000);
     assert_eq!(game.teams[0].finance, initial_finance - cost);
@@ -104,7 +106,7 @@ fn upgrade_main_facility_module_requires_the_next_hub_level_to_be_unlocked() {
     let mut game = make_game();
 
     let result =
-        club::upgrade_main_facility_module(&mut game.teams[0], MainFacilityModuleKind::ScoutingLab);
+        club::upgrade_main_facility_module(&mut game.teams[0], MainFacilityModuleKind::ScoutingLab, "2025-06-16");
 
     assert!(result.is_err());
     assert_eq!(game.teams[0].finance, 2_000_000);
@@ -115,7 +117,7 @@ fn upgrade_main_facility_module_requires_the_next_hub_level_to_be_unlocked() {
 fn legacy_facility_upgrade_entry_point_expands_the_hub_cap_safely() {
     let mut game = make_game();
 
-    let cost = club::upgrade_facility(&mut game.teams[0], FacilityType::Scouting).unwrap();
+    let cost = club::upgrade_facility(&mut game.teams[0], FacilityType::Scouting, "2025-06-16").unwrap();
 
     assert_eq!(cost, 250_000);
     assert_eq!(game.teams[0].facilities.as_main_facility_hub().level, 2);

--- a/src-tauri/crates/olm_core/tests/end_of_season_tests.rs
+++ b/src-tauri/crates/olm_core/tests/end_of_season_tests.rs
@@ -4,6 +4,7 @@ use olm_core::domain::league::{
     Fixture, FixtureStatus, League, LeagueKind, MatchResult, MatchType, StandingEntry,
 };
 use olm_core::domain::manager::Manager;
+use olm_core::domain::message::MessageCategory;
 use olm_core::domain::player::{Player, PlayerAttributes, PlayerSeasonStats};
 use olm_core::domain::stats::LolRole;
 use olm_core::domain::team::{FinancialTransactionKind, Team, TeamKind};
@@ -668,6 +669,12 @@ fn champion_receives_prize_money_and_ledger_entry() {
         FinancialTransactionKind::PrizeMoney
     );
     assert_eq!(team1.financial_ledger[0].amount, 800_000);
+    assert_eq!(team1.financial_ledger[0].date, "2025-06-01");
+    assert_eq!(team1.financial_ledger[0].source, "prize");
+    assert_eq!(
+        team1.financial_ledger[0].source_id.as_deref(),
+        Some("season-1-position-1")
+    );
 }
 
 #[test]
@@ -753,6 +760,53 @@ fn prize_money_message_sent_once_per_season() {
         .count();
 
     assert_eq!(payout_messages, 1);
+}
+
+#[test]
+fn season_end_sends_scoped_prize_and_board_health_finance_mail_once() {
+    let mut game = make_completed_season_game();
+    game.teams[0].finance = 3_500_000;
+
+    process_end_of_season(&mut game);
+    process_end_of_season(&mut game);
+
+    assert_eq!(
+        game.messages
+            .iter()
+            .filter(|message| message.id == "finance:prize:team1:1:1:prizePayout")
+            .count(),
+        1
+    );
+    assert_eq!(
+        game.messages
+            .iter()
+            .filter(|message| message.id
+                == "finance:board-health:team1:2025-06-01:boardFinancialHealth")
+            .count(),
+        1
+    );
+
+    let prize = game
+        .messages
+        .iter()
+        .find(|message| message.id == "finance:prize:team1:1:1:prizePayout")
+        .expect("prize finance mail should exist");
+    assert_eq!(prize.category, MessageCategory::Finance);
+    assert_eq!(
+        prize.subject_key.as_deref(),
+        Some("be.msg.finance.prizePayout.subject")
+    );
+
+    let board_health = game
+        .messages
+        .iter()
+        .find(|message| message.id == "finance:board-health:team1:2025-06-01:boardFinancialHealth")
+        .expect("board health finance mail should exist");
+    assert_eq!(board_health.category, MessageCategory::Finance);
+    assert_eq!(
+        board_health.subject_key.as_deref(),
+        Some("be.msg.finance.boardFinancialHealth.subject")
+    );
 }
 
 #[test]

--- a/src-tauri/crates/olm_core/tests/finances_tests.rs
+++ b/src-tauri/crates/olm_core/tests/finances_tests.rs
@@ -11,7 +11,7 @@ use olm_core::domain::team::{
     Facilities, FinancialTransaction, FinancialTransactionKind, MainFacilityModuleKind,
     Sponsorship, SponsorshipBonusCriterion, Team,
 };
-use olm_core::finances::{self, BudgetImpact, FinanceTransactionInput};
+use olm_core::finances::{self, BudgetImpact, FinanceTransactionError, FinanceTransactionInput};
 use olm_core::game::Game;
 
 // ---------------------------------------------------------------------------
@@ -106,6 +106,16 @@ fn make_first_of_month_game() -> Game {
     make_game_on(2025, 6, 1)
 }
 
+fn finance_snapshot(team: &Team) -> (i64, i64, i64, i64, usize) {
+    (
+        team.finance,
+        team.season_income,
+        team.season_expenses,
+        team.transfer_budget,
+        team.financial_ledger.len(),
+    )
+}
+
 // ---------------------------------------------------------------------------
 // record_transaction — atomic helper
 // ---------------------------------------------------------------------------
@@ -116,7 +126,7 @@ fn record_transaction_applies_income_to_cash_season_totals_and_ledger() {
     team.finance = 100_000;
     team.season_income = 20_000;
 
-    finances::record_transaction(
+    let transaction = finances::record_transaction(
         &mut team,
         FinanceTransactionInput {
             date: "2026-01-15".to_string(),
@@ -125,8 +135,12 @@ fn record_transaction_applies_income_to_cash_season_totals_and_ledger() {
             kind: FinancialTransactionKind::Sponsorship,
             budget_impact: BudgetImpact::None,
             affects_season_totals: true,
+            source: "sponsor".to_string(),
+            source_id: Some("sponsor-acme".to_string()),
+            correlation_id: Some("sponsor-acme:2026-01".to_string()),
         },
-    );
+    )
+    .expect("valid sponsorship transaction should record");
 
     assert_eq!(team.finance, 135_000);
     assert_eq!(team.season_income, 55_000);
@@ -142,6 +156,15 @@ fn record_transaction_applies_income_to_cash_season_totals_and_ledger() {
         team.financial_ledger[0].kind,
         FinancialTransactionKind::Sponsorship
     );
+    assert_eq!(transaction.balance_before, 100_000);
+    assert_eq!(transaction.balance_after, 135_000);
+    assert_eq!(transaction.source, "sponsor");
+    assert_eq!(transaction.source_id.as_deref(), Some("sponsor-acme"));
+    assert_eq!(
+        transaction.correlation_id.as_deref(),
+        Some("sponsor-acme:2026-01")
+    );
+    assert!(transaction.id.contains("team1"));
 }
 
 #[test]
@@ -160,8 +183,12 @@ fn record_transaction_applies_expense_and_signed_budget_impact_atomically() {
             kind: FinancialTransactionKind::TransferPurchase,
             budget_impact: BudgetImpact::Transfer(-40_000),
             affects_season_totals: true,
+            source: "transfer".to_string(),
+            source_id: Some("player-9".to_string()),
+            correlation_id: Some("transfer:player-9".to_string()),
         },
-    );
+    )
+    .expect("valid transfer transaction should record");
 
     assert_eq!(team.finance, 210_000);
     assert_eq!(team.season_income, 0);
@@ -173,6 +200,76 @@ fn record_transaction_applies_expense_and_signed_budget_impact_atomically() {
         team.financial_ledger[0].kind,
         FinancialTransactionKind::TransferPurchase
     );
+}
+
+#[test]
+fn record_transaction_rejects_invalid_input_without_partial_mutation() {
+    let mut team = make_team("team1", "Test FC");
+    team.finance = 250_000;
+    team.season_expenses = 12_000;
+    team.transfer_budget = 90_000;
+    let original = finance_snapshot(&team);
+
+    let result = finances::record_transaction(
+        &mut team,
+        FinanceTransactionInput {
+            date: "".to_string(),
+            description: " ".to_string(),
+            amount: -40_000,
+            kind: FinancialTransactionKind::TransferSale,
+            budget_impact: BudgetImpact::Transfer(-40_000),
+            affects_season_totals: true,
+            source: "transfer".to_string(),
+            source_id: Some("player-9".to_string()),
+            correlation_id: Some("transfer:player-9".to_string()),
+        },
+    );
+
+    assert!(matches!(result, Err(FinanceTransactionError::InvalidDate)));
+    assert_eq!(finance_snapshot(&team), original);
+}
+
+#[test]
+fn record_transaction_rejects_zero_and_sign_kind_mismatch_without_ledger_entry() {
+    let mut team = make_team("team1", "Test FC");
+    let original = finance_snapshot(&team);
+
+    let zero = finances::record_transaction(
+        &mut team,
+        FinanceTransactionInput {
+            date: "2026-03-01".to_string(),
+            description: "Zero noop".to_string(),
+            amount: 0,
+            kind: FinancialTransactionKind::Other,
+            budget_impact: BudgetImpact::None,
+            affects_season_totals: true,
+            source: "manual".to_string(),
+            source_id: None,
+            correlation_id: None,
+        },
+    );
+    assert!(matches!(zero, Err(FinanceTransactionError::ZeroAmount)));
+    assert_eq!(finance_snapshot(&team), original);
+
+    let mismatch = finances::record_transaction(
+        &mut team,
+        FinanceTransactionInput {
+            date: "2026-03-01".to_string(),
+            description: "Sale should be positive".to_string(),
+            amount: -15_000,
+            kind: FinancialTransactionKind::TransferSale,
+            budget_impact: BudgetImpact::Transfer(15_000),
+            affects_season_totals: true,
+            source: "transfer".to_string(),
+            source_id: None,
+            correlation_id: None,
+        },
+    );
+    assert!(matches!(
+        mismatch,
+        Err(FinanceTransactionError::SignKindMismatch)
+    ));
+    assert_eq!(finance_snapshot(&team), original);
 }
 
 #[test]
@@ -189,6 +286,225 @@ fn financial_transaction_kind_deserializes_old_prize_money_entries() {
 
     assert_eq!(entry.kind, FinancialTransactionKind::PrizeMoney);
     assert_eq!(entry.amount, 800_000);
+    assert_eq!(entry.id, "");
+    assert_eq!(entry.balance_before, 0);
+    assert_eq!(entry.balance_after, 0);
+    assert_eq!(entry.source, "legacy");
+    assert_eq!(entry.source_id, None);
+    assert_eq!(entry.correlation_id, None);
+}
+
+#[test]
+fn finance_mail_builder_uses_finance_category_route_keys_and_dedupes_by_correlation() {
+    let mut game = make_first_of_month_game();
+
+    let first = finances::push_finance_mail_once(
+        &mut game,
+        "team1",
+        "sponsor-payout:team1:2025-06",
+        "sponsorPayout",
+        "be.msg.finance.sponsorPayout.subject",
+        "be.msg.finance.sponsorPayout.body",
+        [("amount".to_string(), "10K".to_string())]
+            .into_iter()
+            .collect(),
+        "2025-06-01",
+    );
+    let second = finances::push_finance_mail_once(
+        &mut game,
+        "team1",
+        "sponsor-payout:team1:2025-06",
+        "sponsorPayout",
+        "be.msg.finance.sponsorPayout.subject",
+        "be.msg.finance.sponsorPayout.body",
+        [("amount".to_string(), "10K".to_string())]
+            .into_iter()
+            .collect(),
+        "2025-06-01",
+    );
+
+    assert!(first);
+    assert!(!second);
+    assert_eq!(game.messages.len(), 1);
+    let message = &game.messages[0];
+    assert_eq!(
+        message.id,
+        "finance:sponsor-payout:team1:2025-06:sponsorPayout"
+    );
+    assert_eq!(
+        message.category,
+        olm_core::domain::message::MessageCategory::Finance
+    );
+    assert_eq!(
+        message.subject_key.as_deref(),
+        Some("be.msg.finance.sponsorPayout.subject")
+    );
+    assert_eq!(
+        message.body_key.as_deref(),
+        Some("be.msg.finance.sponsorPayout.body")
+    );
+    assert!(message.actions.iter().any(|action| matches!(
+        &action.action_type,
+        olm_core::domain::message::ActionType::NavigateTo { route } if route == "/dashboard?tab=Finances"
+    )));
+}
+
+#[test]
+fn scoped_finance_mail_helpers_use_localized_payloads_route_and_correlation_dedupe() {
+    let mut game = make_first_of_month_game();
+
+    assert!(finances::push_sponsor_accepted_mail(
+        &mut game,
+        "team1",
+        "Acme Corp",
+        120_000,
+        "2025-06-01",
+    ));
+    assert!(!finances::push_sponsor_accepted_mail(
+        &mut game,
+        "team1",
+        "Acme Corp",
+        120_000,
+        "2025-06-01",
+    ));
+    assert!(finances::push_sponsor_expired_mail(
+        &mut game,
+        "team1",
+        "Acme Corp",
+        "2025-06-01",
+    ));
+    assert!(finances::push_prize_payout_mail(
+        &mut game,
+        "team1",
+        1,
+        2,
+        500_000,
+        "2025-06-01",
+    ));
+    assert!(finances::push_board_financial_health_mail(
+        &mut game,
+        "team1",
+        4_000_000,
+        -25_000,
+        Some(160),
+        "2025-06-01",
+    ));
+
+    let finance_messages: Vec<_> = game
+        .messages
+        .iter()
+        .filter(|message| message.category == olm_core::domain::message::MessageCategory::Finance)
+        .collect();
+    assert_eq!(finance_messages.len(), 4);
+
+    let expected = [
+        (
+            "finance:sponsor-accepted:team1:Acme Corp:2025-06-01:sponsorAccepted",
+            "be.msg.finance.sponsorAccepted.subject",
+            "be.msg.finance.sponsorAccepted.body",
+        ),
+        (
+            "finance:sponsor-expired:team1:Acme Corp:2025-06-01:sponsorExpired",
+            "be.msg.finance.sponsorExpired.subject",
+            "be.msg.finance.sponsorExpired.body",
+        ),
+        (
+            "finance:prize:team1:1:2:prizePayout",
+            "be.msg.finance.prizePayout.subject",
+            "be.msg.finance.prizePayout.body",
+        ),
+        (
+            "finance:board-health:team1:2025-06-01:boardFinancialHealth",
+            "be.msg.finance.boardFinancialHealth.subject",
+            "be.msg.finance.boardFinancialHealth.body",
+        ),
+    ];
+
+    for (id, subject_key, body_key) in expected {
+        let message = finance_messages
+            .iter()
+            .find(|message| message.id == id)
+            .unwrap_or_else(|| panic!("missing finance message {id}"));
+        assert_eq!(message.subject_key.as_deref(), Some(subject_key));
+        assert_eq!(message.body_key.as_deref(), Some(body_key));
+        assert_eq!(message.context.team_id.as_deref(), Some("team1"));
+        assert!(message.actions.iter().any(|action| matches!(
+            &action.action_type,
+            olm_core::domain::message::ActionType::NavigateTo { route } if route == "/dashboard?tab=Finances"
+        )));
+    }
+}
+
+#[test]
+fn accepting_sponsor_offer_sends_finance_mail_and_dedupes() {
+    let mut game = make_first_of_month_game();
+    let mut offer = olm_core::domain::message::InboxMessage::new(
+        "sponsor_2025-06-01".to_string(),
+        "Sponsor offer".to_string(),
+        "Offer body".to_string(),
+        "Financial Director".to_string(),
+        "2025-06-01".to_string(),
+    )
+    .with_category(olm_core::domain::message::MessageCategory::Finance)
+    .with_i18n(
+        "be.msg.sponsorOffer.subject",
+        "be.msg.sponsorOffer.body",
+        [
+            ("sponsor".to_string(), "Acme Corp".to_string()),
+            ("amount".to_string(), "120K".to_string()),
+        ]
+        .into_iter()
+        .collect(),
+    );
+    offer
+        .actions
+        .push(olm_core::domain::message::MessageAction {
+            id: "respond".to_string(),
+            label: "Respond".to_string(),
+            action_type: olm_core::domain::message::ActionType::ChooseOption { options: vec![] },
+            resolved: false,
+            label_key: Some("be.msg.event.ack".to_string()),
+        });
+    game.messages.push(offer);
+
+    let first = olm_core::random_events::apply_event_response(
+        &mut game,
+        "sponsor_2025-06-01",
+        "respond",
+        "accept",
+    );
+    let second = olm_core::random_events::apply_event_response(
+        &mut game,
+        "sponsor_2025-06-01",
+        "respond",
+        "accept",
+    );
+
+    assert!(first.is_some());
+    assert!(second.is_some());
+    assert_eq!(
+        game.messages
+            .iter()
+            .filter(|message| message.id
+                == "finance:sponsor-accepted:team1:Acme Corp:2025-06-01:sponsorAccepted")
+            .count(),
+        1
+    );
+    let message = game
+        .messages
+        .iter()
+        .find(|message| {
+            message.id == "finance:sponsor-accepted:team1:Acme Corp:2025-06-01:sponsorAccepted"
+        })
+        .expect("accepted sponsor finance mail should exist");
+    assert_eq!(
+        message.subject_key.as_deref(),
+        Some("be.msg.finance.sponsorAccepted.subject")
+    );
+    assert_eq!(
+        message.i18n_params.get("sponsorName").map(String::as_str),
+        Some("Acme Corp")
+    );
 }
 
 #[test]
@@ -426,16 +742,22 @@ fn monthly_recurring_expenses_create_categorized_ledger_entries() {
         entry.date == "2025-06-01"
             && entry.amount == -player_wages
             && entry.kind == FinancialTransactionKind::Salary
+            && entry.source == "monthly"
+            && entry.source_id.as_deref() == Some("player-wages")
     }));
     assert!(game.teams[0].financial_ledger.iter().any(|entry| {
         entry.date == "2025-06-01"
             && entry.amount == -staff_wages
             && entry.kind == FinancialTransactionKind::StaffWage
+            && entry.source == "monthly"
+            && entry.source_id.as_deref() == Some("staff-wages")
     }));
     assert!(game.teams[0].financial_ledger.iter().any(|entry| {
         entry.date == "2025-06-01"
             && entry.amount == -upkeep
             && entry.kind == FinancialTransactionKind::FacilityUpkeep
+            && entry.source == "facility"
+            && entry.source_id.as_deref() == Some("monthly-upkeep")
     }));
 }
 
@@ -475,6 +797,59 @@ fn monthly_sponsorship_payout_is_applied_and_duration_decrements_on_monday() {
     assert_eq!(sponsorship_entries.len(), 1);
     assert_eq!(sponsorship_entries[0].date, "2025-06-01");
     assert_eq!(sponsorship_entries[0].amount, expected_sponsor_income);
+    assert_eq!(sponsorship_entries[0].source, "sponsor");
+    assert_eq!(
+        sponsorship_entries[0].source_id.as_deref(),
+        Some("Acme Corp")
+    );
+}
+
+#[test]
+fn monthly_finance_hooks_send_sponsor_upkeep_bonus_and_expiry_mail_once() {
+    let mut game = make_first_of_month_game();
+    game.teams[0].facilities = Facilities {
+        main_hub_level: 4,
+        training: 3,
+        medical: 2,
+        scouting: 1,
+        ..Default::default()
+    };
+    game.teams[0].form = vec!["W".to_string(), "D".to_string(), "W".to_string()];
+    game.teams[0].sponsorship = Some(Sponsorship {
+        sponsor_name: "Acme Corp".to_string(),
+        base_value: 120_000,
+        remaining_months: 1,
+        bonus_criteria: vec![SponsorshipBonusCriterion::UnbeatenRun {
+            required_matches: 3,
+            bonus_amount: 24_000,
+        }],
+    });
+
+    finances::process_monthly_finances(&mut game);
+    finances::process_monthly_finances(&mut game);
+
+    let finance_ids: Vec<_> = game
+        .messages
+        .iter()
+        .filter(|message| message.category == olm_core::domain::message::MessageCategory::Finance)
+        .map(|message| message.id.as_str())
+        .collect();
+
+    assert!(finance_ids.contains(&"finance:sponsor-payout:team1:2025-06-01:sponsorPayout"));
+    assert!(finance_ids.contains(&"finance:sponsor-bonus:team1:Acme Corp:2025-06-01:sponsorBonus"));
+    assert!(
+        finance_ids.contains(&"finance:sponsor-expired:team1:Acme Corp:2025-06-01:sponsorExpired")
+    );
+    assert!(finance_ids.contains(&"finance:facility-upkeep:team1:2025-06-01:facilityUpkeepSummary"));
+    assert!(
+        finance_ids.contains(&"finance:facility-upkeep-spike:team1:2025-06-01:facilityUpkeepSpike")
+    );
+
+    let sponsor_payout_count = finance_ids
+        .iter()
+        .filter(|id| **id == "finance:sponsor-payout:team1:2025-06-01:sponsorPayout")
+        .count();
+    assert_eq!(sponsor_payout_count, 1);
 }
 
 #[test]

--- a/src-tauri/crates/olm_core/tests/transfers_tests.rs
+++ b/src-tauri/crates/olm_core/tests/transfers_tests.rs
@@ -639,6 +639,12 @@ fn release_player_contract_records_release_penalty_ledger_entry() {
         FinancialTransactionKind::ReleasePenalty
     );
     assert_eq!(team.financial_ledger[0].amount, -48_000);
+    assert_eq!(team.financial_ledger[0].date, "2026-08-01");
+    assert_eq!(team.financial_ledger[0].source, "transfer");
+    assert_eq!(
+        team.financial_ledger[0].source_id.as_deref(),
+        Some("player-release")
+    );
     assert!(released.team_id.is_none());
     assert_eq!(released.wage, 0);
 }
@@ -690,6 +696,12 @@ fn accepting_pending_offer_executes_transfer_even_for_reluctant_player() {
         FinancialTransactionKind::TransferSale
     );
     assert_eq!(seller.financial_ledger[0].amount, 950_000);
+    assert_eq!(seller.financial_ledger[0].date, "2026-08-01");
+    assert_eq!(seller.financial_ledger[0].source, "transfer");
+    assert_eq!(
+        seller.financial_ledger[0].source_id.as_deref(),
+        Some("player-accept-reluctant")
+    );
     assert_eq!(buyer.finance, 5_050_000);
     assert_eq!(buyer.transfer_budget, 2_050_000);
     assert_eq!(buyer.financial_ledger.len(), 1);
@@ -698,6 +710,12 @@ fn accepting_pending_offer_executes_transfer_even_for_reluctant_player() {
         FinancialTransactionKind::TransferPurchase
     );
     assert_eq!(buyer.financial_ledger[0].amount, -950_000);
+    assert_eq!(buyer.financial_ledger[0].date, "2026-08-01");
+    assert_eq!(buyer.financial_ledger[0].source, "transfer");
+    assert_eq!(
+        buyer.financial_ledger[0].source_id.as_deref(),
+        Some("player-accept-reluctant")
+    );
 }
 
 #[test]

--- a/src-tauri/src/commands/academy.rs
+++ b/src-tauri/src/commands/academy.rs
@@ -302,8 +302,11 @@ pub(crate) fn acquire_academy_team_in_game(
                 kind: olm_core::domain::team::FinancialTransactionKind::AcademyAcquisition,
                 budget_impact: BudgetImpact::None,
                 affects_season_totals: true,
+                source: "academy".to_string(),
+                source_id: Some(academy_id.clone()),
+                correlation_id: Some(format!("academy-acquisition:{}:{}", request.parent_team_id, academy_id)),
             },
-        );
+        ).map_err(|err| format!("Failed to record academy acquisition: {err:?}"))?;
         parent.academy_team_id = Some(academy_id.clone());
     }
 
@@ -720,5 +723,4 @@ mod tests {
         );
     }
 }
-
 

--- a/src-tauri/src/commands/club.rs
+++ b/src-tauri/src/commands/club.rs
@@ -41,13 +41,14 @@ fn upgrade_facility_internal(state: &StateManager, facility: &str) -> Result<Gam
         _ => return Err(format!("Unknown facility type: {}", facility)),
     };
 
+    let today = game.clock.current_date.format("%Y-%m-%d").to_string();
     let team = game
         .teams
         .iter_mut()
         .find(|team| team.id == team_id)
         .ok_or("Managed team not found".to_string())?;
 
-    olm_core::club::upgrade_facility(team, facility_type)?;
+    olm_core::club::upgrade_facility(team, facility_type, &today)?;
 
     state.set_game(game.clone());
     Ok(game)
@@ -78,13 +79,14 @@ fn upgrade_main_facility_module_internal(
         _ => return Err(format!("Unknown facility module: {}", module)),
     };
 
+    let today = game.clock.current_date.format("%Y-%m-%d").to_string();
     let team = game
         .teams
         .iter_mut()
         .find(|team| team.id == team_id)
         .ok_or("Managed team not found".to_string())?;
 
-    olm_core::club::upgrade_main_facility_module(team, module_kind)?;
+    olm_core::club::upgrade_main_facility_module(team, module_kind, &today)?;
 
     state.set_game(game.clone());
     Ok(game)
@@ -102,13 +104,14 @@ fn expand_main_facility_hub_internal(state: &StateManager) -> Result<Game, Strin
         .clone()
         .ok_or("No team assigned".to_string())?;
 
+    let today = game.clock.current_date.format("%Y-%m-%d").to_string();
     let team = game
         .teams
         .iter_mut()
         .find(|team| team.id == team_id)
         .ok_or("Managed team not found".to_string())?;
 
-    olm_core::club::expand_main_facility_hub(team)?;
+    olm_core::club::expand_main_facility_hub(team, &today)?;
 
     state.set_game(game.clone());
     Ok(game)
@@ -178,5 +181,4 @@ mod tests {
         assert_eq!(stored_team.finance, 750_000);
     }
 }
-
 

--- a/src-tauri/src/commands/staff.rs
+++ b/src-tauri/src/commands/staff.rs
@@ -71,8 +71,11 @@ fn hire_staff_internal(state: &StateManager, staff_id: &str) -> Result<Game, Str
                 kind: FinancialTransactionKind::StaffWage,
                 budget_impact: BudgetImpact::None,
                 affects_season_totals: true,
+                source: "staff".to_string(),
+                source_id: Some(staff.id.clone()),
+                correlation_id: Some(format!("staff-hire:{}:{}", team_id, staff.id)),
             },
-        );
+        ).map_err(|err| format!("Failed to record staff hiring transaction: {err:?}"))?;
     }
 
     state.set_game(game.clone());

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1330,6 +1330,15 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Aktuelle Buchungen",
+    "ledgerSearchLabel": "Buchungen suchen",
+    "ledgerSearchPlaceholder": "Transaktionen suchen",
+    "ledgerKindFilter": "Transaktionstyp",
+    "ledgerSourceFilter": "Quelle",
+    "ledgerAllKinds": "Alle Typen",
+    "ledgerAllSources": "Alle Quellen",
+    "ledgerRunningBalance": "Saldo",
+    "ledgerNoMatches": "Keine Transaktionen entsprechen den Filtern.",
+    "ledgerSource": { "legacy": "Altbestand", "monthly": "Monatlich", "transfer": "Transfer", "staff": "Staff", "academy": "Akademie", "facility": "Einrichtungen", "sponsor": "Sponsor", "prize": "Prämie", "board": "Vorstand", "manual": "Manuell" },
     "ledgerEmpty": "Noch keine Finanzbuchungen vorhanden."
   },
   "inbox": {
@@ -2614,11 +2623,21 @@
       },
       "financeWarning": {
         "subject": "Finanzwarnung — Niedrige Rücklagen",
-        "body": "Unsere finanziellen Rücklagen werden knapp. Beim aktuellen Ausgabentempo (€{{annualWages}}/Jahr an Gehältern) bleiben uns noch ungefähr {{weeksLeft}} Wochen an Reserven.\n\nIch würde empfehlen, die Gehaltsstruktur zu überprüfen und Wege zur Einnahmesteigerung zu suchen."
+        "body": "Unsere finanziellen Rücklagen werden knapp. Beim aktuellen Ausgabentempo (€{{annualWages}}/Jahr an Gehältern) bleiben uns noch ungefähr {{monthsLeft}} Monate an Reserven.\n\nIch würde empfehlen, die Gehaltsstruktur zu überprüfen und Wege zur Einnahmesteigerung zu suchen."
       },
       "wageOverBudget": {
         "subject": "Gehaltsbudget überschritten",
         "body": "Unsere jährlichen Gehaltskosten (€{{annualWages}}) übersteigen derzeit das vorgesehene Gehaltsbudget (€{{wageBudget}}).\n\nKurzfristig ist das noch tragbar, aber der Vorstand würde die Gehaltskosten lieber wieder unter Kontrolle sehen."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Sponsoringvertrag unterzeichnet", "body": "Das Sponsoring von {{sponsorName}} wurde angenommen. Der Vertrag hat einen Jahreswert von €{{amount}} und wird monatlich ausgezahlt." },
+        "sponsorPayout": { "subject": "Sponsoringzahlung erhalten", "body": "{{sponsorName}} hat diesen Monat €{{amount}} auf das Vereinskonto überwiesen." },
+        "sponsorBonus": { "subject": "Sponsoringbonus ausgelöst", "body": "Die Bonuskriterien von {{sponsorName}} wurden erfüllt. €{{bonusAmount}} sind in der monatlichen Sponsoringzahlung von €{{totalAmount}} enthalten." },
+        "sponsorExpired": { "subject": "Sponsoringvertrag ausgelaufen", "body": "Das Sponsoring von {{sponsorName}} ist beendet. Prüfe den Markt auf einen Ersatzvertrag." },
+        "facilityUpkeepSummary": { "subject": "Anlagenunterhalt bezahlt", "body": "Der monatliche Anlagenunterhalt von €{{amount}} wurde vom Vereinskonto bezahlt." },
+        "facilityUpkeepSpike": { "subject": "Anstieg beim Anlagenunterhalt", "body": "Der Anlagenunterhalt erreichte diesen Monat €{{amount}}. Jüngste Ausbauten erhöhen die Betriebskosten." },
+        "prizePayout": { "subject": "Preisgeld bestätigt", "body": "Für Saison {{season}} wurden €{{amount}} Preisgeld für Platz {{position}} zugesprochen." },
+        "boardFinancialHealth": { "subject": "Finanzübersicht des Vorstands", "body": "Aktueller Kontostand: €{{balance}}. Monatlicher Nettotrend: €{{monthlyNet}}. Geschätzte Reichweite: {{monthsLeft}} Monate." }
       },
       "seasonPayout": {
         "subject": "Saison {{season}} — Preisgeld ausgezahlt",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1456,6 +1456,26 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Recent Ledger",
+    "ledgerSearchLabel": "Search ledger",
+    "ledgerSearchPlaceholder": "Search transactions",
+    "ledgerKindFilter": "Transaction type",
+    "ledgerSourceFilter": "Source",
+    "ledgerAllKinds": "All types",
+    "ledgerAllSources": "All sources",
+    "ledgerRunningBalance": "Balance",
+    "ledgerNoMatches": "No transactions match your filters.",
+    "ledgerSource": {
+      "legacy": "Legacy",
+      "monthly": "Monthly",
+      "transfer": "Transfer",
+      "staff": "Staff",
+      "academy": "Academy",
+      "facility": "Facility",
+      "sponsor": "Sponsor",
+      "prize": "Prize",
+      "board": "Board",
+      "manual": "Manual"
+    },
     "ledgerEmpty": "No financial ledger entries yet."
   },
   "inbox": {
@@ -2753,11 +2773,45 @@
       },
       "financeWarning": {
         "subject": "Financial Warning — Low Reserves",
-        "body": "Our financial reserves are running low. At the current burn rate (€{{annualWages}}/year in wages), we have approximately {{weeksLeft}} weeks of funding remaining.\n\nI'd recommend reviewing the wage bill and exploring ways to boost income."
+        "body": "Our financial reserves are running low. At the current burn rate (€{{annualWages}}/year in wages), we have approximately {{monthsLeft}} months of funding remaining.\n\nI'd recommend reviewing the wage bill and exploring ways to boost income."
       },
       "wageOverBudget": {
         "subject": "Wage Bill Exceeds Budget",
         "body": "Our annual wage bill (€{{annualWages}}) currently exceeds the allocated wage budget (€{{wageBudget}}).\n\nWhile we can sustain this in the short term, the board would prefer to see the wage bill brought under control."
+      },
+      "finance": {
+        "sponsorAccepted": {
+          "subject": "Sponsorship Deal Signed",
+          "body": "The {{sponsorName}} sponsorship has been accepted. The deal is worth €{{amount}} annually and will be paid monthly."
+        },
+        "sponsorPayout": {
+          "subject": "Sponsorship Payment Received",
+          "body": "{{sponsorName}} has paid €{{amount}} into the club account this month."
+        },
+        "sponsorBonus": {
+          "subject": "Sponsorship Bonus Triggered",
+          "body": "{{sponsorName}} bonus criteria were met. €{{bonusAmount}} was included in this month's €{{totalAmount}} sponsorship payment."
+        },
+        "sponsorExpired": {
+          "subject": "Sponsorship Deal Expired",
+          "body": "The {{sponsorName}} sponsorship has ended. Review the market for a replacement deal."
+        },
+        "facilityUpkeepSummary": {
+          "subject": "Facility Upkeep Paid",
+          "body": "Monthly facility upkeep of €{{amount}} has been paid from the club account."
+        },
+        "facilityUpkeepSpike": {
+          "subject": "Facility Upkeep Spike",
+          "body": "Facility upkeep reached €{{amount}} this month. Recent upgrades are increasing operating costs."
+        },
+        "prizePayout": {
+          "subject": "Prize Money Confirmed",
+          "body": "Season {{season}} prize money of €{{amount}} has been awarded for finishing {{position}}."
+        },
+        "boardFinancialHealth": {
+          "subject": "Board Financial Health Summary",
+          "body": "Current balance: €{{balance}}. Monthly net trend: €{{monthlyNet}}. Estimated runway: {{monthsLeft}} months."
+        }
       },
       "seasonPayout": {
         "subject": "Season {{season}} Prize Money Awarded",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1457,6 +1457,15 @@
     "staffWages": "Salarios del staff",
     "standardSponsor": "Patrocinador estándar",
     "recentLedger": "Movimientos recientes",
+    "ledgerSearchLabel": "Buscar movimientos",
+    "ledgerSearchPlaceholder": "Buscar transacciones",
+    "ledgerKindFilter": "Tipo de transacción",
+    "ledgerSourceFilter": "Origen",
+    "ledgerAllKinds": "Todos los tipos",
+    "ledgerAllSources": "Todos los orígenes",
+    "ledgerRunningBalance": "Saldo",
+    "ledgerNoMatches": "Ninguna transacción coincide con los filtros.",
+    "ledgerSource": { "legacy": "Legado", "monthly": "Mensual", "transfer": "Transferencia", "staff": "Staff", "academy": "Academia", "facility": "Instalaciones", "sponsor": "Patrocinador", "prize": "Premio", "board": "Directiva", "manual": "Manual" },
     "ledgerEmpty": "Todavía no hay movimientos financieros."
   },
   "inbox": {
@@ -2754,11 +2763,21 @@
       },
       "financeWarning": {
         "subject": "Aviso financiero — Reservas bajas",
-        "body": "Nuestras reservas financieras se están agotando. Al ritmo actual de gasto (€{{annualWages}}/año en salarios), nos quedan aproximadamente {{weeksLeft}} semanas de fondos.\n\nTe recomendaría revisar la masa salarial y buscar formas de aumentar los ingresos."
+        "body": "Nuestras reservas financieras se están agotando. Al ritmo actual de gasto (€{{annualWages}}/año en salarios), nos quedan aproximadamente {{monthsLeft}} meses de fondos.\n\nTe recomendaría revisar la masa salarial y buscar formas de aumentar los ingresos."
       },
       "wageOverBudget": {
         "subject": "La masa salarial supera el presupuesto",
         "body": "Nuestra masa salarial anual (€{{annualWages}}) supera actualmente el presupuesto salarial asignado (€{{wageBudget}}).\n\nAunque podemos sostenerlo a corto plazo, la directiva preferiría ver la masa salarial bajo control."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Acuerdo de patrocinio firmado", "body": "Se aceptó el patrocinio de {{sponsorName}}. El acuerdo vale €{{amount}} al año y se pagará mensualmente." },
+        "sponsorPayout": { "subject": "Pago de patrocinio recibido", "body": "{{sponsorName}} ingresó €{{amount}} en la cuenta del club este mes." },
+        "sponsorBonus": { "subject": "Bonus de patrocinio activado", "body": "Se cumplieron los criterios de bonus de {{sponsorName}}. €{{bonusAmount}} se incluyeron en el pago mensual de patrocinio de €{{totalAmount}}." },
+        "sponsorExpired": { "subject": "Patrocinio finalizado", "body": "El patrocinio de {{sponsorName}} ha terminado. Revisa el mercado para encontrar un reemplazo." },
+        "facilityUpkeepSummary": { "subject": "Mantenimiento de instalaciones pagado", "body": "Se pagaron €{{amount}} de mantenimiento mensual de instalaciones desde la cuenta del club." },
+        "facilityUpkeepSpike": { "subject": "Subida de mantenimiento de instalaciones", "body": "El mantenimiento de instalaciones llegó a €{{amount}} este mes. Las mejoras recientes están aumentando los costes operativos." },
+        "prizePayout": { "subject": "Premio económico confirmado", "body": "Se concedieron €{{amount}} de premio de la temporada {{season}} por terminar en la posición {{position}}." },
+        "boardFinancialHealth": { "subject": "Resumen financiero de la directiva", "body": "Balance actual: €{{balance}}. Tendencia neta mensual: €{{monthlyNet}}. Autonomía estimada: {{monthsLeft}} meses." }
       },
       "seasonPayout": {
         "subject": "Temporada {{season}} — Premio económico concedido",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1330,6 +1330,15 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Journal récent",
+    "ledgerSearchLabel": "Rechercher dans le journal",
+    "ledgerSearchPlaceholder": "Rechercher des transactions",
+    "ledgerKindFilter": "Type de transaction",
+    "ledgerSourceFilter": "Source",
+    "ledgerAllKinds": "Tous les types",
+    "ledgerAllSources": "Toutes les sources",
+    "ledgerRunningBalance": "Solde",
+    "ledgerNoMatches": "Aucune transaction ne correspond aux filtres.",
+    "ledgerSource": { "legacy": "Héritage", "monthly": "Mensuel", "transfer": "Transfert", "staff": "Staff", "academy": "Académie", "facility": "Installations", "sponsor": "Sponsor", "prize": "Prime", "board": "Direction", "manual": "Manuel" },
     "ledgerEmpty": "Aucune écriture financière pour le moment."
   },
   "inbox": {
@@ -2614,11 +2623,21 @@
       },
       "financeWarning": {
         "subject": "Alerte financière — Réserves faibles",
-        "body": "Nos réserves financières diminuent rapidement. Au rythme actuel des dépenses (€{{annualWages}}/an en salaires), il nous reste environ {{weeksLeft}} semaines de marge.\n\nJe vous recommande de revoir la masse salariale et d'explorer des moyens d'augmenter les revenus."
+        "body": "Nos réserves financières diminuent rapidement. Au rythme actuel des dépenses (€{{annualWages}}/an en salaires), il nous reste environ {{monthsLeft}} mois de marge.\n\nJe vous recommande de revoir la masse salariale et d'explorer des moyens d'augmenter les revenus."
       },
       "wageOverBudget": {
         "subject": "La masse salariale dépasse le budget",
         "body": "Notre masse salariale annuelle (€{{annualWages}}) dépasse actuellement le budget salarial alloué (€{{wageBudget}}).\n\nMême si cela reste soutenable à court terme, le conseil préférerait voir la masse salariale revenir sous contrôle."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Contrat de sponsoring signé", "body": "Le sponsoring {{sponsorName}} a été accepté. Le contrat vaut €{{amount}} par an et sera versé mensuellement." },
+        "sponsorPayout": { "subject": "Paiement de sponsoring reçu", "body": "{{sponsorName}} a versé €{{amount}} sur le compte du club ce mois-ci." },
+        "sponsorBonus": { "subject": "Bonus de sponsoring déclenché", "body": "Les critères de bonus de {{sponsorName}} ont été remplis. €{{bonusAmount}} sont inclus dans le paiement mensuel de €{{totalAmount}}." },
+        "sponsorExpired": { "subject": "Contrat de sponsoring expiré", "body": "Le sponsoring {{sponsorName}} est terminé. Consultez le marché pour trouver un remplaçant." },
+        "facilityUpkeepSummary": { "subject": "Entretien des installations payé", "body": "L'entretien mensuel des installations de €{{amount}} a été payé depuis le compte du club." },
+        "facilityUpkeepSpike": { "subject": "Hausse de l'entretien des installations", "body": "L'entretien des installations atteint €{{amount}} ce mois-ci. Les améliorations récentes augmentent les coûts d'exploitation." },
+        "prizePayout": { "subject": "Prime confirmée", "body": "La prime de la saison {{season}} de €{{amount}} a été attribuée pour la place {{position}}." },
+        "boardFinancialHealth": { "subject": "Résumé financier du conseil", "body": "Solde actuel : €{{balance}}. Tendance nette mensuelle : €{{monthlyNet}}. Trésorerie estimée : {{monthsLeft}} mois." }
       },
       "seasonPayout": {
         "subject": "Saison {{season}} — Prime attribuée",

--- a/src/i18n/locales/guard.test.ts
+++ b/src/i18n/locales/guard.test.ts
@@ -194,3 +194,67 @@ describe("i18n locale football guard", () => {
     });
   }
 });
+
+function getValueByPath(localeData: LocaleTree, path: string): unknown {
+  return path.split(".").reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== "object") return undefined;
+    return (current as Record<string, unknown>)[segment];
+  }, localeData);
+}
+
+describe("finance ledger locale parity", () => {
+  const financeLedgerKeys = [
+    "finances.ledgerSearchLabel",
+    "finances.ledgerSearchPlaceholder",
+    "finances.ledgerKindFilter",
+    "finances.ledgerSourceFilter",
+    "finances.ledgerAllKinds",
+    "finances.ledgerAllSources",
+    "finances.ledgerRunningBalance",
+    "finances.ledgerNoMatches",
+    "finances.ledgerSource.legacy",
+    "finances.ledgerSource.monthly",
+    "finances.ledgerSource.transfer",
+    "finances.ledgerSource.staff",
+    "finances.ledgerSource.academy",
+    "finances.ledgerSource.facility",
+    "finances.ledgerSource.sponsor",
+    "finances.ledgerSource.prize",
+    "finances.ledgerSource.board",
+    "finances.ledgerSource.manual",
+    "be.msg.finance.sponsorAccepted.subject",
+    "be.msg.finance.sponsorAccepted.body",
+    "be.msg.finance.sponsorPayout.subject",
+    "be.msg.finance.sponsorPayout.body",
+    "be.msg.finance.sponsorBonus.subject",
+    "be.msg.finance.sponsorBonus.body",
+    "be.msg.finance.sponsorExpired.subject",
+    "be.msg.finance.sponsorExpired.body",
+    "be.msg.finance.facilityUpkeepSummary.subject",
+    "be.msg.finance.facilityUpkeepSummary.body",
+    "be.msg.finance.facilityUpkeepSpike.subject",
+    "be.msg.finance.facilityUpkeepSpike.body",
+    "be.msg.finance.prizePayout.subject",
+    "be.msg.finance.prizePayout.body",
+    "be.msg.finance.boardFinancialHealth.subject",
+    "be.msg.finance.boardFinancialHealth.body",
+  ];
+
+  for (const [localeCode, localeData] of Object.entries(LOCALE_RESOURCES)) {
+    itTest(`includes finance ledger keys in ${localeCode}`, () => {
+      const missing = financeLedgerKeys.filter((key) => typeof getValueByPath(localeData, key) !== "string");
+
+      expect(missing, `Missing finance ledger keys in ${localeCode}`).toEqual([]);
+    });
+  }
+
+  itTest("uses monthsLeft, not weeksLeft, for finance warning interpolation", () => {
+    for (const [localeCode, localeData] of Object.entries(LOCALE_RESOURCES)) {
+      const body = getValueByPath(localeData, "be.msg.financeWarning.body");
+
+      expect(body, `financeWarning body missing in ${localeCode}`).toEqual(expect.any(String));
+      expect(body as string, `financeWarning should interpolate monthsLeft in ${localeCode}`).toContain("{{monthsLeft}}");
+      expect(body as string, `financeWarning should not interpolate weeksLeft in ${localeCode}`).not.toContain("{{weeksLeft}}");
+    }
+  });
+});

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1186,6 +1186,15 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Registro recente",
+    "ledgerSearchLabel": "Cerca nel registro",
+    "ledgerSearchPlaceholder": "Cerca transazioni",
+    "ledgerKindFilter": "Tipo di transazione",
+    "ledgerSourceFilter": "Fonte",
+    "ledgerAllKinds": "Tutti i tipi",
+    "ledgerAllSources": "Tutte le fonti",
+    "ledgerRunningBalance": "Saldo",
+    "ledgerNoMatches": "Nessuna transazione corrisponde ai filtri.",
+    "ledgerSource": { "legacy": "Legacy", "monthly": "Mensile", "transfer": "Trasferimento", "staff": "Staff", "academy": "Academy", "facility": "Strutture", "sponsor": "Sponsor", "prize": "Premio", "board": "Direzione", "manual": "Manuale" },
     "ledgerEmpty": "Nessun movimento finanziario registrato."
   },
   "inbox": {
@@ -2416,11 +2425,21 @@
       },
       "financeWarning": {
         "subject": "Avviso finanziario — Riserve basse",
-        "body": "Le nostre riserve finanziarie si stanno assottigliando. Al ritmo attuale di spesa (€{{annualWages}}/anno di stipendi), abbiamo circa {{weeksLeft}} settimane di copertura rimanenti.\n\nTi consiglierei di rivedere il monte ingaggi e cercare modi per aumentare le entrate."
+        "body": "Le nostre riserve finanziarie si stanno assottigliando. Al ritmo attuale di spesa (€{{annualWages}}/anno di stipendi), abbiamo circa {{monthsLeft}} mesi di copertura rimanenti.\n\nTi consiglierei di rivedere il monte ingaggi e cercare modi per aumentare le entrate."
       },
       "wageOverBudget": {
         "subject": "Monte ingaggi oltre il budget",
         "body": "Il nostro monte ingaggi annuale (€{{annualWages}}) supera attualmente il budget stipendi assegnato (€{{wageBudget}}).\n\nAnche se possiamo sostenerlo nel breve periodo, il consiglio preferirebbe vedere il monte ingaggi tornare sotto controllo."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Accordo di sponsorizzazione firmato", "body": "La sponsorizzazione {{sponsorName}} è stata accettata. L'accordo vale €{{amount}} all'anno e verrà pagato mensilmente." },
+        "sponsorPayout": { "subject": "Pagamento sponsor ricevuto", "body": "{{sponsorName}} ha versato €{{amount}} sul conto del club questo mese." },
+        "sponsorBonus": { "subject": "Bonus sponsor attivato", "body": "I criteri bonus di {{sponsorName}} sono stati raggiunti. €{{bonusAmount}} sono inclusi nel pagamento mensile di €{{totalAmount}}." },
+        "sponsorExpired": { "subject": "Sponsorizzazione scaduta", "body": "La sponsorizzazione {{sponsorName}} è terminata. Controlla il mercato per trovare un sostituto." },
+        "facilityUpkeepSummary": { "subject": "Manutenzione strutture pagata", "body": "La manutenzione mensile delle strutture di €{{amount}} è stata pagata dal conto del club." },
+        "facilityUpkeepSpike": { "subject": "Aumento manutenzione strutture", "body": "La manutenzione delle strutture ha raggiunto €{{amount}} questo mese. I miglioramenti recenti stanno aumentando i costi operativi." },
+        "prizePayout": { "subject": "Premio confermato", "body": "Il premio della stagione {{season}} di €{{amount}} è stato assegnato per la posizione {{position}}." },
+        "boardFinancialHealth": { "subject": "Riepilogo finanziario del consiglio", "body": "Saldo attuale: €{{balance}}. Tendenza netta mensile: €{{monthlyNet}}. Autonomia stimata: {{monthsLeft}} mesi." }
       },
       "seasonPayout": {
         "subject": "Stagione {{season}} — Premio assegnato",

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -1330,6 +1330,15 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Registro recente",
+    "ledgerSearchLabel": "Pesquisar registro",
+    "ledgerSearchPlaceholder": "Pesquisar transações",
+    "ledgerKindFilter": "Tipo de transação",
+    "ledgerSourceFilter": "Origem",
+    "ledgerAllKinds": "Todos os tipos",
+    "ledgerAllSources": "Todas as origens",
+    "ledgerRunningBalance": "Saldo",
+    "ledgerNoMatches": "Nenhuma transação corresponde aos filtros.",
+    "ledgerSource": { "legacy": "Legado", "monthly": "Mensal", "transfer": "Transferência", "staff": "Staff", "academy": "Academia", "facility": "Instalações", "sponsor": "Patrocinador", "prize": "Prêmio", "board": "Diretoria", "manual": "Manual" },
     "ledgerEmpty": "Ainda não há movimentações financeiras."
   },
   "inbox": {
@@ -2614,11 +2623,21 @@
       },
       "financeWarning": {
         "subject": "Alerta Financeiro — Reservas Baixas",
-        "body": "Nossas reservas financeiras estão acabando. No ritmo atual de gastos (€{{annualWages}}/ano em salários), temos aproximadamente {{weeksLeft}} semanas de recursos restantes.\n\nEu recomendaria revisar a folha salarial e buscar formas de aumentar a receita."
+        "body": "Nossas reservas financeiras estão acabando. No ritmo atual de gastos (€{{annualWages}}/ano em salários), temos aproximadamente {{monthsLeft}} meses de recursos restantes.\n\nEu recomendaria revisar a folha salarial e buscar formas de aumentar a receita."
       },
       "wageOverBudget": {
         "subject": "Folha Salarial Acima do Orçamento",
         "body": "Nossa folha salarial anual (€{{annualWages}}) atualmente excede o orçamento salarial definido (€{{wageBudget}}).\n\nEmbora possamos sustentar isso no curto prazo, a diretoria prefere ver a folha salarial sob controle."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Acordo de patrocínio assinado", "body": "O patrocínio {{sponsorName}} foi aceito. O acordo vale €{{amount}} por ano e será pago mensalmente." },
+        "sponsorPayout": { "subject": "Pagamento de patrocínio recebido", "body": "{{sponsorName}} depositou €{{amount}} na conta do clube este mês." },
+        "sponsorBonus": { "subject": "Bônus de patrocínio ativado", "body": "Os critérios de bônus de {{sponsorName}} foram cumpridos. €{{bonusAmount}} foram incluídos no pagamento mensal de €{{totalAmount}}." },
+        "sponsorExpired": { "subject": "Patrocínio encerrado", "body": "O patrocínio {{sponsorName}} terminou. Consulte o mercado para encontrar uma substituição." },
+        "facilityUpkeepSummary": { "subject": "Manutenção das instalações paga", "body": "A manutenção mensal das instalações de €{{amount}} foi paga pela conta do clube." },
+        "facilityUpkeepSpike": { "subject": "Alta na manutenção das instalações", "body": "A manutenção das instalações chegou a €{{amount}} este mês. As melhorias recentes estão aumentando os custos operacionais." },
+        "prizePayout": { "subject": "Premiação confirmada", "body": "A premiação da temporada {{season}} de €{{amount}} foi concedida pela posição {{position}}." },
+        "boardFinancialHealth": { "subject": "Resumo financeiro da diretoria", "body": "Saldo atual: €{{balance}}. Tendência líquida mensal: €{{monthlyNet}}. Autonomia estimada: {{monthsLeft}} meses." }
       },
       "seasonPayout": {
         "subject": "Temporada {{season}} — Premiação concedida",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1329,6 +1329,15 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Registo recente",
+    "ledgerSearchLabel": "Pesquisar registo",
+    "ledgerSearchPlaceholder": "Pesquisar transações",
+    "ledgerKindFilter": "Tipo de transação",
+    "ledgerSourceFilter": "Origem",
+    "ledgerAllKinds": "Todos os tipos",
+    "ledgerAllSources": "Todas as origens",
+    "ledgerRunningBalance": "Saldo",
+    "ledgerNoMatches": "Nenhuma transação corresponde aos filtros.",
+    "ledgerSource": { "legacy": "Legado", "monthly": "Mensal", "transfer": "Transferência", "staff": "Staff", "academy": "Academia", "facility": "Instalações", "sponsor": "Patrocinador", "prize": "Prémio", "board": "Direção", "manual": "Manual" },
     "ledgerEmpty": "Ainda não há movimentos financeiros."
   },
   "inbox": {
@@ -2613,11 +2622,21 @@
       },
       "financeWarning": {
         "subject": "Aviso financeiro — Reservas baixas",
-        "body": "As nossas reservas financeiras estão a diminuir. Ao ritmo atual de despesa (€{{annualWages}}/ano em salários), temos aproximadamente {{weeksLeft}} semanas de margem.\n\nRecomendaria rever a folha salarial e procurar formas de aumentar a receita."
+        "body": "As nossas reservas financeiras estão a diminuir. Ao ritmo atual de despesa (€{{annualWages}}/ano em salários), temos aproximadamente {{monthsLeft}} meses de margem.\n\nRecomendaria rever a folha salarial e procurar formas de aumentar a receita."
       },
       "wageOverBudget": {
         "subject": "Folha salarial acima do orçamento",
         "body": "A nossa folha salarial anual (€{{annualWages}}) excede atualmente o orçamento salarial atribuído (€{{wageBudget}}).\n\nEmbora seja sustentável a curto prazo, a direção preferia ver a folha salarial novamente sob controlo."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Acordo de patrocínio assinado", "body": "O patrocínio {{sponsorName}} foi aceite. O acordo vale €{{amount}} por ano e será pago mensalmente." },
+        "sponsorPayout": { "subject": "Pagamento de patrocínio recebido", "body": "{{sponsorName}} depositou €{{amount}} na conta do clube este mês." },
+        "sponsorBonus": { "subject": "Bónus de patrocínio ativado", "body": "Os critérios de bónus de {{sponsorName}} foram cumpridos. €{{bonusAmount}} foram incluídos no pagamento mensal de €{{totalAmount}}." },
+        "sponsorExpired": { "subject": "Patrocínio expirado", "body": "O patrocínio {{sponsorName}} terminou. Consulta o mercado para encontrar uma substituição." },
+        "facilityUpkeepSummary": { "subject": "Manutenção das instalações paga", "body": "A manutenção mensal das instalações de €{{amount}} foi paga a partir da conta do clube." },
+        "facilityUpkeepSpike": { "subject": "Aumento da manutenção das instalações", "body": "A manutenção das instalações chegou a €{{amount}} este mês. As melhorias recentes estão a aumentar os custos operacionais." },
+        "prizePayout": { "subject": "Prémio confirmado", "body": "O prémio da temporada {{season}} de €{{amount}} foi atribuído pela posição {{position}}." },
+        "boardFinancialHealth": { "subject": "Resumo financeiro da direção", "body": "Saldo atual: €{{balance}}. Tendência líquida mensal: €{{monthlyNet}}. Autonomia estimada: {{monthsLeft}} meses." }
       },
       "seasonPayout": {
         "subject": "Época {{season}} — Prémio atribuído",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1330,6 +1330,15 @@
     "staffWages": "Staff Wages",
     "standardSponsor": "Standard Sponsor",
     "recentLedger": "Son Kayıtlar",
+    "ledgerSearchLabel": "Kayıtlarda ara",
+    "ledgerSearchPlaceholder": "İşlem ara",
+    "ledgerKindFilter": "İşlem türü",
+    "ledgerSourceFilter": "Kaynak",
+    "ledgerAllKinds": "Tüm türler",
+    "ledgerAllSources": "Tüm kaynaklar",
+    "ledgerRunningBalance": "Bakiye",
+    "ledgerNoMatches": "Filtrelerle eşleşen işlem yok.",
+    "ledgerSource": { "legacy": "Eski", "monthly": "Aylık", "transfer": "Transfer", "staff": "Staff", "academy": "Akademi", "facility": "Tesis", "sponsor": "Sponsor", "prize": "Ödül", "board": "Yönetim", "manual": "Manuel" },
     "ledgerEmpty": "Henüz finansal kayıt yok."
   },
   "inbox": {
@@ -2614,11 +2623,21 @@
       },
       "financeWarning": {
         "subject": "Finansal Uyarı — Düşük Rezervler",
-        "body": "Finansal rezervlerimiz tükeniyor. Mevcut harcama hızıyla (yıllık €{{annualWages}} maaş), yaklaşık {{weeksLeft}} haftalık fonumuz kaldı.\n\nMaaş bordrosunu gözden geçirmenizi ve geliri artırmanın yollarını aramanızı tavsiye ederim."
+        "body": "Finansal rezervlerimiz tükeniyor. Mevcut harcama hızıyla (yıllık €{{annualWages}} maaş), yaklaşık {{monthsLeft}} aylık fonumuz kaldı.\n\nMaaş bordrosunu gözden geçirmenizi ve geliri artırmanın yollarını aramanızı tavsiye ederim."
       },
       "wageOverBudget": {
         "subject": "Maaş Gideri Bütçeyi Aşıyor",
         "body": "Yıllık maaş faturamız (€{{annualWages}}) şu anda ayrılan maaş bütçesini (€{{wageBudget}}) aşıyor.\n\nKısa vadede bunu sürdürebilsek de, yönetim maaş giderinin kontrol altına alınmasını tercih eder."
+      },
+      "finance": {
+        "sponsorAccepted": { "subject": "Sponsorluk anlaşması imzalandı", "body": "{{sponsorName}} sponsorluğu kabul edildi. Anlaşmanın yıllık değeri €{{amount}} ve aylık olarak ödenecek." },
+        "sponsorPayout": { "subject": "Sponsorluk ödemesi alındı", "body": "{{sponsorName}} bu ay kulüp hesabına €{{amount}} yatırdı." },
+        "sponsorBonus": { "subject": "Sponsorluk bonusu tetiklendi", "body": "{{sponsorName}} bonus kriterleri karşılandı. Bu ayki €{{totalAmount}} sponsorluk ödemesine €{{bonusAmount}} dahil edildi." },
+        "sponsorExpired": { "subject": "Sponsorluk anlaşması sona erdi", "body": "{{sponsorName}} sponsorluğu sona erdi. Yeni bir anlaşma için piyasayı kontrol edin." },
+        "facilityUpkeepSummary": { "subject": "Tesis bakım ödemesi yapıldı", "body": "€{{amount}} tutarındaki aylık tesis bakımı kulüp hesabından ödendi." },
+        "facilityUpkeepSpike": { "subject": "Tesis bakım maliyeti arttı", "body": "Tesis bakımı bu ay €{{amount}} seviyesine ulaştı. Son yükseltmeler işletme maliyetlerini artırıyor." },
+        "prizePayout": { "subject": "Ödül parası onaylandı", "body": "{{season}}. sezon için {{position}}. sıra karşılığında €{{amount}} ödül verildi." },
+        "boardFinancialHealth": { "subject": "Yönetim finansal durum özeti", "body": "Mevcut bakiye: €{{balance}}. Aylık net eğilim: €{{monthlyNet}}. Tahmini dayanma süresi: {{monthsLeft}} ay." }
       },
       "seasonPayout": {
         "subject": "Sezon {{season}} Ödül Parası Yatırıldı",

--- a/src/lib/finances/finance.test.ts
+++ b/src/lib/finances/finance.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import type { PlayerData, StaffData, TeamData } from "../../store/gameStore";
+import type { FinancialTransactionData, PlayerData, StaffData, TeamData } from "../../store/gameStore";
 import {
   annualAmountToMonthlyCommitment,
   getFinancialLedger,
+  groupLedgerEntriesByDate,
   getAnnualWageBill,
   getCashRunwayMonths,
+  getLedgerEntryBalanceAfter,
+  getLedgerEntrySourceLabelKey,
+  filterLedgerEntries,
   getSeasonNetSummary,
   getTeamFinanceSnapshot,
   getTransferBudgetSummary,
@@ -215,12 +219,18 @@ describe("finance helpers", () => {
           description: "Signed mid laner",
           amount: -250000,
           kind: "TransferPurchase",
+          balance_before: 500000,
+          balance_after: 250000,
+          source: "transfer",
         },
         {
           date: "2026-01-04",
           description: "Sold academy player",
           amount: 125000,
           kind: "TransferSale",
+          balance_before: 250000,
+          balance_after: 375000,
+          source: "transfer",
         },
       ],
     });
@@ -231,18 +241,54 @@ describe("finance helpers", () => {
         description: "Signed mid laner",
         amount: -250000,
         kind: "TransferPurchase",
+        balance_before: 500000,
+        balance_after: 250000,
+        source: "transfer",
       },
       {
         date: "2026-01-04",
         description: "Sold academy player",
         amount: 125000,
         kind: "TransferSale",
+        balance_before: 250000,
+        balance_after: 375000,
+        source: "transfer",
       },
     ]);
   });
 
   it("normalizes missing financial ledger to an empty readable history", () => {
     expect(getFinancialLedger(createTeam())).toEqual([]);
+  });
+
+  it("filters and groups ledger entries by search, kind, and source", () => {
+    const entries = [
+      { date: "2026-01-03", description: "Signed mid laner", amount: -250000, kind: "TransferPurchase", source: "transfer", balance_after: 750000 },
+      { date: "2026-01-03", description: "Sponsor payout", amount: 100000, kind: "Sponsorship", source: "sponsor", balance_after: 850000 },
+      { date: "2026-01-04", description: "Monthly salary", amount: -50000, kind: "Salary", source: "monthly", balance_after: 800000 },
+    ] as const;
+
+    const filtered = filterLedgerEntries(entries, {
+      search: "sponsor",
+      kind: "Sponsorship",
+      source: "sponsor",
+    });
+
+    expect(filtered.map((entry) => entry.description)).toEqual(["Sponsor payout"]);
+    expect(groupLedgerEntriesByDate(entries).map((group) => [group.date, group.entries.length])).toEqual([
+      ["2026-01-04", 1],
+      ["2026-01-03", 2],
+    ]);
+  });
+
+  it("provides legacy source and running balance fallbacks", () => {
+    const legacyEntry: FinancialTransactionData = { date: "2026-01-03", description: "Old save", amount: -250000, kind: "Other" };
+    const accountedEntry = { ...legacyEntry, source: "facility", balance_after: 750000 };
+
+    expect(getLedgerEntrySourceLabelKey(legacyEntry)).toBe("finances.ledgerSource.legacy");
+    expect(getLedgerEntrySourceLabelKey(accountedEntry)).toBe("finances.ledgerSource.facility");
+    expect(getLedgerEntryBalanceAfter(legacyEntry)).toBeNull();
+    expect(getLedgerEntryBalanceAfter(accountedEntry)).toBe(750000);
   });
 
   it("summarizes transfer spending against transfer budget remaining", () => {

--- a/src/lib/finances/finance.ts
+++ b/src/lib/finances/finance.ts
@@ -28,6 +28,17 @@ export interface SeasonNetSummary {
   net: number;
 }
 
+export interface LedgerFilters {
+  search: string;
+  kind: FinancialTransactionData["kind"] | "all";
+  source: string;
+}
+
+export interface LedgerDateGroup {
+  date: string;
+  entries: FinancialTransactionData[];
+}
+
 const HEALTH_PRIORITY: Record<FinanceHealthLevel, number> = {
   stable: 0,
   watch: 1,
@@ -41,6 +52,62 @@ export function safeFinanceNumber(value: unknown, fallback = 0): number {
 
 export function getFinancialLedger(team: Pick<TeamData, "financial_ledger">): FinancialTransactionData[] {
   return team.financial_ledger ?? [];
+}
+
+export function getLedgerEntrySource(entry: Pick<FinancialTransactionData, "source">): string {
+  const source = entry.source?.trim();
+  return source ? source : "legacy";
+}
+
+export function getLedgerEntrySourceLabelKey(entry: Pick<FinancialTransactionData, "source">): string {
+  return `finances.ledgerSource.${getLedgerEntrySource(entry)}`;
+}
+
+export function getLedgerEntryBalanceAfter(
+  entry: Pick<FinancialTransactionData, "balance_after">,
+): number | null {
+  return typeof entry.balance_after === "number" && Number.isFinite(entry.balance_after)
+    ? entry.balance_after
+    : null;
+}
+
+export function filterLedgerEntries(
+  entries: readonly FinancialTransactionData[],
+  filters: LedgerFilters,
+): FinancialTransactionData[] {
+  const normalizedSearch = filters.search.trim().toLowerCase();
+  return entries.filter((entry) => {
+    if (filters.kind !== "all" && entry.kind !== filters.kind) {
+      return false;
+    }
+    if (filters.source !== "all" && getLedgerEntrySource(entry) !== filters.source) {
+      return false;
+    }
+    if (!normalizedSearch) {
+      return true;
+    }
+    return [entry.date, entry.description, entry.kind, getLedgerEntrySource(entry)]
+      .join(" ")
+      .toLowerCase()
+      .includes(normalizedSearch);
+  });
+}
+
+export function groupLedgerEntriesByDate(entries: readonly FinancialTransactionData[]): LedgerDateGroup[] {
+  const groups = new Map<string, FinancialTransactionData[]>();
+  for (const entry of entries) {
+    const current = groups.get(entry.date) ?? [];
+    current.push(entry);
+    groups.set(entry.date, current);
+  }
+
+  return Array.from(groups.entries())
+    .sort(([left], [right]) => right.localeCompare(left))
+    .map(([date, groupEntries]) => ({ date, entries: groupEntries }));
+}
+
+export function getLedgerSources(entries: readonly FinancialTransactionData[]): string[] {
+  return Array.from(new Set(entries.map(getLedgerEntrySource))).sort((left, right) => left.localeCompare(right));
 }
 
 export function getSeasonNetSummary(team: Pick<TeamData, "season_income" | "season_expenses">): SeasonNetSummary {

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -39,10 +39,16 @@ export type FinancialTransactionKind =
   | "Other";
 
 export interface FinancialTransactionData {
+  id?: string;
   date: string;
   description: string;
   amount: number;
   kind: FinancialTransactionKind;
+  balance_before?: number;
+  balance_after?: number;
+  source?: string;
+  source_id?: string | null;
+  correlation_id?: string | null;
 }
 
 export interface TeamSeasonRecord {

--- a/src/ui-v2/dashboard/tabs/FinancesTabV2.test.tsx
+++ b/src/ui-v2/dashboard/tabs/FinancesTabV2.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { GameStateData, PlayerData, StaffData, TeamData } from "@/store/gameStore";
@@ -54,6 +54,17 @@ vi.mock("react-i18next", () => ({
         "finances.facilities": "Facilities",
         "finances.recentLedger": "Recent ledger",
         "finances.ledgerEmpty": "No financial ledger entries yet.",
+        "finances.ledgerSearchLabel": "Search ledger",
+        "finances.ledgerSearchPlaceholder": "Search transactions",
+        "finances.ledgerKindFilter": "Transaction type",
+        "finances.ledgerSourceFilter": "Source",
+        "finances.ledgerAllKinds": "All types",
+        "finances.ledgerAllSources": "All sources",
+        "finances.ledgerSource.transfer": "Transfer",
+        "finances.ledgerSource.monthly": "Monthly",
+        "finances.ledgerSource.legacy": "Legacy",
+        "finances.ledgerRunningBalance": "Balance",
+        "finances.ledgerNoMatches": "No transactions match your filters.",
       };
 
       if (options && typeof options === "object" && "defaultValue" in options) {
@@ -92,8 +103,22 @@ function createTeam(overrides: Partial<TeamData> = {}): TeamData {
     season_income: 900_000,
     season_expenses: 650_000,
     financial_ledger: [
-      { date: "2026-01-03", description: "Transfer purchase", amount: -250_000, kind: "TransferPurchase" },
-      { date: "2026-01-04", description: "Monthly salary", amount: -999_999, kind: "Salary" },
+      {
+        date: "2026-01-03",
+        description: "Transfer purchase",
+        amount: -250_000,
+        kind: "TransferPurchase",
+        source: "transfer",
+        balance_after: 750_000,
+      },
+      {
+        date: "2026-01-04",
+        description: "Monthly salary",
+        amount: -999_999,
+        kind: "Salary",
+        source: "monthly",
+        balance_after: -249_999,
+      },
     ],
     draft_strategy: "Balanced",
     training_focus: "Physical",
@@ -182,11 +207,27 @@ describe("FinancesTabV2 summary semantics", () => {
 
     expect(screen.getByText("Recent ledger")).toBeInTheDocument();
     expect(screen.getByText("2026-01-03")).toBeInTheDocument();
-    expect(screen.getByText("Transfer purchase")).toBeInTheDocument();
+    expect(screen.getAllByText("Transfer purchase").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Transfer").length).toBeGreaterThan(0);
+    expect(screen.getByText("Balance: €750K")).toBeInTheDocument();
     expect(screen.getByText("-€250K")).toBeInTheDocument();
     expect(screen.getByText("2026-01-04")).toBeInTheDocument();
-    expect(screen.getByText("Salary")).toBeInTheDocument();
+    expect(screen.getAllByText("Salary").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Monthly").length).toBeGreaterThan(0);
     expect(screen.getByText("-€999,999")).toBeInTheDocument();
+  });
+
+  it("filters ledger rows by localized search and shows a useful empty result", async () => {
+    const { FinancesTabV2 } = await import("./FinancesTabV2");
+
+    render(<FinancesTabV2 gameState={createGameState()} onGameUpdate={vi.fn()} />);
+
+    fireEvent.change(screen.getByLabelText("Search ledger"), { target: { value: "transfer" } });
+    expect(screen.getAllByText("Transfer purchase").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Monthly salary")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search ledger"), { target: { value: "no-match" } });
+    expect(screen.getByText("No transactions match your filters.")).toBeInTheDocument();
   });
 
   it("renders an empty financial ledger state when the team has no entries", async () => {

--- a/src/ui-v2/dashboard/tabs/FinancesTabV2.tsx
+++ b/src/ui-v2/dashboard/tabs/FinancesTabV2.tsx
@@ -17,8 +17,7 @@ import {
   User,
 } from "lucide-react";
 
-import type { GameStateData, MessageAction, MessageData, PlayerSelectionOptions } from "@/store/gameStore";
-import { resolveMessage } from "@/lib/i18n/backendI18n";
+import type { GameStateData, PlayerSelectionOptions } from "@/store/gameStore";
 import {
   formatVal,
   getContractRiskLevel,
@@ -26,6 +25,12 @@ import {
 } from "@/lib/common/helpers";
 import {
   getFinancialLedger,
+  filterLedgerEntries,
+  getLedgerEntryBalanceAfter,
+  getLedgerEntrySource,
+  getLedgerEntrySourceLabelKey,
+  getLedgerSources,
+  groupLedgerEntriesByDate,
   safeFinanceNumber,
   getTeamFinanceSnapshot,
   getTransferBudgetSummary,
@@ -68,18 +73,6 @@ function getFacilityUpgradeCost(level: number): number {
 
 function getMainHubExpansionCost(level: number): number {
   return level * 500_000;
-}
-
-function isChooseOptionAction(actionType: MessageAction["action_type"]) {
-  return typeof actionType === "object" && "ChooseOption" in actionType;
-}
-
-function isPendingSponsorOffer(message: MessageData): boolean {
-  return (
-    message.id.startsWith("sponsor_") &&
-    message.category === "Finance" &&
-    message.actions.some((a) => !a.resolved && isChooseOptionAction(a.action_type))
-  );
 }
 
 type SortKey = "name" | "position" | "wage" | "value" | "contract";
@@ -135,6 +128,9 @@ export function FinancesTabV2({ gameState, onGameUpdate, onSelectPlayer }: Finan
   const [selectedRiskPlayerIds, setSelectedRiskPlayerIds] = useState<string[]>([]);
   const [sortKey, setSortKey] = useState<SortKey>("wage");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("desc");
+  const [ledgerSearch, setLedgerSearch] = useState("");
+  const [ledgerKindFilter, setLedgerKindFilter] = useState<FinancialTransactionKind | "all">("all");
+  const [ledgerSourceFilter, setLedgerSourceFilter] = useState("all");
 
   const toggleSort = (key: SortKey) => {
     if (sortKey === key) setSortDir((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -153,6 +149,16 @@ export function FinancesTabV2({ gameState, onGameUpdate, onSelectPlayer }: Finan
     ? getTransferBudgetSummary(myTeam)
     : { spend: 0, remaining: 0, total: 0, usagePercent: 0 };
   const financialLedger = myTeam ? getFinancialLedger(myTeam) : [];
+  const ledgerSources = useMemo(() => getLedgerSources(financialLedger), [financialLedger]);
+  const filteredLedger = useMemo(
+    () => filterLedgerEntries(financialLedger, {
+      search: ledgerSearch,
+      kind: ledgerKindFilter,
+      source: ledgerSourceFilter,
+    }),
+    [financialLedger, ledgerSearch, ledgerKindFilter, ledgerSourceFilter],
+  );
+  const ledgerGroups = useMemo(() => groupLedgerEntriesByDate(filteredLedger), [filteredLedger]);
   const totalValue = roster.reduce((s, p) => s + safeFinanceNumber(p.market_value), 0);
 
   const financeSnapshot = myTeam
@@ -176,8 +182,6 @@ export function FinancesTabV2({ gameState, onGameUpdate, onSelectPlayer }: Finan
   const nextHubExpansionCost = getMainHubExpansionCost(mainHubLevel);
   const canExpandMainHub = teamBalance >= nextHubExpansionCost;
   const activeSponsorship = getSponsorshipContractView(myTeam?.sponsorship);
-  const sponsorOffers = gameState.messages.filter(isPendingSponsorOffer).map(resolveMessage);
-
   const contractRiskPlayers = useMemo(
     () =>
       roster
@@ -259,23 +263,6 @@ export function FinancesTabV2({ gameState, onGameUpdate, onSelectPlayer }: Finan
       );
     } catch (err) {
       console.error("Failed to delegate renewals:", err);
-    } finally {
-      setActionLoading(null);
-    }
-  };
-
-  const handleSponsorOption = async (messageId: string, actionId: string, optionId: string) => {
-    const loadingKey = `sponsor:${messageId}:${optionId}`;
-    setActionLoading(loadingKey);
-    try {
-      const result = await invoke<{ game: GameStateData }>("resolve_message_action", {
-        messageId,
-        actionId,
-        optionId,
-      });
-      onGameUpdate(result.game);
-    } catch (err) {
-      console.error("Failed to resolve sponsor offer:", err);
     } finally {
       setActionLoading(null);
     }
@@ -472,16 +459,69 @@ export function FinancesTabV2({ gameState, onGameUpdate, onSelectPlayer }: Finan
         </CardHeader>
         <CardContent>
           {financialLedger.length > 0 ? (
-            <div className="space-y-2">
-              {financialLedger.map((entry, index) => (
-                <div key={`${entry.date}-${entry.kind}-${index}`} className="grid grid-cols-[7rem_1fr_auto] items-center gap-3 rounded-lg bg-muted/40 px-3 py-2 text-sm">
-                  <span className="tabular-nums text-muted-foreground">{entry.date}</span>
-                  <span className="truncate text-foreground">{LEDGER_KIND_LABELS[entry.kind] ?? entry.kind}</span>
-                  <span className={cn("font-heading font-bold tabular-nums", entry.amount < 0 ? "text-red-400" : "text-emerald-400")}>
-                    {formatLedgerAmount(entry.amount)}
-                  </span>
-                </div>
-              ))}
+            <div className="space-y-3">
+              <div className="grid gap-2 md:grid-cols-[1fr_auto_auto]">
+                <label className="sr-only" htmlFor="ledger-search">{t("finances.ledgerSearchLabel")}</label>
+                <input
+                  id="ledger-search"
+                  value={ledgerSearch}
+                  onChange={(event) => setLedgerSearch(event.target.value)}
+                  placeholder={t("finances.ledgerSearchPlaceholder")}
+                  className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-muted-foreground focus:border-primary"
+                />
+                <label className="sr-only" htmlFor="ledger-kind-filter">{t("finances.ledgerKindFilter")}</label>
+                <select
+                  id="ledger-kind-filter"
+                  value={ledgerKindFilter}
+                  onChange={(event) => setLedgerKindFilter(event.target.value as FinancialTransactionKind | "all")}
+                  className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+                >
+                  <option value="all">{t("finances.ledgerAllKinds")}</option>
+                  {(Object.keys(LEDGER_KIND_LABELS) as FinancialTransactionKind[]).map((kind) => (
+                    <option key={kind} value={kind}>{LEDGER_KIND_LABELS[kind]}</option>
+                  ))}
+                </select>
+                <label className="sr-only" htmlFor="ledger-source-filter">{t("finances.ledgerSourceFilter")}</label>
+                <select
+                  id="ledger-source-filter"
+                  value={ledgerSourceFilter}
+                  onChange={(event) => setLedgerSourceFilter(event.target.value)}
+                  className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground outline-none focus:border-primary"
+                >
+                  <option value="all">{t("finances.ledgerAllSources")}</option>
+                  {ledgerSources.map((source) => (
+                    <option key={source} value={source}>{t(`finances.ledgerSource.${source}`)}</option>
+                  ))}
+                </select>
+              </div>
+              {ledgerGroups.length > 0 ? ledgerGroups.map((group) => (
+                <section key={group.date} className="space-y-2">
+                  <h4 className="font-heading text-[10px] uppercase tracking-wider text-muted-foreground tabular-nums">{group.date}</h4>
+                  {group.entries.map((entry, index) => {
+                    const balanceAfter = getLedgerEntryBalanceAfter(entry);
+                    return (
+                      <div key={`${entry.id ?? entry.date}-${entry.kind}-${index}`} className="grid grid-cols-[1fr_auto] items-center gap-3 rounded-lg bg-muted/40 px-3 py-2 text-sm md:grid-cols-[1fr_8rem_auto]">
+                        <div className="min-w-0">
+                          <span className="block truncate text-foreground">{entry.description || (LEDGER_KIND_LABELS[entry.kind] ?? entry.kind)}</span>
+                          <span className="mt-0.5 inline-flex gap-2 text-[11px] text-muted-foreground">
+                            <span>{LEDGER_KIND_LABELS[entry.kind] ?? entry.kind}</span>
+                            <span>·</span>
+                            <span>{t(getLedgerEntrySourceLabelKey(entry), getLedgerEntrySource(entry))}</span>
+                          </span>
+                        </div>
+                        <span className="hidden text-xs tabular-nums text-muted-foreground md:inline">
+                          {balanceAfter === null ? "—" : `${t("finances.ledgerRunningBalance")}: ${formatVal(balanceAfter)}`}
+                        </span>
+                        <span className={cn("font-heading font-bold tabular-nums", entry.amount < 0 ? "text-red-400" : "text-emerald-400")}>
+                          {formatLedgerAmount(entry.amount)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </section>
+              )) : (
+                <p className="text-sm text-muted-foreground">{t("finances.ledgerNoMatches")}</p>
+              )}
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

Strengthen the embedded accounting ledger with validated transactions, mandatory canonical dates, source metadata, computed balances, and deterministic invariants. Scoped finance mail notifications for significant economy events. Improved FinancesTabV2 with search, filters, date grouping, source display, and running balance.

## What's Included

### Backend — Ledger Model
- Additive serde-defaulted fields on `FinancialTransaction`: `id`, `balance_before`, `balance_after`, `source`, `source_id`, `correlation_id`
- Legacy entries deserialize safely via `#[serde(default)]`

### Backend — Result Gateway
- `record_transaction` → `Result<FinancialTransaction, FinanceTransactionError>`
- Validates: ISO date, non-blank description/key, non-zero amount, sign/kind consistency, deterministic balance math
- No partial mutation on invalid input

### Backend — Canonical Dates
- All callers pass canonical game dates (finances, transfers, academy, season-end, club, staff)
- Facility upgrades fixed — no more empty dates

### Backend — Finance Mail
- `push_finance_mail_once` builder with `MessageCategory::Finance`, finance route, backend i18n keys, correlation-based dedupe
- Hooks: sponsor accepted/expired/payout/bonus, facility upkeep summary/spike, prize payout, board financial health
- **Excluded**: FFP, fines, penalties

### Frontend — V2 Ledger UI
- Pure helpers for source fallback, running balance, date grouping, search/filter
- FinancesTabV2: localized search, kind/source filters, date groups, running balance, empty states

### i18n
- All new strings across en, es, fr, de, it, pt, pt-BR, tr
- Fixed `weeksLeft` → `monthsLeft` in finance warning interpolation

## Verification
- ✅ Rust `finances_tests`: 40/40
- ✅ Rust `academy_tests`: 5 passed, 1 pre-existing ignored
- ✅ Rust `club_tests`: 5/5
- ✅ Targeted `end_of_season_tests` and `transfers_tests`: passed
- ✅ Frontend finance/i18n focused tests: 34/34
- ✅ `cargo check --workspace`: passed (pre-existing warnings only)
- ⚠️ Pre-existing failures documented (1 end_of_season i18n, 9 transfers, legacy build/typecheck)

## size:exception
This PR spans 1727 insertions across 29 files — exceeding the standard review budget. Accepted by maintainer as a single delivery given the tightly coupled nature (model + callers + mail + UI + i18n are interdependent).