### PR TITLE
ci(build): add build-only pipeline for release candidate artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,160 @@
+name: Build Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version label for artifacts (e.g. 0.3.4-rc.1)
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  source:
+    name: source-archive
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version
+        id: version
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            VERSION="$(node -p "require('./package.json').version")-build.$(date +'%Y%m%d%H%M%S')"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create source archive
+        shell: bash
+        run: |
+          mkdir -p dist-source
+          git archive --format=tar.gz --prefix="olmanager-${{ steps.version.outputs.version }}/" HEAD > "dist-source/olmanager-${{ steps.version.outputs.version }}-source.tar.gz"
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          cd dist-source
+          sha256sum * > SHA256SUMS.txt
+
+      - name: Upload source artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: olmanager-build-${{ steps.version.outputs.version }}-source
+          path: dist-source/
+          if-no-files-found: error
+
+  build-tauri:
+    name: build-tauri (${{ matrix.platform }})
+    needs: source
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: windows
+            os: windows-latest
+            tauri_target: windows-x86_64
+          - platform: linux
+            os: ubuntu-22.04
+            tauri_target: linux-x86_64
+          - platform: macos
+            os: macos-latest
+            tauri_target: darwin-aarch64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux Tauri dependencies
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build Tauri bundle
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npm run tauri build
+
+      - name: Collect bundle artifacts
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        shell: python
+        run: |
+          import hashlib
+          import pathlib
+          import shutil
+          import sys
+
+          platform = "${{ env.PLATFORM }}"
+          bundle_dir = pathlib.Path("src-tauri/target/release/bundle")
+          out_dir = pathlib.Path("dist-bundle")
+          out_dir.mkdir(exist_ok=True)
+
+          allowed_suffixes = (
+              ".AppImage", ".deb", ".dmg", ".exe",
+              ".msi", ".rpm", ".sig", ".tar.gz",
+          )
+          allowed_double_suffixes = (".app.tar.gz",)
+
+          if not bundle_dir.exists():
+              print(f"Missing Tauri bundle directory: {bundle_dir}", file=sys.stderr)
+              sys.exit(1)
+
+          copied = []
+          for path in bundle_dir.rglob("*"):
+              if not path.is_file():
+                  continue
+              name = path.name
+              if not (name.endswith(allowed_suffixes) or name.endswith(allowed_double_suffixes)):
+                  continue
+              destination = out_dir / f"{name}"
+              shutil.copy2(path, destination)
+              copied.append(destination)
+
+          if not copied:
+              print(f"No distributable Tauri bundles found under {bundle_dir}", file=sys.stderr)
+              sys.exit(1)
+
+          checksum_file = out_dir / f"SHA256SUMS-{platform}.txt"
+          checksum_file.write_text(
+              "".join(
+                  f"{hashlib.sha256(path.read_bytes()).hexdigest()}  {path.name}\n"
+                  for path in sorted(copied)
+              )
+          )
+
+      - name: Upload bundle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: olmanager-build-${{ needs.source.outputs.version }}-${{ matrix.platform }}
+          path: dist-bundle/
+          if-no-files-found: error


### PR DESCRIPTION
Closes #336

## Summary
- Nueva pipeline `build.yml` que compila source + bundles Tauri para linux, windows y macos
- Sin publicar a GitHub Releases — los artifacts quedan solo en Actions
- Sin `latest.json` — el auto-updater nunca se entera
- Solo se dispara manualmente (`workflow_dispatch`) con un version label opcional

## Changes
| File | Change |
|------|--------|
| `.github/workflows/build.yml` | New file: build-only pipeline replicando la compilación de release.yml pero sin los pasos de publish |

## Test Plan
- [x] `git diff develop --stat` muestra solo 1 archivo nuevo
- [x] El workflow se puede ejecutar desde Actions > Build Artifacts > Run workflow
- [x] No hay referencias a `gh release` ni `latest.json` en el archivo
