### PR TITLE
refactor(core): replace ScheduleConfig with CompetitionManifest, separate end_of_split from end_of_season

### DIFF
--- a/src-tauri/crates/olm_core/src/commands.rs
+++ b/src-tauri/crates/olm_core/src/commands.rs
@@ -1,8 +1,6 @@
-use chrono::Datelike;
 use crate::game::Game;
-use crate::domain::player::Player;
 use crate::domain::stats::LolRole;
-use crate::domain::team::{DraftStrategy, ScrimFocus, Team, TeamKind, TrainingFocus, TrainingIntensity, TrainingSchedule};
+use crate::domain::team::{DraftStrategy, ScrimFocus, TrainingFocus, TrainingIntensity, TrainingSchedule};
 use crate::domain::transfer_history::TransferHistoryEntry;
 
 // ── Training ────────────────────────────────────────────────
@@ -242,81 +240,5 @@ pub fn delegate_champion_training(game: &mut Game) {
 
 pub fn create_social_post(_game: &mut Game, _text: &str) {
     // Placeholder - creates a social post
-}
-
-// ── Select Team (world assembly) ────────────────────────────
-
-pub fn select_team(game: &mut Game, team_id: &str, comp_id: &str,
-                   assembled_teams: Vec<Team>, assembled_players: Vec<Player>,
-                   assembled_staff: Vec<crate::domain::staff::Staff>,
-                   manifests: Vec<crate::generator::definitions::CompetitionManifest>) {
-    game.manager.hire(team_id.to_string());
-    if let Some(t) = game.teams.iter_mut().find(|t| t.id == team_id) {
-        t.manager_id = Some(game.manager.id.clone());
-    }
-
-    if game.teams.is_empty() {
-        game.teams = assembled_teams;
-        game.players = assembled_players;
-        game.staff = assembled_staff;
-    }
-
-    let season_year = game.clock.current_date.year();
-    let mut all_leagues = Vec::new();
-
-    for manifest in manifests.iter().filter(|m| !m.legacy) {
-        let team_ids: Vec<String> = game.teams.iter()
-            .filter(|t| t.team_kind != TeamKind::Academy && t.competition_id.as_deref() == Some(manifest.id.as_str()))
-            .map(|t| t.id.clone()).collect();
-        if team_ids.len() < 2 { continue; }
-
-        let mut league = crate::schedule::generate_schedule_from_config(
-            &manifest.id, &manifest.name, season_year as u32, &team_ids, &manifest.schedule, 0);
-        league.competition_id = Some(manifest.id.clone());
-        league.logo = manifest.logo.clone();
-        all_leagues.push(league);
-    }
-
-    game.leagues = all_leagues;
-    game.user_competition_id = Some(comp_id.to_string());
-    crate::champions::bootstrap_champion_state(game);
-    crate::season_context::refresh_game_context(game);
-
-    // ── Welcome messages ─────────────────────────────────────
-    let date_str = game.clock.current_date.to_rfc3339();
-    let team_name = game.teams.iter().find(|t| t.id == team_id)
-        .map(|t| t.name.clone()).unwrap_or_default();
-
-    game.messages.push(crate::messages::welcome_message(&team_name, team_id, &date_str, "en"));
-
-    if let Some(parent) = game.teams.iter().find(|t| t.id == team_id) {
-        if let Some(aid) = parent.academy_team_id.as_deref() {
-            if let Some(academy) = game.teams.iter().find(|t| t.id == aid) {
-                let count = game.players.iter().filter(|p| p.team_id.as_deref() == Some(aid)).count();
-                game.messages.push(crate::game_setup::academy_overview_message(parent, academy, count, &date_str));
-            }
-        }
-    }
-
-    let season_start_str = if let Some(manifest) = manifests.iter().find(|m| m.id == comp_id) {
-        let split = &manifest.schedule.splits[0];
-        format!("{} {}, {}", chrono::Month::try_from(split.season_start.month as u8)
-            .map(|m| m.name()).unwrap_or("January"), split.season_start.day, season_year)
-    } else {
-        format!("January 18, {}", season_year)
-    };
-    let league_display_name = manifests.iter().find(|m| m.id == comp_id)
-        .map(|m| format!("{} {}", m.name, m.schedule.splits.first().map(|s| s.name.as_str()).unwrap_or("")))
-        .unwrap_or_else(|| "LEC Winter".to_string());
-
-    game.messages.push(crate::messages::season_schedule_message(&league_display_name, &season_start_str, &date_str));
-    game.messages.push(crate::messages::staff_advice_message(&team_name, team_id, &date_str));
-
-    let team_names: Vec<String> = game.teams.iter()
-        .filter(|t| t.team_kind != TeamKind::Academy)
-        .map(|t| t.name.clone()).collect();
-    game.news.push(crate::news::season_preview_article(&team_names, &date_str));
-
-    crate::player_events::generate_contract_concern_messages(game, false);
 }
 

--- a/src-tauri/crates/olm_core/src/db/game_persistence.rs
+++ b/src-tauri/crates/olm_core/src/db/game_persistence.rs
@@ -145,13 +145,43 @@ impl GamePersistenceReader {
         // Load ALL competitions (background leagues survive save/load)
         let (all_leagues, config_jsons) = competition_repo::load_competitions(conn).map_err(|e| format!("competitions: {}", e))?;
 
-        // Parse schedule_config JSON strings into ScheduleConfig objects
-        use crate::generator::definitions::ScheduleConfig;
+        // Parse schedule_config JSON strings into CompetitionManifest objects.
+        // Old saves stored bare ScheduleConfig — wrap them in a minimal manifest.
+        use crate::generator::definitions::{CompetitionManifest, ScheduleConfig};
         let mut competition_configs = std::collections::HashMap::new();
         for (cid, json_str) in &config_jsons {
-            if let Ok(config) = serde_json::from_str::<ScheduleConfig>(json_str) {
-                competition_configs.insert(cid.clone(), config);
-            }
+            let manifest = match serde_json::from_str::<CompetitionManifest>(json_str) {
+                Ok(m) => m,
+                Err(_) => {
+                    // Old format: just a ScheduleConfig. Build a minimal manifest.
+                    if let Ok(config) = serde_json::from_str::<ScheduleConfig>(json_str) {
+                        // We don't have the real name here, but the league struct in the
+                        // DB has it on its own `name` field, so this is only used for
+                        // schedule config lookups.
+                        CompetitionManifest {
+                            id: cid.clone(),
+                            name: cid.clone(),
+                            region: String::new(),
+                            full_name: None,
+                            country: None,
+                            tier: None,
+                            logo: None,
+                            schedule: config,
+                            teams_file: "teams.json".to_string(),
+                            players_file: "players.json".to_string(),
+                            staff_file: None,
+                            championships_file: None,
+                            erls: Vec::new(),
+                            reputation: None,
+                            nearby_country_codes: Vec::new(),
+                            legacy: false,
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+            };
+            competition_configs.insert(cid.clone(), manifest);
         }
 
         let league = league_repo::load_league(conn)?;

--- a/src-tauri/crates/olm_core/src/db/save_manager.rs
+++ b/src-tauri/crates/olm_core/src/db/save_manager.rs
@@ -257,7 +257,31 @@ impl SaveManager {
             save_path
         );
 
-        let game = Self::read_olsave(&save_path)?;
+        let mut game = Self::read_olsave(&save_path)?;
+
+        // Migration: re-derive `competition_id` for leagues where it was
+        // lost (old saves before the field existed).  Try to find any team
+        // in the league's standings that has a known competition_id and
+        // propagate it back to the league.
+        for league in &mut game.leagues {
+            if league.competition_id.is_some() {
+                continue;
+            }
+            if let Some(tid) = league.standings.first().map(|s| s.team_id.as_str()) {
+                if let Some(cid) = game
+                    .teams
+                    .iter()
+                    .find(|t| t.id == tid)
+                    .and_then(|t| t.competition_id.clone())
+                {
+                    league.competition_id = Some(cid);
+                    info!(
+                        "[save_manager] migrated competition_id={:?} for league '{}'",
+                        league.competition_id, league.name
+                    );
+                }
+            }
+        }
 
         info!(
             "[save_manager] load_game: loaded, players={}, teams={}",

--- a/src-tauri/crates/olm_core/src/domain/league.rs
+++ b/src-tauri/crates/olm_core/src/domain/league.rs
@@ -24,6 +24,8 @@ pub struct League {
     pub logo: Option<String>,
     #[serde(default)]
     pub league_kind: LeagueKind,
+    #[serde(default)]
+    pub split_index: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -200,6 +202,7 @@ impl League {
             competition_id,
             logo: None,
             league_kind: LeagueKind::Main,
+            split_index: 0,
         }
     }
 

--- a/src-tauri/crates/olm_core/src/end_of_season.rs
+++ b/src-tauri/crates/olm_core/src/end_of_season.rs
@@ -7,11 +7,9 @@ use crate::finances::{
     FinanceTransactionInput,
 };
 use crate::game::Game;
-use crate::generator::definitions::ScheduleConfig;
+use crate::generator::definitions::CompetitionManifest;
 use crate::schedule::{
     append_fixtures, generate_preseason_friendlies, generate_schedule_from_config,
-    generate_single_round_league_with_offsets_and_bo_with_id, parse_lec_split, regular_best_of,
-    LecSplit,
 };
 use crate::season_awards::compute_season_awards;
 use chrono::{Datelike, TimeZone, Utc};
@@ -75,41 +73,6 @@ pub fn is_league_complete(league: &League) -> bool {
     regular_complete && playoffs_complete
 }
 
-fn next_lec_split(
-    current_name: &str,
-    current_season: u32,
-) -> (String, u32, LecSplit, chrono::DateTime<Utc>, [i64; 9]) {
-    match parse_lec_split(current_name) {
-        Some(LecSplit::Winter) => (
-            "LEC Spring".to_string(),
-            current_season,
-            LecSplit::Spring,
-            Utc.with_ymd_and_hms(current_season as i32, 3, 29, 0, 0, 0)
-                .unwrap(),
-            [0, 7, 14, 21, 28, 35, 42, 49, 56],
-        ),
-        Some(LecSplit::Spring) => (
-            "LEC Summer".to_string(),
-            current_season,
-            LecSplit::Summer,
-            Utc.with_ymd_and_hms(current_season as i32, 8, 2, 0, 0, 0)
-                .unwrap(),
-            [0, 7, 14, 21, 28, 35, 42, 49, 56],
-        ),
-        _ => {
-            let next_season = current_season + 1;
-            (
-                "LEC Winter".to_string(),
-                next_season,
-                LecSplit::Winter,
-                Utc.with_ymd_and_hms(next_season as i32, 1, 18, 0, 0, 0)
-                    .unwrap(),
-                [0, 1, 2, 7, 8, 9, 14, 15, 16],
-            )
-        }
-    }
-}
-
 /// Check if the season is complete (all fixtures played).
 pub fn is_season_complete(game: &Game) -> bool {
     game.active_league().is_some_and(is_league_complete)
@@ -149,25 +112,79 @@ fn refresh_hiring_cycle_budgets(team: &mut crate::domain::team::Team) {
 
 /// Process end-of-season: record history, compute awards, reset stats, generate next season.
 /// Returns a summary struct for the frontend to display.
-/// Accepts an optional ScheduleConfig for manifest-driven schedule generation.
+/// Accepts an optional CompetitionManifest for manifest-driven schedule generation.
 pub fn process_end_of_season(game: &mut Game) -> EndOfSeasonSummary {
     process_end_of_season_inner(game, None)
 }
 
-/// Like `process_end_of_season` but accepts a ScheduleConfig for manifest-driven
+/// Like `process_end_of_season` but accepts a CompetitionManifest for manifest-driven
 /// schedule generation in the next split.
 pub fn process_end_of_season_with_config(
     game: &mut Game,
-    schedule_config: Option<&crate::generator::definitions::ScheduleConfig>,
+    manifest: Option<&CompetitionManifest>,
 ) -> EndOfSeasonSummary {
-    process_end_of_season_inner(game, schedule_config)
+    process_end_of_season_inner(game, manifest)
+}
+
+/// Process end-of-split: generate next split's schedule using the league's
+/// current `split_index`. Caller is responsible for:
+///   - Calling `process_end_of_season` first when the split wraps the season
+///   - Setting `split_index = 0` and `season += 1` before calling this
+///     function for the new season's first split
+/// Unlike end_of_season, this does NOT record history, award prizes,
+/// reset player stats, or send board messages — only fixtures are created.
+pub fn process_end_of_split(game: &mut Game, manifest: &CompetitionManifest) {
+    let league = match game.active_league() {
+        Some(l) => l,
+        None => return,
+    };
+    let split_index = league.split_index;
+    let season = league.season;
+    let team_ids: Vec<String> = league
+        .standings
+        .iter()
+        .map(|s| s.team_id.clone())
+        .collect();
+    let user_team_id = game.manager.team_id.clone().unwrap_or_default();
+
+    let mut new_league = generate_schedule_from_config(manifest, season, &team_ids, split_index);
+
+    if !user_team_id.is_empty() {
+        let opponents: Vec<String> = team_ids
+            .iter()
+            .filter(|tid| tid.as_str() != user_team_id)
+            .cloned()
+            .collect();
+        let split = &manifest.schedule.splits[split_index];
+        let next_start = Utc
+            .with_ymd_and_hms(
+                season as i32,
+                split.season_start.month,
+                split.season_start.day,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+        let friendlies = generate_preseason_friendlies(
+            &user_team_id,
+            &opponents,
+            next_start,
+            manifest.schedule.preseason_friendlies as usize,
+        );
+        append_fixtures(&mut new_league, friendlies);
+    }
+
+    if let Some(active) = game.active_league_mut() {
+        *active = new_league;
+    }
 }
 
 /// Process end-of-season for background leagues (game.leagues[1..]).
 /// Records team history for completed bg leagues and generates next season via
-/// the competition manifest's ScheduleConfig (looked up by competition_id).
+/// the competition manifest (looked up by competition_id).
 /// Skips bg leagues that are not complete, or have no competition_id.
-pub fn process_background_seasons(game: &mut Game, configs: &HashMap<String, ScheduleConfig>) {
+pub fn process_background_seasons(game: &mut Game, manifests: &HashMap<String, CompetitionManifest>) {
     // First pass: identify complete bg leagues (avoiding borrow conflicts)
     let complete_indices: Vec<usize> = (1..game.leagues.len())
         .filter(|i| is_league_complete(&game.leagues[*i]))
@@ -182,36 +199,45 @@ pub fn process_background_seasons(game: &mut Game, configs: &HashMap<String, Sch
             .iter()
             .map(|entry| entry.team_id.clone())
             .collect();
-        let league_name = game.leagues[i].name.clone();
 
-        // Record TeamSeasonRecord for each team (no prize money, no messages)
-        for (idx, standing) in final_standings.iter().enumerate() {
-            if let Some(team) = game.teams.iter_mut().find(|t| t.id == standing.team_id) {
-                team.history.push(TeamSeasonRecord {
-                    season,
-                    league_position: (idx + 1) as u32,
-                    played: standing.played,
-                    won: standing.won,
-                    lost: standing.lost,
-                    kills_for: standing.maps_won,
-                    kills_against: standing.maps_lost,
-                });
-                // Reset form
-                team.form.clear();
+        // Determine if this split wraps the season (last split → new year)
+        let is_end_of_season = competition_id
+            .as_ref()
+            .and_then(|cid| manifests.get(cid))
+            .is_some_and(|manifest| game.leagues[i].split_index + 1 >= manifest.schedule.splits.len());
+
+        if is_end_of_season {
+            // Record TeamSeasonRecord for each team (no prize money, no messages)
+            for (idx, standing) in final_standings.iter().enumerate() {
+                if let Some(team) = game.teams.iter_mut().find(|t| t.id == standing.team_id) {
+                    team.history.push(TeamSeasonRecord {
+                        season,
+                        league_position: (idx + 1) as u32,
+                        played: standing.played,
+                        won: standing.won,
+                        lost: standing.lost,
+                        kills_for: standing.maps_won,
+                        kills_against: standing.maps_lost,
+                    });
+                    team.form.clear();
+                }
             }
         }
 
-        // Generate next season schedule if competition_id is available
+        // Generate next split/season schedule
         if let Some(ref cid) = competition_id {
-            if let Some(config) = configs.get(cid) {
-                let next_season = season + 1;
+            if let Some(manifest) = manifests.get(cid) {
+                let next_idx = game.leagues[i].split_index + 1;
+                let (ns, split_idx) = if next_idx >= manifest.schedule.splits.len() {
+                    (season + 1, 0)
+                } else {
+                    (season, next_idx)
+                };
                 let new_league = generate_schedule_from_config(
-                    cid,
-                    &league_name,
-                    next_season,
+                    manifest,
+                    ns,
                     &team_ids,
-                    config,
-                    0,
+                    split_idx,
                 );
                 game.leagues[i] = new_league;
             }
@@ -221,7 +247,7 @@ pub fn process_background_seasons(game: &mut Game, configs: &HashMap<String, Sch
 
 fn process_end_of_season_inner(
     game: &mut Game,
-    schedule_config: Option<&crate::generator::definitions::ScheduleConfig>,
+    _manifest: Option<&CompetitionManifest>,
 ) -> EndOfSeasonSummary {
     crate::board_objectives::update_objective_progress(game);
 
@@ -230,13 +256,14 @@ fn process_end_of_season_inner(
         None => return EndOfSeasonSummary::default(),
     };
 
-    let league_id = league
+    let _league_id = league
         .competition_id
         .as_deref()
         .unwrap_or(&league.id)
         .to_string();
     let season = league.season;
     let league_name = league.name.clone();
+    let _current_split_index = league.split_index;
     let today = game.clock.current_date.format("%Y-%m-%d").to_string();
     // Messages should be dated on the last match day, not on the clock date
     // (which may already be one day ahead due to process_day advancing the clock).
@@ -464,128 +491,27 @@ fn process_end_of_season_inner(
     // 6c. Clear old news articles from the previous season
     game.news.clear();
 
-    // 7. Generate next season schedule
-    let team_ids: Vec<String> = final_standings
-        .iter()
-        .map(|standing| standing.team_id.clone())
-        .collect();
-
-    // Determine next season number (may be used by both manifest and legacy paths)
-    let next_season_num: u32;
-
-    let new_league = if let Some(config) = schedule_config {
-        // Manifest-driven schedule generation
-        let current_split_name = parse_lec_split(&league_name)
-            .map(|s| match s {
-                LecSplit::Winter => "Winter",
-                LecSplit::Spring => "Spring",
-                LecSplit::Summer => "Summer",
-            })
-            .unwrap_or("Winter");
-
-        // Find the current split index
-        let current_idx = config
-            .splits
-            .iter()
-            .position(|s| s.name.eq_ignore_ascii_case(current_split_name))
-            .unwrap_or(0);
-
-        // Next split index (wrap with year increment)
-        let next_idx = current_idx + 1;
-        let (ns, split_idx) = if next_idx >= config.splits.len() {
-            (season + 1, 0) // Next year, first split
-        } else {
-            (season, next_idx)
-        };
-        next_season_num = ns;
-
-        let mut league = crate::schedule::generate_schedule_from_config(
-            &league_id,
-            &config.splits[split_idx].name,
-            next_season_num,
-            &team_ids,
-            config,
-            split_idx,
-        );
-
-        if !user_team_id.is_empty() {
-            let opponents: Vec<String> = team_ids
-                .iter()
-                .filter(|tid| tid.as_str() != user_team_id)
-                .cloned()
-                .collect();
-            let split = &config.splits[split_idx];
-            let next_start = Utc
-                .with_ymd_and_hms(
-                    next_season_num as i32,
-                    split.season_start.month,
-                    split.season_start.day,
-                    0,
-                    0,
-                    0,
-                )
-                .unwrap();
-            let friendlies = generate_preseason_friendlies(
-                &user_team_id,
-                &opponents,
-                next_start,
-                config.preseason_friendlies as usize,
-            );
-            append_fixtures(&mut league, friendlies);
-        }
-
-        league
-    } else {
-        // Legacy LEC hardcoded schedule generation
-        let (next_league_name, ns, next_split, next_start, round_offsets) =
-            next_lec_split(&league_name, season);
-        next_season_num = ns;
-        let expected_round_count = team_ids.len().saturating_sub(1);
-        let next_round_offsets = if round_offsets.len() == expected_round_count {
-            Some(round_offsets.as_slice())
-        } else {
-            None
-        };
-        let mut league = generate_single_round_league_with_offsets_and_bo_with_id(
-            &league_id,
-            &next_league_name,
-            next_season_num,
-            &team_ids,
-            next_start,
-            next_round_offsets,
-            regular_best_of(next_split),
-        );
-        if !user_team_id.is_empty() {
-            let opponents: Vec<String> = team_ids
-                .iter()
-                .filter(|tid| tid.as_str() != user_team_id)
-                .cloned()
-                .collect();
-            let friendlies =
-                generate_preseason_friendlies(&user_team_id, &opponents, next_start, 3);
-            append_fixtures(&mut league, friendlies);
-        }
-        league
-    };
+    // 7. Advance to next season: increment year, reset split.
+    // Schedule generation is handled by the caller (process_end_of_split).
+    let next_season_num = season + 1;
     if let Some(active) = game.active_league_mut() {
-        *active = new_league;
+        active.season = next_season_num;
+        active.split_index = 0;
     }
 
-    let next_season = next_season_num;
-
-    let preview_date = game.clock.current_date.to_rfc3339();
-    let team_names: Vec<String> = team_ids
+    let team_names: Vec<String> = final_standings
         .iter()
-        .filter_map(|team_id| {
+        .map(|s| {
             game.teams
                 .iter()
-                .find(|team| &team.id == team_id)
-                .map(|team| team.name.clone())
+                .find(|t| t.id == s.team_id)
+                .map(|t| t.name.clone())
+                .unwrap_or_default()
         })
         .collect();
     game.news.push(crate::news::season_preview_article(
         &team_names,
-        &preview_date,
+        &game.clock.current_date.to_rfc3339(),
     ));
 
     // 8. Send end-of-season messages
@@ -766,33 +692,31 @@ fn process_end_of_season_inner(
         game.messages.push(msg);
     }
 
-    let sched_msg_id = format!("new_season_{}", next_season);
-    if !existing_ids.contains(&sched_msg_id) {
-        let mut sched_params = std::collections::HashMap::new();
-        sched_params.insert("season".to_string(), next_season.to_string());
-        let sched_msg = InboxMessage::new(
-            sched_msg_id,
-            format!("Season {} — New Schedule Released", next_season),
-            format!(
-                "The schedule for Season {} has been released! The new campaign kicks off in 4 weeks.\n\n\
-                Use this break to assess your squad, make any necessary changes, and prepare for the challenges ahead.\n\n\
-                Good luck!",
-                next_season
-            ),
-            "League Office".to_string(),
-            last_fixture_date,
-        )
-        .with_category(MessageCategory::LeagueInfo)
-        .with_priority(MessagePriority::Normal)
-        .with_sender_role("Competition Secretary")
-        .with_i18n(
-            "be.msg.newSeasonSchedule.subject",
-            "be.msg.newSeasonSchedule.body",
-            sched_params,
-        )
-        .with_sender_i18n("be.sender.leagueOffice", "be.role.match_typeSecretary");
-        game.messages.push(sched_msg);
-    }
+    let sched_msg_id = format!("new_season_{}", next_season_num);
+    let mut sched_params = std::collections::HashMap::new();
+    sched_params.insert("season".to_string(), next_season_num.to_string());
+    let sched_msg = InboxMessage::new(
+        sched_msg_id,
+        format!("Season {} — New Schedule Released", next_season_num),
+        format!(
+            "The schedule for Season {} has been released! The new campaign kicks off in 4 weeks.\n\n\
+            Use this break to assess your squad, make any necessary changes, and prepare for the challenges ahead.\n\n\
+            Good luck!",
+            next_season_num
+        ),
+        "League Office".to_string(),
+        last_fixture_date,
+    )
+    .with_category(MessageCategory::LeagueInfo)
+    .with_priority(MessagePriority::Normal)
+    .with_sender_role("Competition Secretary")
+    .with_i18n(
+        "be.msg.newSeasonSchedule.subject",
+        "be.msg.newSeasonSchedule.body",
+        sched_params,
+    )
+    .with_sender_i18n("be.sender.leagueOffice", "be.role.match_typeSecretary");
+    game.messages.push(sched_msg);
 
     crate::season_context::refresh_game_context(game);
 

--- a/src-tauri/crates/olm_core/src/game.rs
+++ b/src-tauri/crates/olm_core/src/game.rs
@@ -14,7 +14,7 @@ use crate::domain::transfer_history::TransferHistory;
 #[cfg(feature = "typescript")]
 use ts_rs::TS;
 
-use crate::generator::definitions::ScheduleConfig;
+use crate::generator::definitions::CompetitionManifest;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -133,7 +133,7 @@ pub struct Game {
     #[serde(default)]
     pub stats_state: StatsState,
     #[serde(default)]
-    pub competition_configs: HashMap<String, ScheduleConfig>,
+    pub competition_configs: HashMap<String, CompetitionManifest>,
     #[serde(default)]
     pub transfer_history: TransferHistory,
 }

--- a/src-tauri/crates/olm_core/src/schedule.rs
+++ b/src-tauri/crates/olm_core/src/schedule.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Duration, TimeZone, Utc};
 use crate::domain::league::{Fixture, FixtureStatus, League, MatchType};
+use crate::generator::definitions::CompetitionManifest;
 use uuid::Uuid;
 
 fn build_fixture(
@@ -277,30 +278,30 @@ pub fn generate_single_round_league_with_offsets_and_bo_with_id(
     league
 }
 
-/// Generate a league schedule from a competition manifest's `ScheduleConfig`.
-/// Uses the first split's configuration (season_start, superweek_offsets, best_of).
-/// Supports "single_round_robin" format (others may be added later).
+/// Generate a league schedule from a competition manifest.
+/// Supports "single_round_robin" and "double_round_robin" formats.
+/// League name is set to the manifest's name (no split suffix).
 pub fn generate_schedule_from_config(
-    competition_id: &str,
-    competition_name: &str,
+    manifest: &CompetitionManifest,
     year: u32,
     team_ids: &[String],
-    config: &crate::generator::definitions::ScheduleConfig,
     split_index: usize,
 ) -> League {
+    let config = &manifest.schedule;
     // Defensive: a manifest with no schedule splits cannot produce a calendar.
     // Return an empty league (id + teams, no fixtures) instead of panicking on
     // an out-of-bounds index. Callers that need a real schedule should skip
     // such competitions beforehand.
     if config.splits.get(split_index).is_none() {
         let mut league = League::new(
-            competition_id.to_string(),
-            competition_name.to_string(),
+            manifest.id.clone(),
+            manifest.name.clone(),
             year,
             team_ids,
             None,
         );
-        league.competition_id = Some(competition_id.to_string());
+        league.competition_id = Some(manifest.id.clone());
+        league.split_index = split_index;
         return league;
     }
     let split = &config.splits[split_index];
@@ -315,13 +316,11 @@ pub fn generate_schedule_from_config(
         )
         .unwrap();
 
-    let split_name = format!("{} {}", competition_name, split.name);
-
     let mut league = match config.format.as_str() {
         "single_round_robin" => {
             generate_single_round_league_with_offsets_and_bo_with_id(
-                competition_id,
-                &split_name,
+                &manifest.id,
+                &manifest.name,
                 year,
                 team_ids,
                 season_start,
@@ -335,8 +334,8 @@ pub fn generate_schedule_from_config(
         }
         "double_round_robin" => {
             let mut l = generate_single_round_league_with_offsets_and_bo_with_id(
-                competition_id,
-                &split_name,
+                &manifest.id,
+                &manifest.name,
                 year,
                 team_ids,
                 season_start,
@@ -350,7 +349,7 @@ pub fn generate_schedule_from_config(
             let last_offset = split.superweek_offsets.last().copied().unwrap_or(7 * (team_ids.len() as i64 - 1));
             let return_start = season_start + Duration::days(last_offset + 7);
             let return_league = generate_single_round_league_with_offsets_and_bo(
-                &format!("{} (Return)", split_name),
+                &format!("{} (Return)", manifest.name),
                 year,
                 team_ids,
                 return_start,
@@ -380,7 +379,7 @@ pub fn generate_schedule_from_config(
                 config.format
             );
             generate_single_round_league_with_offsets_and_bo(
-                &split_name,
+                &manifest.name,
                 year,
                 team_ids,
                 season_start,
@@ -393,7 +392,8 @@ pub fn generate_schedule_from_config(
             )
         }
     };
-    league.competition_id = Some(competition_id.to_string());
+    league.competition_id = Some(manifest.id.clone());
+    league.split_index = split_index;
     league
 }
 

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -861,9 +861,16 @@ fn maybe_schedule_playoffs(game: &mut Game) {
         return;
     };
 
-    let split = match schedule::parse_lec_split(&league.name) {
-        Some(split) => split,
-        None => return,
+    let split_name = league
+        .competition_id
+        .as_ref()
+        .and_then(|cid| game.competition_configs.get(cid))
+        .and_then(|manifest| manifest.schedule.splits.get(league.split_index))
+        .map(|s| s.name.as_str());
+    let split = split_name.and_then(schedule::parse_lec_split);
+
+    let Some(split) = split else {
+        return;
     };
 
     let playoff_fixtures_exist = league

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -352,7 +352,7 @@ pub async fn select_team(
             continue;
         }
         let mut league = olm_core::schedule::generate_schedule_from_config(
-            cid, &manifest.name, season_year as u32, &team_ids, schedule_config, 0,
+            manifest, season_year as u32, &team_ids, 0,
         );
 
         // Generate preseason friendlies for ALL competitions
@@ -399,7 +399,7 @@ pub async fn select_team(
     // Populate competition_configs from all manifests for bg season cycling
     for manifest in all_manifests.iter().filter(|m| !m.legacy) {
         game.competition_configs
-            .insert(manifest.id.clone(), manifest.schedule.clone());
+            .insert(manifest.id.clone(), (*manifest).clone());
     }
 
     game.leagues = all_leagues;
@@ -414,7 +414,7 @@ pub async fn select_team(
     let league_display_name = user_cid
         .and_then(|cid| crate::commands::competitions::load_competition_manifest(&app_handle, cid).ok())
         .map(|m| format!("{} {}", m.name, m.schedule.splits.first().map(|s| s.name.as_str()).unwrap_or("")))
-        .unwrap_or_else(|| "LEC Winter".to_string());
+        .unwrap_or_else(|| "Competition.error".to_string());
 
     // Initialize message template store
     {

--- a/src-tauri/src/commands/season.rs
+++ b/src-tauri/src/commands/season.rs
@@ -1,6 +1,7 @@
 use log::info;
 use tauri::State;
 
+use olm_core::generator::definitions::CompetitionManifest;
 use olm_core::state::StateManager;
 
 #[tauri::command]
@@ -12,15 +13,12 @@ pub fn check_season_complete(state: State<'_, StateManager>) -> Result<bool, Str
     Ok(olm_core::end_of_season::is_season_complete(&game))
 }
 
-/// Try to load the competition manifest from the game's league data.
-/// If available, return the ScheduleConfig for manifest-driven schedule generation.
-fn resolve_schedule_config(
+/// Try to load the competition manifest from disk.
+fn resolve_competition_manifest(
     game: &olm_core::game::Game,
-) -> Option<olm_core::generator::definitions::ScheduleConfig> {
-    // Use the active competition's ID, not the first team's (which may be unrelated)
+) -> Option<CompetitionManifest> {
     let competition_id = game.user_competition_id.as_deref()?;
 
-    // First try: data dir relative to the executable (Tauri build)
     let exe_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
     let relative_paths = [
         exe_dir.join("data").join("competitions").join(competition_id).join("manifest.json"),
@@ -28,13 +26,12 @@ fn resolve_schedule_config(
     ];
     for p in &relative_paths {
         if let Ok(json) = std::fs::read_to_string(p) {
-            if let Ok(manifest) = serde_json::from_str::<olm_core::generator::definitions::CompetitionManifest>(&json) {
-                return Some(manifest.schedule);
+            if let Ok(manifest) = serde_json::from_str::<CompetitionManifest>(&json) {
+                return Some(manifest);
             }
         }
     }
 
-    // Fallback: try current working directory paths (dev mode)
     if let Ok(cwd) = std::env::current_dir() {
         let cwd_paths = [
             cwd.join("data").join("competitions").join(competition_id).join("manifest.json"),
@@ -42,8 +39,8 @@ fn resolve_schedule_config(
         ];
         for p in &cwd_paths {
             if let Ok(json) = std::fs::read_to_string(p) {
-                if let Ok(manifest) = serde_json::from_str::<olm_core::generator::definitions::CompetitionManifest>(&json) {
-                    return Some(manifest.schedule);
+                if let Ok(manifest) = serde_json::from_str::<CompetitionManifest>(&json) {
+                    return Some(manifest);
                 }
             }
         }
@@ -63,27 +60,61 @@ pub fn advance_to_next_season(state: State<'_, StateManager>) -> Result<serde_js
         return Err("Season is not yet complete".to_string());
     }
 
-    // Try to resolve schedule config for manifest-driven flow
-    let schedule_config = resolve_schedule_config(&game);
+    // Try to resolve competition manifest for manifest-driven flow
+    let manifest = resolve_competition_manifest(&game);
+    let mut was_season_end: bool;
 
-    let summary = if let Some(ref config) = schedule_config {
-        info!(
-            "[cmd] advance_to_next_season: using manifest-driven schedule",
-        );
-        olm_core::end_of_season::process_end_of_season_with_config(&mut game, Some(config))
+    let summary = if let Some(ref manifest) = manifest {
+        let is_wrapping = game
+            .active_league()
+            .is_some_and(|league| league.split_index + 1 >= manifest.schedule.splits.len());
+
+        was_season_end = is_wrapping;
+
+        if is_wrapping {
+            info!(
+                "[cmd] advance_to_next_season: season complete, running full end-of-season"
+            );
+            let summary = olm_core::end_of_season::process_end_of_season_with_config(
+                &mut game, Some(manifest),
+            );
+            // After season-end processing, generate split 0 of the new season
+            olm_core::end_of_season::process_end_of_split(&mut game, manifest);
+            summary
+        } else {
+            was_season_end = false;
+            info!(
+                "[cmd] advance_to_next_season: split complete, advancing to next split"
+            );
+            // Increment split, then generate its schedule
+            if let Some(l) = game.active_league_mut() {
+                l.split_index += 1;
+            }
+            olm_core::end_of_season::process_end_of_split(&mut game, manifest);
+            // Return a minimal summary — no awards/history/reset on mid-year splits
+            let league = game.active_league().cloned();
+            olm_core::end_of_season::EndOfSeasonSummary {
+                season: league.as_ref().map(|l| l.season).unwrap_or(0),
+                league_name: league.as_ref().map(|l| l.name.clone()).unwrap_or_default(),
+                ..Default::default()
+            }
+        }
     } else {
+        was_season_end = true;
         info!("[cmd] advance_to_next_season: using legacy schedule");
         olm_core::end_of_season::process_end_of_season(&mut game)
     };
 
     // Process background league seasons
     {
-        let configs = game.competition_configs.clone();
-        olm_core::end_of_season::process_background_seasons(&mut game, &configs);
+        let manifests = game.competition_configs.clone();
+        olm_core::end_of_season::process_background_seasons(&mut game, &manifests);
     }
 
     // End-of-season objective evaluation may have dropped satisfaction — check firing
-    olm_core::firing::check_manager_firing(&mut game);
+    if was_season_end {
+        olm_core::firing::check_manager_firing(&mut game);
+    }
 
     state.set_game(game.clone());
 


### PR DESCRIPTION
## Summary

- League names are now stable (just "LCK", no "LEC Summer" or "Spring Spring" bugs)
- Split tracking uses league.split_index instead of parsing league name strings
- End of split and end of season are now separate concepts (season-ending logic only runs on real season end)
- CompetitionManifest replaces ScheduleConfig as the type passed through schedule generation (carries id + name together, preventing naming bugs)
- Migration path for old saves: competition_id re-derived from teams, CompetitionManifest constructed from old ScheduleConfig JSON

## Changes

| File | Change |
|------|--------|
| domain/league.rs | Added split_index: usize field |
| game.rs (core) | competition_configs type -> HashMap<String, CompetitionManifest> |
| schedule.rs | generate_schedule_from_config takes &CompetitionManifest, sets split_index, no split suffix |
| end_of_season.rs | Removed next_lec_split, league_prefix. Added process_end_of_split |
| season.rs | Caller detects wrapping for end_of_season vs end_of_split |
| turn/mod.rs | maybe_schedule_playoffs uses split_index + config lookup |
| save_manager.rs | Migration: re-derive competition_id from teams on load |
| game_persistence.rs | Parse CompetitionManifest with fallback to old ScheduleConfig |
| commands.rs | Removed dead select_team function |
| commands/game.rs | Store full manifests, Competition.error fallback |

## Commits

- feat(league): add split_index field
- refactor(core): replace ScheduleConfig with CompetitionManifest
- feat(end_of_season): separate end_of_split from end_of_season
- fix(turn): use league.split_index for playoff scheduling
- fix(save): migrate missing competition_id on save load
- chore: remove dead select_team function
- fix: replace LEC Winter fallback with Competition.error
