### PR TITLE
fix(ui-v2): remove dead ThemeToggle/ThemeContext references causing Settings crash

### DIFF
--- a/src/ui-v2/_legacy/components/match/PressConference.test.tsx
+++ b/src/ui-v2/_legacy/components/match/PressConference.test.tsx
@@ -379,14 +379,12 @@ describe("PressConference LoL social content", () => {
 
   it("persists a scoped recent question history after rendering", async () => {
     render(
-      <ThemeProvider>
         <PressConference
           snapshot={makeObjectiveWinSnapshot()}
           gameState={makeGameState()}
           userSide="Home"
           onFinish={vi.fn()}
         />
-      </ThemeProvider>,
     );
 
     await waitFor(() => {

--- a/src/ui-v2/_legacy/components/ui/DatePicker.tsx
+++ b/src/ui-v2/_legacy/components/ui/DatePicker.tsx
@@ -242,6 +242,7 @@ export function DatePicker({ value, onChange, error, nextFieldId }: DatePickerPr
               const currentIdx = months.findIndex(
                 m => m.value === month || m.value.padStart(2, '0') === month
               );
+              const dir = e.key === "ArrowDown" ? 1 : -1;
               let nextIdx = currentIdx < 0 ? 0 : currentIdx + dir;
               if (nextIdx < 0) nextIdx = months.length - 1;
               if (nextIdx >= months.length) nextIdx = 0;

--- a/src/ui-v2/_legacy/pages/Settings.tsx
+++ b/src/ui-v2/_legacy/pages/Settings.tsx
@@ -4,14 +4,12 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useTranslation } from "react-i18next";
 import { useSettingsStore, AppSettings } from "@/store/settingsStore";
-import { useTheme } from "@/context/ThemeContext";
-import { ThemeToggle, Select } from "@/ui-v2/_legacy/components/ui";
+import { Select } from "@/ui-v2/_legacy/components/ui";
 import { SUPPORTED_LANGUAGES } from "@/i18n";
-import { setUIVersion, useUIVersion, type UIVersion } from "@/ui-v2/uiVersion";
+
 import {
   ArrowLeft,
   Monitor,
-  Moon,
   Gamepad2,
   Save,
   Zap,
@@ -56,8 +54,7 @@ export default function Settings() {
   const location = useLocation();
   const { t, i18n } = useTranslation();
   const { settings, loaded, loadSettings, updateSettings } = useSettingsStore();
-  const { theme, toggleTheme } = useTheme();
-  const uiVersion = useUIVersion();
+
   const {
     updateAvailable,
     updateInfo,
@@ -121,17 +118,6 @@ export default function Settings() {
 
   const handleUpdate = (partial: Partial<AppSettings>) => {
     updateSettings(partial);
-
-    // Sync theme with ThemeContext
-    if (partial.theme) {
-      const desired =
-        partial.theme === "system"
-          ? window.matchMedia("(prefers-color-scheme: dark)").matches
-            ? "dark"
-            : "light"
-          : partial.theme;
-      if (desired !== theme) toggleTheme();
-    }
 
     // Sync language with i18n
     if (partial.language) {
@@ -962,7 +948,6 @@ export default function Settings() {
               {t("settings.title")}
             </h1>
           </div>
-          <ThemeToggle />
         </div>
       </header>
 


### PR DESCRIPTION
Closes #312

## Summary
Settings page crashes after upstream merge because ThemeToggle/ThemeContext was removed upstream but Settings.tsx still references it.

## Changes
- **Settings.tsx**: Removed `useTheme` import, `ThemeToggle` import and usage, theme sync block. Cleaned up unused `setUIVersion`/UIVersion/`Moon`/uiVersion references.
- **DatePicker.tsx**: Fixed `dir` variable scoping — was used out of scope in month arrow-key handler.
- **PressConference.test.tsx**: Removed stale `<ThemeProvider>` wrapper.

## Verification
- ✅ `npx tsc --noEmit`: no errors related to Settings/DatePicker/ThemeToggle (pre-existing TacticsTab/LolMatchLive errors only)
- ✅ Frontend focused tests 34/34 pass