### PR TITLE
fix(ui-v2): remove ThemeToggle/useTheme references broken by upstream merge

### DIFF
--- a/src/ui-v2/_legacy/components/match/PressConference.test.tsx
+++ b/src/ui-v2/_legacy/components/match/PressConference.test.tsx
@@ -379,14 +379,12 @@ describe("PressConference LoL social content", () => {
 
   it("persists a scoped recent question history after rendering", async () => {
     render(
-      <ThemeProvider>
         <PressConference
           snapshot={makeObjectiveWinSnapshot()}
           gameState={makeGameState()}
           userSide="Home"
           onFinish={vi.fn()}
         />
-      </ThemeProvider>,
     );
 
     await waitFor(() => {

--- a/src/ui-v2/_legacy/components/ui/DatePicker.tsx
+++ b/src/ui-v2/_legacy/components/ui/DatePicker.tsx
@@ -239,6 +239,7 @@ export function DatePicker({ value, onChange, error, nextFieldId }: DatePickerPr
             if (e.key === "ArrowDown" || e.key === "ArrowUp") {
               if (!monthOpen) return;
               e.preventDefault();
+              const dir = e.key === "ArrowDown" ? 1 : -1;
               const currentIdx = months.findIndex(
                 m => m.value === month || m.value.padStart(2, '0') === month
               );

--- a/src/ui-v2/_legacy/pages/Settings.tsx
+++ b/src/ui-v2/_legacy/pages/Settings.tsx
@@ -4,14 +4,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useTranslation } from "react-i18next";
 import { useSettingsStore, AppSettings } from "@/store/settingsStore";
-import { useTheme } from "@/context/ThemeContext";
-import { ThemeToggle, Select } from "@/ui-v2/_legacy/components/ui";
+import { Select } from "@/ui-v2/_legacy/components/ui";
 import { SUPPORTED_LANGUAGES } from "@/i18n";
-import { setUIVersion, useUIVersion, type UIVersion } from "@/ui-v2/uiVersion";
 import {
   ArrowLeft,
   Monitor,
-  Moon,
   Gamepad2,
   Save,
   Zap,
@@ -56,8 +53,6 @@ export default function Settings() {
   const location = useLocation();
   const { t, i18n } = useTranslation();
   const { settings, loaded, loadSettings, updateSettings } = useSettingsStore();
-  const { theme, toggleTheme } = useTheme();
-  const uiVersion = useUIVersion();
   const {
     updateAvailable,
     updateInfo,
@@ -121,17 +116,6 @@ export default function Settings() {
 
   const handleUpdate = (partial: Partial<AppSettings>) => {
     updateSettings(partial);
-
-    // Sync theme with ThemeContext
-    if (partial.theme) {
-      const desired =
-        partial.theme === "system"
-          ? window.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light"
-          : partial.theme;
-      if (desired !== theme) toggleTheme();
-    }
 
     // Sync language with i18n
     if (partial.language) {
@@ -962,7 +946,6 @@ export default function Settings() {
               {t("settings.title")}
             </h1>
           </div>
-          <ThemeToggle />
         </div>
       </header>
 


### PR DESCRIPTION
Closes #312

## PR Type

- [x] Bug fix

## Summary

- Removes ThemeToggle and useTheme from Settings.tsx (both were deleted in upstream, lost during fast-forward merge of PR #311)
- Fixes missing \dir\ variable in DatePicker.tsx causing TS error
- Removes stale ThemeProvider wrapper from PressConference.test.tsx

## Changes

| File | Change |
|------|--------|
| \src/ui-v2/_legacy/pages/Settings.tsx\ | Removed ThemeToggle import/usage, useTheme, and dead imports (Moon, setUIVersion, UIVersion) |
| \src/ui-v2/_legacy/components/ui/DatePicker.tsx\ | Added missing \const dir\ in month keydown handler |
| \src/ui-v2/_legacy/components/match/PressConference.test.tsx\ | Removed ThemeProvider wrapper (no longer exported) |

## Test Plan

- [x] \
px tsc --noEmit\ — no new errors
- [x] \
pm run build\ — completes successfully
- [x] Settings page no longer crashes on navigation