### PR TITLE
fix(core): prevent teams from becoming match-ineligible due to contract/transfer/lifecycle gaps

### DIFF
--- a/src-tauri/crates/olm_core/src/contracts.rs
+++ b/src-tauri/crates/olm_core/src/contracts.rs
@@ -4,6 +4,7 @@ use crate::contract_wage_policy::{
 };
 use crate::delegated_renewals::delegate_renewals as delegate_renewals_service;
 use crate::game::Game;
+use crate::roster_stability::{RosterStabilityReason, repair_team};
 use chrono::{Datelike, Months, NaiveDate};
 use crate::domain::message::{InboxMessage, MessageCategory, MessagePriority};
 use crate::domain::negotiation::{NegotiationFeedback, NegotiationMood};
@@ -461,6 +462,8 @@ pub fn process_contract_expiries(game: &mut Game) {
         })
         .collect();
 
+    let mut affected_team_ids: Vec<String> = Vec::new();
+
     for player_index in expired_player_indices {
         let player_id = game.players[player_index].id.clone();
         let player_name = game.players[player_index].match_name.clone();
@@ -489,7 +492,20 @@ pub fn process_contract_expiries(game: &mut Game) {
                 &team_name,
                 &today,
             ));
+
+            if !affected_team_ids.contains(&team_id.to_string()) {
+                affected_team_ids.push(team_id.to_string());
+            }
         }
+    }
+
+    // After releasing expired players, repair non-player AI teams affected by
+    // the expirations. User-managed teams are skipped internally by repair_team
+    // (is_schedulable_ai_main_team returns false when manager_id is Some).
+    let mut sorted_ids = affected_team_ids.clone();
+    sorted_ids.sort();
+    for team_id in sorted_ids {
+        let _ = repair_team(game, &team_id, RosterStabilityReason::ContractExpired);
     }
 }
 

--- a/src-tauri/crates/olm_core/src/end_of_season.rs
+++ b/src-tauri/crates/olm_core/src/end_of_season.rs
@@ -8,6 +8,7 @@ use crate::finances::{
 };
 use crate::game::Game;
 use crate::generator::definitions::CompetitionManifest;
+use crate::roster_stability::{RosterStabilityReason, repair_league};
 use crate::schedule::{
     append_fixtures, generate_preseason_friendlies, generate_schedule_from_config,
 };
@@ -723,8 +724,9 @@ fn process_end_of_season_inner(
     // 9. Renew contracts for players who finished the season with a team
     renew_contracts_for_retained_players(game);
 
-    // 10. Assign free agents to teams with insufficient rosters
-    replenish_depleted_rosters(game);
+    // 10. Repair depleted rosters via the roster stability seam (replaces old
+    //     replenish_depleted_rosters). Handles all schedulable AI main teams.
+    let _ = repair_league(game, RosterStabilityReason::SeasonTransition);
 
     summary
 }
@@ -800,120 +802,6 @@ fn renew_contracts_for_retained_players(game: &mut Game) {
 
         player.contract_end = Some(contract_end.format("%Y-%m-%d").to_string());
         player.wage = wage;
-    }
-}
-
-/// Assign free agents to teams that have fewer than 5 players.
-/// This ensures every team can field a roster for the new season.
-fn replenish_depleted_rosters(game: &mut Game) {
-    let current_date = game.clock.current_date.date_naive();
-    let next_season_year = current_date.year() + 1;
-
-    let team_ids: Vec<String> = game.teams.iter().map(|t| t.id.clone()).collect();
-
-    for team_id in team_ids {
-        let roster_count = game
-            .players
-            .iter()
-            .filter(|p| p.team_id.as_ref().map(|id| id.as_str()) == Some(team_id.as_str()))
-            .count();
-
-        if roster_count >= 5 {
-            continue;
-        }
-
-        let Some(team_name) = game
-            .teams
-            .iter()
-            .find(|t| t.id == team_id)
-            .map(|t| t.name.clone())
-        else {
-            continue;
-        };
-
-        let needed = 5usize.saturating_sub(roster_count);
-
-        for _ in 0..needed {
-            let available_agent = game.players.iter_mut().find(|p| {
-                p.team_id.is_none()
-                    && p.contract_end.is_none()
-                    && p.wage == 0
-                    && !p.was_released
-                    && p.transfer_offers.is_empty()
-            });
-
-            let Some(agent) = available_agent else {
-                break;
-            };
-
-            let agent_id = agent.id.clone();
-            let wage;
-            let contract_years;
-            {
-                let Some(team) = game.teams.iter().find(|t| t.id == team_id) else {
-                    break;
-                };
-                wage = crate::contracts::expected_wage(agent, team, current_date);
-                contract_years = 1;
-            }
-
-            agent.team_id = Some(team_id.clone());
-            agent.wage = wage;
-            agent.contract_end = Some(
-                current_date
-                    .checked_add_months(chrono::Months::new(contract_years * 12))
-                    .unwrap_or_else(|| {
-                        chrono::NaiveDate::from_ymd_opt(next_season_year, 11, 30).unwrap()
-                    })
-                    .format("%Y-%m-%d")
-                    .to_string(),
-            );
-            agent.transfer_listed = false;
-            agent.loan_listed = false;
-
-            let agent_name = agent.match_name.clone();
-            let mut params = std::collections::HashMap::new();
-            params.insert("player".to_string(), agent_name.clone());
-            params.insert("years".to_string(), contract_years.to_string());
-            params.insert("team".to_string(), team_name.clone());
-            params.insert("wage".to_string(), wage.to_string());
-            let msg = crate::domain::message::InboxMessage::new(
-                format!("free_agent_signed_{}_{}", agent_id, team_id),
-                format!("{} signs with {}", agent_name, team_name),
-                format!(
-                    "Free agent {} has signed a {}-year contract with {} at €{}/year.",
-                    agent_name, contract_years, team_name, wage
-                ),
-                "Team Management".to_string(),
-                current_date.format("%Y-%m-%d").to_string(),
-            )
-            .with_category(crate::domain::message::MessageCategory::Transfer)
-            .with_priority(crate::domain::message::MessagePriority::Normal)
-            .with_i18n(
-                "be.msg.freeAgentSigned.subject",
-                "be.msg.freeAgentSigned.body",
-                params,
-            );
-            game.messages.push(msg);
-
-            let user_team_id = game.manager.team_id.clone().unwrap_or_default();
-            let is_user_involved = team_id == user_team_id;
-            crate::transfers::record_transfer(
-                game,
-                &agent_id,
-                "",
-                &team_id,
-                0,
-                wage,
-                contract_years as u8,
-                is_user_involved,
-                is_user_involved,
-                false,
-                None,
-                0,
-                &[],
-            );
-        }
     }
 }
 

--- a/src-tauri/crates/olm_core/src/lib.rs
+++ b/src-tauri/crates/olm_core/src/lib.rs
@@ -29,6 +29,7 @@ pub mod player_identity;
 pub mod player_rating;
 pub mod potential;
 pub mod random_events;
+pub mod roster_stability;
 pub mod schedule;
 pub mod scouting;
 pub mod scrim_flow;

--- a/src-tauri/crates/olm_core/src/roster_stability.rs
+++ b/src-tauri/crates/olm_core/src/roster_stability.rs
@@ -1,0 +1,592 @@
+use crate::domain::player::{Player, PlayerAttributes};
+use crate::domain::season::TransferWindowStatus;
+use crate::domain::stats::LolRole;
+use crate::domain::team::TeamKind;
+use crate::game::Game;
+use chrono::{Datelike, NaiveDate};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+const MIN_MATCH_PLAYERS: usize = 5;
+const MAX_REPAIR_ITERATIONS: usize = MIN_MATCH_PLAYERS;
+const REQUIRED_ROLES: [LolRole; MIN_MATCH_PLAYERS] = [
+    LolRole::Top,
+    LolRole::Jungle,
+    LolRole::Mid,
+    LolRole::Adc,
+    LolRole::Support,
+];
+const POLICY_EXCEPTION_TRANSFER_WINDOW_CLOSED: &str = "transfer_window_closed";
+const EMERGENCY_PLAYER_BIRTH_DATE: &str = "2001-01-01";
+const EMERGENCY_PLAYER_NATIONALITY: &str = "Generated";
+const EMERGENCY_PLAYER_ATTRIBUTE_BASELINE: u8 = 55;
+const EMERGENCY_PLAYER_WAGE: u32 = 50_000;
+const EMERGENCY_PLAYER_MARKET_VALUE: u64 = 250_000;
+const RENEWED_CONTRACT_END_MONTH_DAY: &str = "11-30";
+const MAX_GENERATED_PLAYER_ID_COLLISIONS: usize = 16;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RosterStabilityReason {
+    ContractExpired,
+    TransferOut,
+    Release,
+    SeasonTransition,
+    PreMatch,
+    BackgroundSimulation,
+    LoadMigration,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RepairAction {
+    RenewedContract {
+        player_id: String,
+        role: LolRole,
+    },
+    AssignedFreeAgent {
+        player_id: String,
+        role: LolRole,
+    },
+    GeneratedReplacement {
+        player_id: String,
+        role: LolRole,
+    },
+    ReconciledLineup {
+        removed_ids: Vec<String>,
+        lineup_ids: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RosterEvaluation {
+    pub team_id: String,
+    pub match_eligible: bool,
+    pub schedulable: bool,
+    pub eligible_player_count: usize,
+    pub missing_roles: Vec<LolRole>,
+    pub stale_lineup_ids: Vec<String>,
+    pub expired_player_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RosterStabilityReport {
+    pub team_id: String,
+    pub reason: RosterStabilityReason,
+    pub actions: Vec<RepairAction>,
+    pub policy_exceptions: Vec<String>,
+    pub before: RosterEvaluation,
+    pub after: RosterEvaluation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RosterStabilityError {
+    pub team_id: String,
+    pub reason: RosterStabilityReason,
+    pub missing_count: usize,
+    pub missing_roles: Vec<LolRole>,
+    pub expired_player_ids: Vec<String>,
+    pub stale_lineup_ids: Vec<String>,
+}
+
+impl fmt::Display for RosterStabilityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "team {} is not match eligible: missing_count={}, missing_roles={:?}, expired_players={:?}, stale_lineup_ids={:?}",
+            self.team_id,
+            self.missing_count,
+            self.missing_roles,
+            self.expired_player_ids,
+            self.stale_lineup_ids
+        )
+    }
+}
+
+impl std::error::Error for RosterStabilityError {}
+
+pub fn evaluate_team(
+    game: &Game,
+    team_id: &str,
+    reason: RosterStabilityReason,
+) -> Result<RosterEvaluation, RosterStabilityError> {
+    let team = game
+        .teams
+        .iter()
+        .find(|team| team.id == team_id)
+        .ok_or_else(|| RosterStabilityError {
+            team_id: team_id.to_string(),
+            reason,
+            missing_count: MIN_MATCH_PLAYERS,
+            missing_roles: REQUIRED_ROLES.to_vec(),
+            expired_player_ids: Vec::new(),
+            stale_lineup_ids: Vec::new(),
+        })?;
+
+    let current_date = current_date(game);
+    let eligible_players = eligible_team_players(game, team_id, current_date);
+    let eligible_ids = eligible_players
+        .iter()
+        .map(|player| player.id.as_str())
+        .collect::<HashSet<_>>();
+    let eligible_roles_by_id = eligible_players
+        .iter()
+        .map(|player| (player.id.as_str(), player.natural_position))
+        .collect::<HashMap<_, _>>();
+    let stale_lineup_ids = lineup_issues(&team.active_lineup_ids, &eligible_ids);
+    let lineup_is_valid = active_lineup_is_valid(&team.active_lineup_ids, &eligible_roles_by_id);
+    let missing_roles = missing_roles(&eligible_players);
+    let expired_player_ids = game
+        .players
+        .iter()
+        .filter(|player| player.team_id.as_deref() == Some(team_id))
+        .filter(|player| !has_current_contract(player, current_date))
+        .map(|player| player.id.clone())
+        .collect::<Vec<_>>();
+    let match_eligible =
+        eligible_players.len() >= MIN_MATCH_PLAYERS && missing_roles.is_empty() && lineup_is_valid;
+
+    Ok(RosterEvaluation {
+        team_id: team_id.to_string(),
+        match_eligible,
+        schedulable: is_schedulable_ai_main_team(game, team_id),
+        eligible_player_count: eligible_players.len(),
+        missing_roles,
+        stale_lineup_ids,
+        expired_player_ids,
+    })
+}
+
+pub fn repair_team(
+    game: &mut Game,
+    team_id: &str,
+    reason: RosterStabilityReason,
+) -> Result<RosterStabilityReport, RosterStabilityError> {
+    let before = evaluate_team(game, team_id, reason)?;
+    let mut actions = Vec::new();
+    let mut policy_exceptions = Vec::new();
+
+    if !before.schedulable {
+        return Ok(RosterStabilityReport {
+            team_id: team_id.to_string(),
+            reason,
+            actions,
+            policy_exceptions,
+            after: before.clone(),
+            before,
+        });
+    }
+
+    let mut repaired_game = game.clone();
+
+    renew_needed_current_players(&mut repaired_game, team_id, &mut actions);
+    fill_missing_roles(&mut repaired_game, team_id, reason, &mut actions)?;
+    reconcile_lineup(&mut repaired_game, team_id, &mut actions);
+
+    let after = evaluate_team(&repaired_game, team_id, reason)?;
+    if !after.match_eligible {
+        return Err(error_from_evaluation(reason, &after));
+    }
+
+    if game.season_context.transfer_window.status == TransferWindowStatus::Closed
+        && actions_require_transfer_window_exception(&actions)
+    {
+        policy_exceptions.push(POLICY_EXCEPTION_TRANSFER_WINDOW_CLOSED.to_string());
+    }
+
+    *game = repaired_game;
+
+    Ok(RosterStabilityReport {
+        team_id: team_id.to_string(),
+        reason,
+        actions,
+        policy_exceptions,
+        before,
+        after,
+    })
+}
+
+pub fn repair_league(
+    game: &mut Game,
+    reason: RosterStabilityReason,
+) -> Result<Vec<RosterStabilityReport>, RosterStabilityError> {
+    let mut team_ids = game
+        .teams
+        .iter()
+        .filter(|team| is_schedulable_ai_main_team(game, &team.id))
+        .map(|team| team.id.clone())
+        .collect::<Vec<_>>();
+    team_ids.sort();
+
+    let mut repaired_game = game.clone();
+    let mut reports = Vec::new();
+    for team_id in team_ids {
+        reports.push(repair_team(&mut repaired_game, &team_id, reason)?);
+    }
+
+    *game = repaired_game;
+    Ok(reports)
+}
+
+fn renew_needed_current_players(game: &mut Game, team_id: &str, actions: &mut Vec<RepairAction>) {
+    let current_date = current_date(game);
+    let mut missing = missing_roles(&eligible_team_players(game, team_id, current_date));
+    let contract_end = renewed_contract_end(game);
+    let mut candidate_ids = game
+        .players
+        .iter()
+        .filter(|player| player.team_id.as_deref() == Some(team_id))
+        .filter(|player| !has_current_contract(player, current_date))
+        .map(|player| player.id.clone())
+        .collect::<Vec<_>>();
+    candidate_ids.sort();
+
+    for player_id in candidate_ids {
+        let Some(player_role) = game
+            .players
+            .iter()
+            .find(|player| player.id == player_id)
+            .map(|player| player.natural_position)
+        else {
+            continue;
+        };
+        if missing.contains(&player_role) {
+            if let Some(player) = game
+                .players
+                .iter_mut()
+                .find(|player| player.id == player_id)
+            {
+                player.contract_end = Some(contract_end.clone());
+            }
+            actions.push(RepairAction::RenewedContract {
+                player_id,
+                role: player_role,
+            });
+            missing = missing_roles(&eligible_team_players(game, team_id, current_date));
+        }
+    }
+}
+
+fn fill_missing_roles(
+    game: &mut Game,
+    team_id: &str,
+    reason: RosterStabilityReason,
+    actions: &mut Vec<RepairAction>,
+) -> Result<(), RosterStabilityError> {
+    for _ in 0..MAX_REPAIR_ITERATIONS {
+        let evaluation = evaluate_team(game, team_id, reason).expect("team already evaluated");
+        if evaluation.eligible_player_count >= MIN_MATCH_PLAYERS
+            && evaluation.missing_roles.is_empty()
+        {
+            return Ok(());
+        }
+
+        let role = evaluation
+            .missing_roles
+            .first()
+            .copied()
+            .unwrap_or_else(|| first_uncovered_extra_role(game, team_id));
+
+        if let Some(player_id) = assign_free_agent(game, team_id, role) {
+            actions.push(RepairAction::AssignedFreeAgent { player_id, role });
+        } else {
+            let player_id = available_generated_player_id(game, team_id, reason, role)
+                .ok_or_else(|| error_from_evaluation(reason, &evaluation))?;
+            game.players
+                .push(generated_player(&player_id, team_id, role, game));
+            actions.push(RepairAction::GeneratedReplacement { player_id, role });
+        }
+    }
+    Ok(())
+}
+
+fn assign_free_agent(game: &mut Game, team_id: &str, role: LolRole) -> Option<String> {
+    let current_date = current_date(game);
+    let index = game
+        .players
+        .iter()
+        .enumerate()
+        .filter(|(_, player)| player.team_id.is_none())
+        .filter(|(_, player)| player.natural_position == role)
+        .filter(|(_, player)| {
+            player.contract_end.is_none() || has_current_contract(player, current_date)
+        })
+        .min_by(|(_, left), (_, right)| left.id.cmp(&right.id))
+        .map(|(index, _)| index)?;
+    let contract_end = renewed_contract_end(game);
+    let player = &mut game.players[index];
+    player.team_id = Some(team_id.to_string());
+    player.contract_end = Some(contract_end);
+    Some(player.id.clone())
+}
+
+fn actions_require_transfer_window_exception(actions: &[RepairAction]) -> bool {
+    actions.iter().any(|action| {
+        matches!(
+            action,
+            RepairAction::RenewedContract { .. }
+                | RepairAction::AssignedFreeAgent { .. }
+                | RepairAction::GeneratedReplacement { .. }
+        )
+    })
+}
+
+fn reconcile_lineup(game: &mut Game, team_id: &str, actions: &mut Vec<RepairAction>) {
+    let current_date = current_date(game);
+    let previous = game
+        .teams
+        .iter()
+        .find(|team| team.id == team_id)
+        .map(|team| team.active_lineup_ids.clone())
+        .unwrap_or_default();
+    let lineup = select_lineup(game, team_id, current_date);
+    let lineup_set = lineup.iter().map(String::as_str).collect::<HashSet<_>>();
+    let removed_ids = previous
+        .iter()
+        .filter(|id| !lineup_set.contains(id.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if previous != lineup {
+        if let Some(team) = game.teams.iter_mut().find(|team| team.id == team_id) {
+            team.active_lineup_ids = lineup.clone();
+        }
+        actions.push(RepairAction::ReconciledLineup {
+            removed_ids,
+            lineup_ids: lineup,
+        });
+    }
+}
+
+fn select_lineup(game: &Game, team_id: &str, current_date: NaiveDate) -> Vec<String> {
+    let eligible = eligible_team_players(game, team_id, current_date);
+    REQUIRED_ROLES
+        .iter()
+        .filter_map(|role| {
+            eligible
+                .iter()
+                .filter(|player| player.natural_position == *role)
+                .min_by(|left, right| left.id.cmp(&right.id))
+                .map(|player| player.id.clone())
+        })
+        .collect()
+}
+
+fn first_uncovered_extra_role(game: &Game, team_id: &str) -> LolRole {
+    let current_date = current_date(game);
+    let covered = eligible_team_players(game, team_id, current_date)
+        .iter()
+        .map(|player| player.natural_position)
+        .collect::<HashSet<_>>();
+    REQUIRED_ROLES
+        .iter()
+        .copied()
+        .find(|role| !covered.contains(role))
+        .unwrap_or(LolRole::Support)
+}
+
+fn missing_roles(players: &[&Player]) -> Vec<LolRole> {
+    let covered = players
+        .iter()
+        .map(|player| player.natural_position)
+        .collect::<HashSet<_>>();
+    REQUIRED_ROLES
+        .iter()
+        .copied()
+        .filter(|role| !covered.contains(role))
+        .collect()
+}
+
+fn active_lineup_is_valid(
+    active_lineup_ids: &[String],
+    eligible_roles_by_id: &HashMap<&str, LolRole>,
+) -> bool {
+    if active_lineup_ids.len() != MIN_MATCH_PLAYERS {
+        return false;
+    }
+
+    let mut unique_lineup_ids = HashSet::new();
+    let mut covered_roles = HashSet::new();
+    for player_id in active_lineup_ids {
+        if !unique_lineup_ids.insert(player_id.as_str()) {
+            return false;
+        }
+        let Some(role) = eligible_roles_by_id.get(player_id.as_str()) else {
+            return false;
+        };
+        covered_roles.insert(*role);
+    }
+
+    REQUIRED_ROLES
+        .iter()
+        .all(|role| covered_roles.contains(role))
+}
+
+fn lineup_issues(active_lineup_ids: &[String], eligible_ids: &HashSet<&str>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    active_lineup_ids
+        .iter()
+        .filter(|id| !eligible_ids.contains(id.as_str()) || !seen.insert(id.as_str()))
+        .cloned()
+        .collect()
+}
+
+fn eligible_team_players<'a>(
+    game: &'a Game,
+    team_id: &str,
+    current_date: NaiveDate,
+) -> Vec<&'a Player> {
+    game.players
+        .iter()
+        .filter(|player| player.team_id.as_deref() == Some(team_id))
+        .filter(|player| has_current_contract(player, current_date))
+        .collect()
+}
+
+fn has_current_contract(player: &Player, current_date: NaiveDate) -> bool {
+    let Some(contract_end) = player.contract_end.as_deref() else {
+        return false;
+    };
+    NaiveDate::parse_from_str(contract_end, "%Y-%m-%d")
+        .map(|contract_end| contract_end >= current_date)
+        .unwrap_or(false)
+}
+
+fn is_schedulable_ai_main_team(game: &Game, team_id: &str) -> bool {
+    let Some(team) = game.teams.iter().find(|team| team.id == team_id) else {
+        return false;
+    };
+    if team.team_kind != TeamKind::Main || team.manager_id.is_some() {
+        return false;
+    }
+
+    game.leagues.iter().any(|league| {
+        league.league_kind == crate::domain::league::LeagueKind::Main
+            && (league
+                .standings
+                .iter()
+                .any(|entry| entry.team_id == team_id)
+                || league.fixtures.iter().any(|fixture| {
+                    fixture.status == crate::domain::league::FixtureStatus::Scheduled
+                        && (fixture.home_team_id == team_id || fixture.away_team_id == team_id)
+                }))
+    })
+}
+
+fn generated_player(player_id: &str, team_id: &str, role: LolRole, game: &Game) -> Player {
+    let mut player = Player::new(
+        player_id.to_string(),
+        format!("Emergency {}", role_slug(role).to_uppercase()),
+        format!("Emergency {} Replacement", role_slug(role).to_uppercase()),
+        EMERGENCY_PLAYER_BIRTH_DATE.to_string(),
+        EMERGENCY_PLAYER_NATIONALITY.to_string(),
+        role,
+        PlayerAttributes {
+            mental_resilience: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            champion_pool: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            laning: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            mechanics: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            macro_play: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            consistency: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            discipline: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            teamfighting: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+            shotcalling: EMERGENCY_PLAYER_ATTRIBUTE_BASELINE,
+        },
+    );
+    player.team_id = Some(team_id.to_string());
+    player.contract_end = Some(renewed_contract_end(game));
+    player.wage = EMERGENCY_PLAYER_WAGE;
+    player.market_value = EMERGENCY_PLAYER_MARKET_VALUE;
+    player.lol_ovr = crate::potential::calculate_lol_ovr(&player);
+    player
+}
+
+fn available_generated_player_id(
+    game: &Game,
+    team_id: &str,
+    reason: RosterStabilityReason,
+    role: LolRole,
+) -> Option<String> {
+    let base_id = generated_player_id(team_id, reason, role);
+    if !player_id_exists(game, &base_id) {
+        return Some(base_id);
+    }
+
+    for collision_index in 2..=(MAX_GENERATED_PLAYER_ID_COLLISIONS + 1) {
+        let candidate_id = format!("{base_id}-{collision_index}");
+        if !player_id_exists(game, &candidate_id) {
+            return Some(candidate_id);
+        }
+    }
+    None
+}
+
+fn error_from_evaluation(
+    reason: RosterStabilityReason,
+    evaluation: &RosterEvaluation,
+) -> RosterStabilityError {
+    RosterStabilityError {
+        team_id: evaluation.team_id.clone(),
+        reason,
+        missing_count: MIN_MATCH_PLAYERS.saturating_sub(evaluation.eligible_player_count),
+        missing_roles: evaluation.missing_roles.clone(),
+        expired_player_ids: evaluation.expired_player_ids.clone(),
+        stale_lineup_ids: evaluation.stale_lineup_ids.clone(),
+    }
+}
+
+fn player_id_exists(game: &Game, player_id: &str) -> bool {
+    game.players.iter().any(|player| player.id == player_id)
+}
+
+fn generated_player_id(team_id: &str, reason: RosterStabilityReason, role: LolRole) -> String {
+    format!(
+        "emergency-{}-{}-{}",
+        slug(team_id),
+        reason_slug(reason),
+        role_slug(role)
+    )
+}
+
+fn renewed_contract_end(game: &Game) -> String {
+    let current = current_date(game);
+    format!("{}-{}", current.year() + 1, RENEWED_CONTRACT_END_MONTH_DAY)
+}
+
+fn current_date(game: &Game) -> NaiveDate {
+    game.clock.get_date().date_naive()
+}
+
+fn slug(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn reason_slug(reason: RosterStabilityReason) -> &'static str {
+    match reason {
+        RosterStabilityReason::ContractExpired => "contract-expired",
+        RosterStabilityReason::TransferOut => "transfer-out",
+        RosterStabilityReason::Release => "release",
+        RosterStabilityReason::SeasonTransition => "season-transition",
+        RosterStabilityReason::PreMatch => "prematch",
+        RosterStabilityReason::BackgroundSimulation => "background-simulation",
+        RosterStabilityReason::LoadMigration => "load-migration",
+    }
+}
+
+fn role_slug(role: LolRole) -> &'static str {
+    match role {
+        LolRole::Top => "top",
+        LolRole::Jungle => "jungle",
+        LolRole::Mid => "mid",
+        LolRole::Adc => "adc",
+        LolRole::Support => "support",
+        LolRole::Unknown => "unknown",
+    }
+}

--- a/src-tauri/crates/olm_core/src/transfers.rs
+++ b/src-tauri/crates/olm_core/src/transfers.rs
@@ -1,5 +1,6 @@
 use crate::finances::{calc_annual_wages, record_transaction, BudgetImpact, FinanceTransactionInput};
 use crate::game::Game;
+use crate::roster_stability::{RosterStabilityReason, repair_team};
 use chrono::{Datelike, NaiveDate};
 use crate::domain::negotiation::{NegotiationFeedback, NegotiationMood};
 use crate::domain::player::{PlayerOfferItem, TransferOfferStatus, WageNegotiationStatus};
@@ -3024,6 +3025,11 @@ fn execute_transfer_with_payer(
         clear_player_from_active_lineup(t, player_id);
         reconcile_lol_active_lineup(t, &players_snapshot);
     }
+
+    // After transfer-out, repair non-player AI selling teams whose roster may
+    // have fallen below the match-eligibility threshold. Academy teams are
+    // skipped internally by is_schedulable_ai_main_team.
+    let _ = repair_team(game, from_team_id, RosterStabilityReason::TransferOut);
 
     if should_generate_major_transfer_news(&player_snapshot, fee) {
         let article_id = format!(

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -659,7 +659,32 @@ fn simulate_background_league(
 
 /// Simulate all background leagues (game.leagues[1..]) for today.
 /// This is a no-op when there is only the active league.
+/// Before simulation, runs repair_league to ensure all AI teams are match eligible.
 fn process_background_leagues(game: &mut Game, today: &str) {
+    // Before background simulation, ensure all AI teams are match eligible.
+    // If repair fails, log the warning — the game continues without crashing.
+    match crate::roster_stability::repair_league(
+        game,
+        crate::roster_stability::RosterStabilityReason::BackgroundSimulation,
+    ) {
+        Ok(reports) => {
+            let total_actions: usize = reports.iter().map(|r| r.actions.len()).sum();
+            if total_actions > 0 {
+                info!(
+                    "[turn] background simulation: repaired {} team(s) with {} action(s)",
+                    reports.len(),
+                    total_actions
+                );
+            }
+        }
+        Err(e) => {
+            info!(
+                "[turn] background simulation repair failed for team {}: {}",
+                e.team_id, e
+            );
+        }
+    }
+
     let season = game.clock.current_date.year() as u32;
     for i in 1..game.leagues.len() {
         let league = &mut game.leagues[i];
@@ -1248,18 +1273,32 @@ where
         .teams
         .iter()
         .find(|t| t.id == home_team_id)
-        .map(|t| t.name.as_str())
-        .unwrap_or("?");
+        .map(|t| t.name.clone())
+        .unwrap_or_else(|| "?".to_string());
     let away_name = game
         .teams
         .iter()
         .find(|t| t.id == away_team_id)
-        .map(|t| t.name.as_str())
-        .unwrap_or("?");
+        .map(|t| t.name.clone())
+        .unwrap_or_else(|| "?".to_string());
     debug!(
         "[turn] simulate_single_match: {} vs {} (fixture #{})",
         home_name, away_name, idx
     );
+
+    // Pre-match: ensure both teams are match eligible before engine team building.
+    // For user teams, repair_team is a no-op (skips non-schedulable teams).
+    for team_id in [&home_team_id, &away_team_id] {
+        if let Err(e) = crate::roster_stability::repair_team(
+            game,
+            team_id,
+            crate::roster_stability::RosterStabilityReason::PreMatch,
+        ) {
+            info!(
+                "[turn] pre-match repair failed for team {team_id}: {e}"
+            );
+        }
+    }
 
     let home_data = build_engine_team(game, &home_team_id);
     let away_data = build_engine_team(game, &away_team_id);

--- a/src-tauri/crates/olm_core/tests/lifecycle_stability_tests.rs
+++ b/src-tauri/crates/olm_core/tests/lifecycle_stability_tests.rs
@@ -1,0 +1,482 @@
+use chrono::{TimeZone, Utc};
+use olm_core::clock::GameClock;
+use olm_core::domain::league::{
+    Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry,
+};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::game::Game;
+use olm_core::roster_stability::{
+    evaluate_team, RepairAction, RosterStabilityReason,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn attrs() -> PlayerAttributes {
+    PlayerAttributes {
+        mental_resilience: 60,
+        champion_pool: 60,
+        laning: 60,
+        mechanics: 60,
+        macro_play: 60,
+        consistency: 60,
+        discipline: 60,
+        teamfighting: 60,
+        shotcalling: 60,
+    }
+}
+
+fn player(id: &str, team_id: Option<&str>, role: LolRole, contract_end: Option<&str>) -> Player {
+    let mut player = Player::new(
+        id.to_string(),
+        id.to_string(),
+        format!("{id} Test"),
+        "2000-01-01".to_string(),
+        "Spain".to_string(),
+        role,
+        attrs(),
+    );
+    player.team_id = team_id.map(str::to_string);
+    player.contract_end = contract_end.map(str::to_string);
+    player.wage = 50_000;
+    player.market_value = 500_000;
+    player
+}
+
+fn team(id: &str, manager_id: Option<&str>, lineup: Vec<&str>) -> Team {
+    let mut team = Team::new(
+        id.to_string(),
+        format!("{id} Esports"),
+        id.chars().take(3).collect::<String>().to_uppercase(),
+        "Spain".to_string(),
+        "Madrid".to_string(),
+        "Arena".to_string(),
+        10_000,
+    );
+    team.manager_id = manager_id.map(str::to_string);
+    team.active_lineup_ids = lineup.into_iter().map(str::to_string).collect();
+    team
+}
+
+fn league_with_team(team_id: &str) -> League {
+    League {
+        id: "league-1".to_string(),
+        name: "League One".to_string(),
+        season: 2026,
+        fixtures: vec![Fixture {
+            id: "fixture-1".to_string(),
+            matchday: 1,
+            date: "2026-08-02".to_string(),
+            home_team_id: team_id.to_string(),
+            away_team_id: "other-ai".to_string(),
+            match_type: MatchType::League,
+            best_of: 1,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        }],
+        standings: vec![StandingEntry::new(team_id.to_string())],
+        competition_id: Some("competition-1".to_string()),
+        logo: None,
+        league_kind: LeagueKind::Main,
+        split_index: 0,
+        tier: 1,
+        active: true,
+    }
+}
+
+fn game_with_ai_team(players: Vec<Player>, lineup: Vec<&str>) -> Game {
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "manager-1".to_string(),
+        "Jane".to_string(),
+        "Doe".to_string(),
+        "1980-01-01".to_string(),
+        "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![
+            team("ai-team", None, lineup),
+            team("other-ai", None, vec![]),
+        ],
+        players,
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("ai-team")];
+    game.user_competition_id = Some("competition-1".to_string());
+    game
+}
+
+/// Helper: returns players with contracts that expire on `2026-08-01` (the game
+/// clock date in the default test setup). Using `2026-07-31` so they are already
+/// expired *before* today's processing begins.
+fn expired_roster(team_id: &str) -> Vec<Player> {
+    vec![
+        player("exp-top", Some(team_id), LolRole::Top, Some("2026-07-31")),
+        player("exp-jungle", Some(team_id), LolRole::Jungle, Some("2026-07-31")),
+        player("exp-mid", Some(team_id), LolRole::Mid, Some("2026-07-31")),
+        player("exp-adc", Some(team_id), LolRole::Adc, Some("2026-07-31")),
+        player("exp-support", Some(team_id), LolRole::Support, Some("2026-07-31")),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// 2.1 — Contract expiry scenarios
+// ---------------------------------------------------------------------------
+
+#[test]
+fn same_day_mass_expiry_depletes_ai_team_and_repair_restores_eligibility() {
+    // Five players, all contracts expired before today.
+    // After process_contract_expiries releases them, the wiring in contracts.rs
+    // must call repair_team so the AI team remains match eligible.
+    let mut game = game_with_ai_team(
+        expired_roster("ai-team"),
+        vec!["exp-top", "exp-jungle", "exp-mid", "exp-adc", "exp-support"],
+    );
+
+    // Before expiry processing: all players have expired contracts, but they
+    // still belong to the team (not yet released).
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::ContractExpired)
+        .expect("team should evaluate before expiry");
+    assert!(!before.match_eligible, "team should be ineligible before expiry processing");
+    assert_eq!(before.eligible_player_count, 0, "all contracts are expired");
+
+    // Process contract expiries — this should release expired players AND
+    // repair the AI team (via wiring in contracts.rs).
+    olm_core::contracts::process_contract_expiries(&mut game);
+
+    // After wiring: the AI team must be match eligible again.
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::ContractExpired)
+        .expect("team should evaluate after expiry");
+    assert!(
+        after.match_eligible,
+        "AI team should be match eligible after mass contract expiry + repair"
+    );
+    assert_eq!(
+        after.eligible_player_count, 5,
+        "repair should restore five eligible players"
+    );
+}
+
+#[test]
+fn role_loss_expiry_restores_eligibility_after_repair() {
+    // Four players with active contracts, one key role (support) expired.
+    let players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player("jungle", Some("ai-team"), LolRole::Jungle, Some("2028-06-30")),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("exp-support", Some("ai-team"), LolRole::Support, Some("2026-07-31")),
+    ];
+    let mut game = game_with_ai_team(
+        players,
+        vec!["top", "jungle", "mid", "adc", "exp-support"],
+    );
+
+    // Before: team is missing support due to expired contract
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::ContractExpired)
+        .expect("team should evaluate before expiry");
+    assert!(!before.match_eligible);
+    assert!(before.missing_roles.contains(&LolRole::Support));
+    assert!(before.expired_player_ids.contains(&"exp-support".to_string()));
+
+    // Process contract expiries — releases exp-support, then repair fills the role
+    olm_core::contracts::process_contract_expiries(&mut game);
+
+    // After: support role should be filled
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::ContractExpired)
+        .expect("team should evaluate after expiry");
+    assert!(
+        after.match_eligible,
+        "AI team should be match eligible after role-loss expiry + repair"
+    );
+    assert!(
+        after.missing_roles.is_empty(),
+        "all roles should be covered after repair"
+    );
+
+    // The expired support player was released by process_contract_expiries, but
+    // repair_team may re-sign them as a free agent (assign_free_agent picks up
+    // players with contract_end == None). Either way, the team's support role
+    // is covered.
+    let exp_support = game.players.iter().find(|p| p.id == "exp-support")
+        .expect("exp-support should still exist");
+    // The player is either re-signed to ai-team (by free-agent assignment) or
+    // remains a free agent — either state is valid as long as the team is eligible.
+    assert!(
+        exp_support.team_id.is_none() || exp_support.team_id.as_deref() == Some("ai-team"),
+        "expired support should be released or re-signed by repair"
+    );
+}
+
+#[test]
+fn user_managed_team_expiry_evaluates_but_does_not_auto_repair() {
+    // User team with expired contracts — contracts.rs should only repair
+    // non-player AI teams, not user-managed ones.
+    let manager_id = "manager-1";
+    let mut user_team = team("user-team", Some(manager_id), vec![]);
+    user_team.active_lineup_ids = vec!["exp-top".to_string(), "exp-jungle".to_string(),
+        "exp-mid".to_string(), "exp-adc".to_string(), "exp-support".to_string()];
+
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        manager_id.to_string(), "Jane".to_string(), "Doe".to_string(),
+        "1980-01-01".to_string(), "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![
+            user_team,
+            team("other-ai", None, vec![]),
+        ],
+        expired_roster("user-team"),
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("user-team")];
+    game.user_competition_id = Some("competition-1".to_string());
+
+    // Process contract expiries
+    olm_core::contracts::process_contract_expiries(&mut game);
+
+    // User team should still be ineligible — no auto-repair for managed teams
+    let after = evaluate_team(&game, "user-team", RosterStabilityReason::ContractExpired)
+        .expect("user team should evaluate");
+    assert!(
+        !after.match_eligible,
+        "user-managed team should NOT be auto-repaired after contract expiry"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2.3 — Transfer scenario tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ai_team_transfer_out_restores_eligibility_after_repair() {
+    // AI team sells a key player (the support). After execute_transfer removes
+    // the player, the wiring must repair the team.
+    let players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player("jungle", Some("ai-team"), LolRole::Jungle, Some("2028-06-30")),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("support", Some("ai-team"), LolRole::Support, Some("2028-06-30")),
+    ];
+    let mut game = game_with_ai_team(
+        players,
+        vec!["top", "jungle", "mid", "adc", "support"],
+    );
+    // Add a buyer team to the game
+    game.teams.push(team("buyer-team", None, vec![]));
+
+    // Execute transfer: move support from ai-team to buyer-team (internal fn)
+    // This simulates an AI team selling a player.
+    let result = crate::transfer_out_from_ai_team(
+        &mut game, "support", "ai-team", "buyer-team",
+    );
+    assert!(result.is_ok(), "transfer should succeed: {:?}", result.err());
+
+    // After transfer-out, the AI team must still be match eligible
+    let evaluated = evaluate_team(&game, "ai-team", RosterStabilityReason::TransferOut)
+        .expect("ai-team should evaluate after transfer");
+    assert!(
+        evaluated.match_eligible,
+        "AI team should be match eligible after selling a key player"
+    );
+    assert!(evaluated.missing_roles.is_empty(),
+        "all roles should be covered after repair");
+}
+
+/// Helper that calls the internal execute_transfer to move a player between teams.
+/// We use this because the public transfer API (make_transfer_bid, respond_to_offer)
+/// is user-team-only and requires a negotiation flow.
+fn transfer_out_from_ai_team(
+    game: &mut Game,
+    player_id: &str,
+    from_team: &str,
+    to_team: &str,
+) -> Result<(), String> {
+    // Directly set player's team_id + call execute_transfer-like logic
+    // Actually, we call execute_transfer which is a private fn in transfers.rs.
+    // Since it's not pub, we need another approach.
+    //
+    // We simulate the transfer manually: move the player, then call repair_team.
+    // The actual wiring in transfers.rs will do both atomically.
+    // For the test, we manually move + repair to assert the seam's contract.
+    let player_was_transferred = game.players.iter_mut()
+        .find(|p| p.id == player_id && p.team_id.as_deref() == Some(from_team))
+        .map(|p| {
+            p.team_id = Some(to_team.to_string());
+        })
+        .is_some();
+    if !player_was_transferred {
+        return Err("Player not found on source team".to_string());
+    }
+    // Remove from lineup
+    if let Some(team) = game.teams.iter_mut().find(|t| t.id == from_team) {
+        team.active_lineup_ids.retain(|id| id != player_id);
+    }
+    // The production wiring in transfers.rs will call repair_team after
+    // execute_transfer for non-player selling teams. We simulate that here.
+    olm_core::roster_stability::repair_team(
+        game, from_team, RosterStabilityReason::TransferOut,
+    ).map_err(|e| format!("repair failed: {e}"))?;
+    Ok(())
+}
+
+#[test]
+fn ai_team_contract_release_repairs_roster() {
+    // A non-user AI team loses a key player through release/expiry.
+    // This works through process_contract_expiries which calls repair_team.
+    let players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player("jungle", Some("ai-team"), LolRole::Jungle, Some("2028-06-30")),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        // Support contract expires today
+        player("exp-support", Some("ai-team"), LolRole::Support, Some("2026-07-31")),
+    ];
+    let mut game = game_with_ai_team(players, vec!["top", "jungle", "mid", "adc", "exp-support"]);
+
+    // Process contract expiries — releases support, then repairs
+    olm_core::contracts::process_contract_expiries(&mut game);
+
+    let evaluation = evaluate_team(&game, "ai-team", RosterStabilityReason::Release)
+        .expect("team should evaluate after release");
+    assert!(
+        evaluation.match_eligible,
+        "AI team should be eligible after release + repair"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2.5 — End-of-season replacement tests (exercised via repair_league)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn season_transition_repair_replaces_depleted_rosters() {
+    // After season transition, an AI team with only 4 players should be repaired
+    // by repair_league with SeasonTransition reason.
+    let players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player("jungle", Some("ai-team"), LolRole::Jungle, Some("2028-06-30")),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+    ];
+    let mut game = game_with_ai_team(players, vec!["top", "jungle", "mid", "adc"]);
+
+    // Before repair: team is ineligible
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::SeasonTransition)
+        .expect("team should evaluate before transition");
+    assert!(!before.match_eligible);
+
+    // repair_league should fix all AI teams
+    let reports = olm_core::roster_stability::repair_league(
+        &mut game,
+        RosterStabilityReason::SeasonTransition,
+    ).expect("repair_league should succeed");
+
+    // At least one report for ai-team
+    let ai_report = reports.iter().find(|r| r.team_id == "ai-team")
+        .expect("ai-team should have a repair report");
+
+    // Team should now be eligible
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::SeasonTransition)
+        .expect("team should evaluate after transition");
+    assert!(after.match_eligible);
+
+    // Report should have at least one roster-changing action
+    let has_roster_action = ai_report.actions.iter().any(|a| matches!(
+        a,
+        RepairAction::GeneratedReplacement { .. }
+            | RepairAction::AssignedFreeAgent { .. }
+            | RepairAction::RenewedContract { .. }
+    ));
+    assert!(has_roster_action, "season transition repair should produce a roster action");
+}
+
+#[test]
+fn repair_league_contract_expired_restores_all_ai_teams() {
+    // Two AI teams, both with expired rosters. repair_league(ContractExpired)
+    // should restore both.
+    let expired_ai = expired_roster("ai-team");
+    let expired_other = expired_roster("other-ai");
+
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "manager-1".to_string(), "Jane".to_string(), "Doe".to_string(),
+        "1980-01-01".to_string(), "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut all_players = Vec::new();
+    all_players.extend(expired_ai);
+    all_players.extend(expired_other);
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![
+            team("ai-team", None, vec!["exp-top", "exp-jungle", "exp-mid", "exp-adc", "exp-support"]),
+            team("other-ai", None, vec!["exp-top", "exp-jungle", "exp-mid", "exp-adc", "exp-support"]),
+        ],
+        all_players,
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("ai-team")];
+    game.user_competition_id = Some("competition-1".to_string());
+    // Add other-ai to the league's standings so it's also schedulable
+    game.leagues[0].standings.push(StandingEntry::new("other-ai".to_string()));
+    // Add a fixture for other-ai
+    game.leagues[0].fixtures.push(Fixture {
+        id: "fixture-2".to_string(),
+        matchday: 1,
+        date: "2026-08-02".to_string(),
+        home_team_id: "other-ai".to_string(),
+        away_team_id: "ai-team".to_string(),
+        match_type: MatchType::League,
+        best_of: 1,
+        status: FixtureStatus::Scheduled,
+        result: None,
+    });
+
+    // Run repair_league with ContractExpired reason
+    let reports = olm_core::roster_stability::repair_league(
+        &mut game,
+        RosterStabilityReason::ContractExpired,
+    ).expect("repair_league should succeed");
+
+    // Both teams should have been repaired
+    assert!(
+        reports.iter().any(|r| r.team_id == "ai-team"),
+        "ai-team should have a report"
+    );
+    assert!(
+        reports.iter().any(|r| r.team_id == "other-ai"),
+        "other-ai should have a report"
+    );
+
+    // Both teams should now be match eligible
+    let ai_after = evaluate_team(&game, "ai-team", RosterStabilityReason::ContractExpired)
+        .expect("ai-team should evaluate");
+    assert!(ai_after.match_eligible, "ai-team should be eligible");
+    assert_eq!(ai_after.eligible_player_count, 5);
+
+    let other_after = evaluate_team(&game, "other-ai", RosterStabilityReason::ContractExpired)
+        .expect("other-ai should evaluate");
+    assert!(other_after.match_eligible, "other-ai should be eligible");
+    assert_eq!(other_after.eligible_player_count, 5);
+}

--- a/src-tauri/crates/olm_core/tests/roster_stability_tests.rs
+++ b/src-tauri/crates/olm_core/tests/roster_stability_tests.rs
@@ -1,0 +1,759 @@
+use chrono::{TimeZone, Utc};
+use olm_core::clock::GameClock;
+use olm_core::domain::league::{
+    Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry,
+};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::season::TransferWindowStatus;
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::game::Game;
+use olm_core::roster_stability::{
+    RepairAction, RosterStabilityReason, evaluate_team, repair_league, repair_team,
+};
+
+fn attrs() -> PlayerAttributes {
+    PlayerAttributes {
+        mental_resilience: 60,
+        champion_pool: 60,
+        laning: 60,
+        mechanics: 60,
+        macro_play: 60,
+        consistency: 60,
+        discipline: 60,
+        teamfighting: 60,
+        shotcalling: 60,
+    }
+}
+
+fn player(id: &str, team_id: Option<&str>, role: LolRole, contract_end: Option<&str>) -> Player {
+    let mut player = Player::new(
+        id.to_string(),
+        id.to_string(),
+        format!("{id} Test"),
+        "2000-01-01".to_string(),
+        "Spain".to_string(),
+        role,
+        attrs(),
+    );
+    player.team_id = team_id.map(str::to_string);
+    player.contract_end = contract_end.map(str::to_string);
+    player.wage = 50_000;
+    player.market_value = 500_000;
+    player
+}
+
+fn team(id: &str, manager_id: Option<&str>, lineup: Vec<&str>) -> Team {
+    let mut team = Team::new(
+        id.to_string(),
+        format!("{id} Esports"),
+        id.chars().take(3).collect::<String>().to_uppercase(),
+        "Spain".to_string(),
+        "Madrid".to_string(),
+        "Arena".to_string(),
+        10_000,
+    );
+    team.manager_id = manager_id.map(str::to_string);
+    team.active_lineup_ids = lineup.into_iter().map(str::to_string).collect();
+    team
+}
+
+fn league_with_team(team_id: &str) -> League {
+    League {
+        id: "league-1".to_string(),
+        name: "League One".to_string(),
+        season: 2026,
+        fixtures: vec![Fixture {
+            id: "fixture-1".to_string(),
+            matchday: 1,
+            date: "2026-08-02".to_string(),
+            home_team_id: team_id.to_string(),
+            away_team_id: "other-ai".to_string(),
+            match_type: MatchType::League,
+            best_of: 1,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        }],
+        standings: vec![StandingEntry::new(team_id.to_string())],
+        competition_id: Some("competition-1".to_string()),
+        logo: None,
+        league_kind: LeagueKind::Main,
+        split_index: 0,
+        tier: 1,
+        active: true,
+    }
+}
+
+fn game_with(players: Vec<Player>, lineup: Vec<&str>) -> Game {
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "manager-1".to_string(),
+        "Jane".to_string(),
+        "Doe".to_string(),
+        "1980-01-01".to_string(),
+        "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![
+            team("ai-team", None, lineup),
+            team("other-ai", None, vec![]),
+        ],
+        players,
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("ai-team")];
+    game.user_competition_id = Some("competition-1".to_string());
+    game
+}
+
+fn full_roster(team_id: &str) -> Vec<Player> {
+    vec![
+        player("top", Some(team_id), LolRole::Top, Some("2028-06-30")),
+        player("jungle", Some(team_id), LolRole::Jungle, Some("2028-06-30")),
+        player("mid", Some(team_id), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some(team_id), LolRole::Adc, Some("2028-06-30")),
+        player(
+            "support",
+            Some(team_id),
+            LolRole::Support,
+            Some("2028-06-30"),
+        ),
+    ]
+}
+
+#[test]
+fn valid_roster_evaluates_without_repair_actions() {
+    let game = game_with(
+        full_roster("ai-team"),
+        vec!["top", "jungle", "mid", "adc", "support"],
+    );
+
+    let evaluation = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate");
+
+    assert!(evaluation.match_eligible);
+    assert_eq!(evaluation.eligible_player_count, 5);
+    assert!(evaluation.missing_roles.is_empty());
+    assert!(evaluation.stale_lineup_ids.is_empty());
+}
+
+#[test]
+fn below_minimum_roster_is_repaired_with_generated_players() {
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        ],
+        vec!["top", "jungle", "mid", "adc"],
+    );
+
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("generated emergency player should repair below-minimum roster");
+    let evaluation = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate after repair");
+
+    assert!(evaluation.match_eligible);
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::GeneratedReplacement {
+            role: LolRole::Support,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn missing_role_prefers_role_fit_free_agent() {
+    let mut players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "jungle",
+            Some("ai-team"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("adc2", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("free-support", None, LolRole::Support, Some("2028-06-30")),
+    ];
+    players[5].market_value = 100_000;
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc", "adc2"]);
+
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("free support should repair role gap");
+
+    assert_eq!(
+        game.players
+            .iter()
+            .find(|player| player.id == "free-support")
+            .unwrap()
+            .team_id
+            .as_deref(),
+        Some("ai-team")
+    );
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::AssignedFreeAgent { player_id, role: LolRole::Support } if player_id == "free-support"
+    )));
+}
+
+#[test]
+fn stale_lineup_ids_are_reconciled_to_current_eligible_players() {
+    let mut game = game_with(
+        full_roster("ai-team"),
+        vec!["top", "released-player", "mid", "adc", "support"],
+    );
+
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::LoadMigration)
+        .expect("stale lineup should reconcile");
+    let lineup = &game
+        .teams
+        .iter()
+        .find(|team| team.id == "ai-team")
+        .unwrap()
+        .active_lineup_ids;
+
+    assert_eq!(lineup.len(), 5);
+    assert!(!lineup.iter().any(|id| id == "released-player"));
+    assert!(lineup.iter().any(|id| id == "jungle"));
+    assert!(
+        report
+            .actions
+            .iter()
+            .any(|action| matches!(action, RepairAction::ReconciledLineup { .. }))
+    );
+}
+
+#[test]
+fn closed_window_emergency_repairs_and_reports_policy_exception() {
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        ],
+        vec!["top", "jungle", "mid", "adc"],
+    );
+    game.season_context.transfer_window.status = TransferWindowStatus::Closed;
+
+    let report = repair_team(
+        &mut game,
+        "ai-team",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("emergency policy should bypass closed transfer window");
+
+    assert!(
+        report
+            .policy_exceptions
+            .iter()
+            .any(|exception| exception == "transfer_window_closed")
+    );
+}
+
+#[test]
+fn closed_window_expired_bench_without_repair_does_not_report_policy_exception() {
+    let mut players = full_roster("ai-team");
+    players.push(player(
+        "expired-bench",
+        Some("ai-team"),
+        LolRole::Support,
+        Some("2026-07-31"),
+    ));
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc", "support"]);
+    game.season_context.transfer_window.status = TransferWindowStatus::Closed;
+
+    let report = repair_team(
+        &mut game,
+        "ai-team",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("eligible active roster should remain a no-op despite expired bench players");
+
+    assert!(report.before.match_eligible);
+    assert!(report.after.match_eligible);
+    assert!(report.actions.is_empty());
+    assert!(
+        !report
+            .policy_exceptions
+            .iter()
+            .any(|exception| exception == "transfer_window_closed")
+    );
+}
+
+#[test]
+fn free_agent_starvation_uses_deterministic_generated_replacement() {
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player(
+                "support",
+                Some("ai-team"),
+                LolRole::Support,
+                Some("2028-06-30"),
+            ),
+        ],
+        vec!["top", "jungle", "mid", "support"],
+    );
+
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("generated ADC should repair free-agent starvation");
+
+    assert!(game.players.iter().any(|player| {
+        player.id == "emergency-ai-team-prematch-adc"
+            && player.team_id.as_deref() == Some("ai-team")
+            && player.natural_position == LolRole::Adc
+    }));
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::GeneratedReplacement { player_id, role: LolRole::Adc } if player_id == "emergency-ai-team-prematch-adc"
+    )));
+}
+
+#[test]
+fn generated_replacement_collision_uses_next_deterministic_id() {
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player(
+                "support",
+                Some("ai-team"),
+                LolRole::Support,
+                Some("2028-06-30"),
+            ),
+            player(
+                "emergency-ai-team-prematch-adc",
+                Some("other-ai"),
+                LolRole::Adc,
+                Some("2028-06-30"),
+            ),
+        ],
+        vec!["top", "jungle", "mid", "support"],
+    );
+
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("ID collision should still make deterministic repair progress");
+
+    assert!(game.players.iter().any(|player| {
+        player.id == "emergency-ai-team-prematch-adc-2"
+            && player.team_id.as_deref() == Some("ai-team")
+            && player.natural_position == LolRole::Adc
+    }));
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::GeneratedReplacement { player_id, role: LolRole::Adc } if player_id == "emergency-ai-team-prematch-adc-2"
+    )));
+}
+
+#[test]
+fn generated_replacement_wrong_role_collision_uses_next_deterministic_id() {
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player(
+                "support",
+                Some("ai-team"),
+                LolRole::Support,
+                Some("2028-06-30"),
+            ),
+            player(
+                "emergency-ai-team-prematch-adc",
+                Some("ai-team"),
+                LolRole::Support,
+                Some("2028-06-30"),
+            ),
+        ],
+        vec![
+            "top",
+            "jungle",
+            "mid",
+            "support",
+            "emergency-ai-team-prematch-adc",
+        ],
+    );
+
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("wrong-role ID collision should still make deterministic repair progress");
+
+    assert!(game.players.iter().any(|player| {
+        player.id == "emergency-ai-team-prematch-adc-2"
+            && player.team_id.as_deref() == Some("ai-team")
+            && player.natural_position == LolRole::Adc
+    }));
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::GeneratedReplacement { player_id, role: LolRole::Adc } if player_id == "emergency-ai-team-prematch-adc-2"
+    )));
+}
+
+#[test]
+fn duplicate_lineup_ids_are_not_match_eligible_until_reconciled() {
+    let mut game = game_with(
+        full_roster("ai-team"),
+        vec!["top", "top", "mid", "adc", "support"],
+    );
+
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate");
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("duplicate lineup ids should reconcile");
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate after repair");
+
+    assert!(!before.match_eligible);
+    assert!(after.match_eligible);
+    assert_eq!(after.stale_lineup_ids, Vec::<String>::new());
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::ReconciledLineup { lineup_ids, .. } if lineup_ids == &vec![
+            "top".to_string(),
+            "jungle".to_string(),
+            "mid".to_string(),
+            "adc".to_string(),
+            "support".to_string(),
+        ]
+    )));
+}
+
+#[test]
+fn short_non_empty_lineup_is_not_match_eligible_until_reconciled() {
+    let mut game = game_with(full_roster("ai-team"), vec!["top", "jungle", "mid", "adc"]);
+
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate");
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("short non-empty lineup should reconcile");
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate after repair");
+
+    assert!(!before.match_eligible);
+    assert!(after.match_eligible);
+    assert_eq!(after.eligible_player_count, 5);
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::ReconciledLineup { lineup_ids, .. } if lineup_ids.len() == 5
+    )));
+}
+
+#[test]
+fn empty_lineup_is_not_match_eligible_until_reconciled() {
+    let mut game = game_with(full_roster("ai-team"), vec![]);
+
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate");
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("empty lineup should reconcile when a lineup is required");
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate after repair");
+
+    assert!(!before.match_eligible);
+    assert!(after.match_eligible);
+    assert_eq!(after.stale_lineup_ids, Vec::<String>::new());
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::ReconciledLineup { lineup_ids, .. } if lineup_ids == &vec![
+            "top".to_string(),
+            "jungle".to_string(),
+            "mid".to_string(),
+            "adc".to_string(),
+            "support".to_string(),
+        ]
+    )));
+}
+
+#[test]
+fn lineup_missing_required_role_is_not_match_eligible_until_reconciled() {
+    let mut players = full_roster("ai-team");
+    players.push(player(
+        "adc2",
+        Some("ai-team"),
+        LolRole::Adc,
+        Some("2028-06-30"),
+    ));
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc", "adc2"]);
+
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate");
+    let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("lineup missing support should reconcile");
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("team should evaluate after repair");
+
+    assert!(!before.match_eligible);
+    assert!(after.match_eligible);
+    assert!(report.actions.iter().any(|action| matches!(
+        action,
+        RepairAction::ReconciledLineup { removed_ids, lineup_ids }
+            if removed_ids == &vec!["adc2".to_string()]
+                && lineup_ids == &vec![
+                    "top".to_string(),
+                    "jungle".to_string(),
+                    "mid".to_string(),
+                    "adc".to_string(),
+                    "support".to_string(),
+                ]
+    )));
+}
+
+#[test]
+fn generated_replacement_id_exhaustion_returns_error_without_mutating_game() {
+    let mut players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "jungle",
+            Some("ai-team"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player(
+            "support",
+            Some("ai-team"),
+            LolRole::Support,
+            Some("2028-06-30"),
+        ),
+    ];
+    players.push(player(
+        "emergency-ai-team-prematch-adc",
+        Some("other-ai"),
+        LolRole::Adc,
+        Some("2028-06-30"),
+    ));
+    for suffix in 2..=17 {
+        players.push(player(
+            &format!("emergency-ai-team-prematch-adc-{suffix}"),
+            Some("other-ai"),
+            LolRole::Adc,
+            Some("2028-06-30"),
+        ));
+    }
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "support"]);
+    let original_players = game
+        .players
+        .iter()
+        .map(|player| {
+            (
+                player.id.clone(),
+                player.team_id.clone(),
+                player.contract_end.clone(),
+                player.natural_position,
+            )
+        })
+        .collect::<Vec<_>>();
+    let original_lineup = game
+        .teams
+        .iter()
+        .find(|team| team.id == "ai-team")
+        .unwrap()
+        .active_lineup_ids
+        .clone();
+
+    let error = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect_err("exhausted generated IDs should return a fatal domain error");
+
+    assert_eq!(error.reason, RosterStabilityReason::PreMatch);
+    assert_eq!(error.missing_roles, vec![LolRole::Adc]);
+    assert_eq!(
+        game.players
+            .iter()
+            .map(|player| {
+                (
+                    player.id.clone(),
+                    player.team_id.clone(),
+                    player.contract_end.clone(),
+                    player.natural_position,
+                )
+            })
+            .collect::<Vec<_>>(),
+        original_players
+    );
+    assert_eq!(
+        game.teams
+            .iter()
+            .find(|team| team.id == "ai-team")
+            .unwrap()
+            .active_lineup_ids,
+        original_lineup
+    );
+}
+
+#[test]
+fn repair_league_repairs_all_schedulable_ai_main_teams() {
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        ],
+        vec!["top", "jungle", "mid", "adc"],
+    );
+
+    let reports = repair_league(&mut game, RosterStabilityReason::LoadMigration)
+        .expect("league repair should repair schedulable AI teams through the PR1 seam");
+    let evaluation = evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+        .expect("team should evaluate after repair");
+
+    assert_eq!(reports.len(), 2);
+    assert!(reports.iter().any(|report| report.team_id == "ai-team"
+        && report.reason == RosterStabilityReason::LoadMigration));
+    assert!(evaluation.match_eligible);
+}
+
+#[test]
+fn repair_league_error_does_not_commit_partial_team_repairs() {
+    let mut players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "jungle",
+            Some("ai-team"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player(
+            "other-top",
+            Some("other-ai"),
+            LolRole::Top,
+            Some("2028-06-30"),
+        ),
+        player(
+            "other-jungle",
+            Some("other-ai"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player(
+            "other-mid",
+            Some("other-ai"),
+            LolRole::Mid,
+            Some("2028-06-30"),
+        ),
+        player(
+            "other-support",
+            Some("other-ai"),
+            LolRole::Support,
+            Some("2028-06-30"),
+        ),
+    ];
+    players.push(player(
+        "emergency-other-ai-load-migration-adc",
+        Some("ai-team"),
+        LolRole::Adc,
+        Some("2028-06-30"),
+    ));
+    for suffix in 2..=17 {
+        players.push(player(
+            &format!("emergency-other-ai-load-migration-adc-{suffix}"),
+            Some("ai-team"),
+            LolRole::Adc,
+            Some("2028-06-30"),
+        ));
+    }
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc"]);
+    let original_players = game
+        .players
+        .iter()
+        .map(|player| {
+            (
+                player.id.clone(),
+                player.team_id.clone(),
+                player.contract_end.clone(),
+                player.natural_position,
+            )
+        })
+        .collect::<Vec<_>>();
+    let original_teams = game
+        .teams
+        .iter()
+        .map(|team| (team.id.clone(), team.active_lineup_ids.clone()))
+        .collect::<Vec<_>>();
+
+    let error = repair_league(&mut game, RosterStabilityReason::LoadMigration)
+        .expect_err("league repair should fail atomically when any team cannot be repaired");
+
+    assert_eq!(error.team_id, "other-ai");
+    assert_eq!(error.missing_roles, vec![LolRole::Adc]);
+    assert_eq!(
+        game.players
+            .iter()
+            .map(|player| {
+                (
+                    player.id.clone(),
+                    player.team_id.clone(),
+                    player.contract_end.clone(),
+                    player.natural_position,
+                )
+            })
+            .collect::<Vec<_>>(),
+        original_players
+    );
+    assert_eq!(
+        game.teams
+            .iter()
+            .map(|team| (team.id.clone(), team.active_lineup_ids.clone()))
+            .collect::<Vec<_>>(),
+        original_teams
+    );
+}
+
+#[test]
+fn evaluate_team_missing_team_uses_supplied_reason() {
+    let game = game_with(
+        full_roster("ai-team"),
+        vec!["top", "jungle", "mid", "adc", "support"],
+    );
+
+    let error = evaluate_team(&game, "missing-team", RosterStabilityReason::LoadMigration)
+        .expect_err("missing team should include caller context in error");
+
+    assert_eq!(error.reason, RosterStabilityReason::LoadMigration);
+    assert_eq!(error.team_id, "missing-team");
+}

--- a/src-tauri/crates/olm_core/tests/roster_stability_tests.rs
+++ b/src-tauri/crates/olm_core/tests/roster_stability_tests.rs
@@ -757,3 +757,453 @@ fn evaluate_team_missing_team_uses_supplied_reason() {
     assert_eq!(error.reason, RosterStabilityReason::LoadMigration);
     assert_eq!(error.team_id, "missing-team");
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Load / rehydration tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn load_migration_repairs_ai_team_with_four_players_and_stale_lineup() {
+    // GIVEN an existing save state with a non-player team
+    // that has only 4 players and stale lineup IDs
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        ],
+        vec!["top", "stale-player-id", "mid", "adc"],
+    );
+
+    // Before repair: not match eligible, stale lineup
+    let before =
+        evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+            .expect("team should evaluate before repair");
+    assert!(!before.match_eligible);
+    assert!(before
+        .stale_lineup_ids
+        .contains(&"stale-player-id".to_string()));
+
+    // WHEN repair_league runs with LoadMigration reason
+    let reports = repair_league(&mut game, RosterStabilityReason::LoadMigration)
+        .expect("load migration should repair the league");
+
+    // THEN the team is match eligible (5 players, valid lineup)
+    let after =
+        evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+            .expect("team should evaluate after repair");
+    assert!(after.match_eligible);
+    assert_eq!(after.eligible_player_count, 5);
+    assert!(after.stale_lineup_ids.is_empty());
+
+    // AND the report captures the repair actions
+    let ai_report = reports
+        .iter()
+        .find(|r| r.team_id == "ai-team")
+        .expect("ai-team should have a report");
+    assert!(
+        !ai_report.actions.is_empty(),
+        "load migration repair should produce actions"
+    );
+
+    // AND the stale lineup ID is gone
+    let lineup = game
+        .teams
+        .iter()
+        .find(|t| t.id == "ai-team")
+        .unwrap()
+        .active_lineup_ids
+        .clone();
+    assert_eq!(lineup.len(), 5);
+    assert!(
+        !lineup.contains(&"stale-player-id".to_string()),
+        "stale player should be removed from lineup"
+    );
+}
+
+#[test]
+fn load_migration_does_not_generate_emergency_players_for_user_team() {
+    // GIVEN a user-managed team and an AI team, both with 4 players
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "mgr-1".to_string(),
+        "Test".to_string(),
+        "User".to_string(),
+        "1980-01-01".to_string(),
+        "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![
+            team(
+                "user-team",
+                Some("mgr-1"),
+                vec!["top", "jungle", "mid", "adc"],
+            ),
+            team("ai-team", None, vec!["a-top", "a-jungle", "a-mid", "a-adc"]),
+        ],
+        vec![
+            // User team players — only 4, missing support
+            player("top", Some("user-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("user-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("user-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("user-team"), LolRole::Adc, Some("2028-06-30")),
+            // AI team players — only 4, missing support
+            player(
+                "a-top",
+                Some("ai-team"),
+                LolRole::Top,
+                Some("2028-06-30"),
+            ),
+            player(
+                "a-jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player(
+                "a-mid",
+                Some("ai-team"),
+                LolRole::Mid,
+                Some("2028-06-30"),
+            ),
+            player(
+                "a-adc",
+                Some("ai-team"),
+                LolRole::Adc,
+                Some("2028-06-30"),
+            ),
+        ],
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("ai-team")];
+    game.leagues[0]
+        .standings
+        .push(StandingEntry::new("user-team".to_string()));
+    game.user_competition_id = Some("competition-1".to_string());
+
+    // Verify user team is ineligible before (no repair expected for user teams)
+    let user_before =
+        evaluate_team(&game, "user-team", RosterStabilityReason::LoadMigration)
+            .expect("user team should evaluate");
+    assert!(!user_before.match_eligible);
+
+    // WHEN repair_league runs with LoadMigration
+    let reports = repair_league(&mut game, RosterStabilityReason::LoadMigration)
+        .expect("load migration should succeed");
+
+    // THEN the AI team is repaired and match eligible
+    let ai_after =
+        evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+            .expect("ai-team should evaluate");
+    assert!(
+        ai_after.match_eligible,
+        "AI team should be eligible after load migration"
+    );
+    assert_eq!(ai_after.eligible_player_count, 5);
+
+    // AND the user team did NOT receive emergency generated players
+    let user_emergency: Vec<_> = game
+        .players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some("user-team"))
+        .filter(|p| p.id.starts_with("emergency-"))
+        .collect();
+    assert!(
+        user_emergency.is_empty(),
+        "user team should not get emergency generated players"
+    );
+
+    // AND repair_league report includes ai-team but NOT user-team
+    assert!(
+        reports.iter().any(|r| r.team_id == "ai-team"),
+        "ai-team should have a repair report"
+    );
+    assert!(
+        !reports.iter().any(|r| r.team_id == "user-team"),
+        "user-team should not appear in repair reports"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Pre-match / simulation precondition tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pre_match_repair_fixes_invalid_ai_opponent() {
+    // GIVEN a scheduled match where the opponent AI team has an invalid roster
+    // (missing support role)
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+            // opponent (other-ai) is missing support
+            player(
+                "o-top",
+                Some("other-ai"),
+                LolRole::Top,
+                Some("2028-06-30"),
+            ),
+            player(
+                "o-jungle",
+                Some("other-ai"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player(
+                "o-mid",
+                Some("other-ai"),
+                LolRole::Mid,
+                Some("2028-06-30"),
+            ),
+            player(
+                "o-adc",
+                Some("other-ai"),
+                LolRole::Adc,
+                Some("2028-06-30"),
+            ),
+        ],
+        vec!["top", "jungle", "mid", "adc", "adc"], // ai-team has adc-duplicate lineup
+    );
+    // Make other-ai schedulable in the league
+    game.leagues[0]
+        .standings
+        .push(StandingEntry::new("other-ai".to_string()));
+    game.leagues[0].fixtures.push(Fixture {
+        id: "fixture-2".to_string(),
+        matchday: 1,
+        date: "2026-08-02".to_string(),
+        home_team_id: "other-ai".to_string(),
+        away_team_id: "ai-team".to_string(),
+        match_type: MatchType::League,
+        best_of: 1,
+        status: FixtureStatus::Scheduled,
+        result: None,
+    });
+
+    // Before: other-ai is not match eligible (missing support)
+    let other_before =
+        evaluate_team(&game, "other-ai", RosterStabilityReason::PreMatch)
+            .expect("other-ai should evaluate");
+    assert!(!other_before.match_eligible);
+
+    // WHEN pre-match repair runs on the opponent
+    let report = repair_team(&mut game, "other-ai", RosterStabilityReason::PreMatch)
+        .expect("pre-match repair should fix opponent roster");
+
+    // THEN the opponent is match eligible
+    let other_after =
+        evaluate_team(&game, "other-ai", RosterStabilityReason::PreMatch)
+            .expect("other-ai should evaluate after repair");
+    assert!(
+        other_after.match_eligible,
+        "opponent should be eligible after pre-match repair"
+    );
+    assert_eq!(other_after.eligible_player_count, 5);
+    assert!(
+        other_after.missing_roles.is_empty(),
+        "all roles should be covered after pre-match repair"
+    );
+
+    // AND the repair action captures a generated replacement for the missing role
+    assert!(
+        report.actions.iter().any(|a| matches!(
+            a,
+            RepairAction::GeneratedReplacement {
+                role: LolRole::Support,
+                ..
+            }
+        )),
+        "repair should generate a support replacement for the opponent"
+    );
+}
+
+#[test]
+fn pre_match_repair_exhaustion_returns_fatal_error() {
+    // GIVEN an opponent AI team with an invalid roster
+    // AND all emergency generated player IDs are exhausted for the missing role
+    let mut players = vec![
+        player("o-top", Some("other-ai"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "o-jungle",
+            Some("other-ai"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("o-mid", Some("other-ai"), LolRole::Mid, Some("2028-06-30")),
+        player(
+            "o-support",
+            Some("other-ai"),
+            LolRole::Support,
+            Some("2028-06-30"),
+        ),
+    ];
+    // Exhaust all emergency ID slots for other-ai prematch adc
+    players.push(player(
+        "emergency-other-ai-prematch-adc",
+        Some("ai-team"),
+        LolRole::Adc,
+        Some("2028-06-30"),
+    ));
+    for suffix in 2..=17 {
+        players.push(player(
+            &format!("emergency-other-ai-prematch-adc-{suffix}"),
+            Some("ai-team"),
+            LolRole::Adc,
+            Some("2028-06-30"),
+        ));
+    }
+
+    let mut game = game_with(players, vec![]);
+    game.leagues[0]
+        .standings
+        .push(StandingEntry::new("other-ai".to_string()));
+
+    // WHEN repair_team is called with PreMatch reason
+    let error = repair_team(&mut game, "other-ai", RosterStabilityReason::PreMatch)
+        .expect_err("exhausted emergency IDs should return a fatal domain error");
+
+    // THEN the error identifies the team and the unmet invariant
+    assert_eq!(
+        error.team_id, "other-ai",
+        "error should identify the failing team"
+    );
+    assert_eq!(
+        error.reason,
+        RosterStabilityReason::PreMatch,
+        "error should preserve the PreMatch reason"
+    );
+    assert_eq!(
+        error.missing_roles,
+        vec![LolRole::Adc],
+        "error should identify the missing role"
+    );
+    // AND no emergency player for the exhausted role was added
+    assert!(
+        !game.players.iter().any(|p| {
+            p.id.starts_with("emergency-other-ai-prematch-adc")
+                && p.team_id.as_deref() == Some("other-ai")
+        }),
+        "no emergency ADC should have been added to other-ai"
+    );
+}
+
+#[test]
+fn background_simulation_repair_fixes_all_ai_teams() {
+    // GIVEN background league teams with incomplete rosters
+    let mut game = game_with(
+        vec![
+            player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+            player(
+                "jungle",
+                Some("ai-team"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+            // other-ai is missing support
+            player(
+                "o-top",
+                Some("other-ai"),
+                LolRole::Top,
+                Some("2028-06-30"),
+            ),
+            player(
+                "o-jungle",
+                Some("other-ai"),
+                LolRole::Jungle,
+                Some("2028-06-30"),
+            ),
+            player(
+                "o-mid",
+                Some("other-ai"),
+                LolRole::Mid,
+                Some("2028-06-30"),
+            ),
+            player(
+                "o-adc",
+                Some("other-ai"),
+                LolRole::Adc,
+                Some("2028-06-30"),
+            ),
+        ],
+        vec!["top", "jungle", "mid", "adc"],
+    );
+    // Make other-ai schedulable
+    game.leagues[0]
+        .standings
+        .push(StandingEntry::new("other-ai".to_string()));
+
+    // Verify both teams are ineligible before repair
+    let ai_before =
+        evaluate_team(&game, "ai-team", RosterStabilityReason::BackgroundSimulation)
+            .expect("ai-team should evaluate");
+    assert!(!ai_before.match_eligible);
+    let other_before =
+        evaluate_team(&game, "other-ai", RosterStabilityReason::BackgroundSimulation)
+            .expect("other-ai should evaluate");
+    assert!(!other_before.match_eligible);
+
+    // WHEN repair_league runs with BackgroundSimulation reason
+    let reports =
+        repair_league(&mut game, RosterStabilityReason::BackgroundSimulation)
+            .expect("background simulation repair should succeed");
+
+    // THEN all AI teams are match eligible
+    let ai_after =
+        evaluate_team(&game, "ai-team", RosterStabilityReason::BackgroundSimulation)
+            .expect("ai-team should evaluate after repair");
+    assert!(
+        ai_after.match_eligible,
+        "ai-team should be eligible after background simulation repair"
+    );
+    assert_eq!(
+        ai_after.eligible_player_count, 5,
+        "ai-team should have 5 eligible players"
+    );
+
+    let other_after =
+        evaluate_team(&game, "other-ai", RosterStabilityReason::BackgroundSimulation)
+            .expect("other-ai should evaluate after repair");
+    assert!(
+        other_after.match_eligible,
+        "other-ai should be eligible after background simulation repair"
+    );
+    assert_eq!(
+        other_after.eligible_player_count, 5,
+        "other-ai should have 5 eligible players"
+    );
+
+    // AND both AI teams report repair actions
+    assert!(
+        reports.iter().any(|r| r.team_id == "ai-team"),
+        "ai-team should have a repair report"
+    );
+    assert!(
+        reports.iter().any(|r| r.team_id == "other-ai"),
+        "other-ai should have a repair report"
+    );
+}

--- a/src-tauri/src/application/live_match.rs
+++ b/src-tauri/src/application/live_match.rs
@@ -7,6 +7,7 @@ use olm_core::engine::report::{MatchReport, MatchReportEndReason, PlayerMatchSta
 use olm_core::engine::types::{Side, Zone};
 use olm_core::game::Game;
 use olm_core::live_match_manager::{self, MatchMode};
+use olm_core::roster_stability;
 use olm_core::state::StateManager;
 use serde::{Deserialize, Serialize};
 
@@ -369,11 +370,38 @@ pub fn start_live_match(
         "[cmd] start_live_match: fixture={}, mode={}, extra_time={}",
         fixture_index, mode, allows_extra_time
     );
-    let game = state
+    let mut game = state
         .get_game(|g| g.clone())
         .ok_or("No active game session")?;
 
     validate_user_team_role_coverage(&game)?;
+
+    // Pre-match: ensure both teams are match eligible before building engine teams.
+    // For the user team, repair_team is a no-op (skips non-schedulable teams).
+    // For the AI opponent, repair fills missing roles, reconciles lineups, etc.
+    let match_team_ids: Vec<String> = {
+        let league = game.active_league()
+            .ok_or("No active league for start_live_match")?;
+        let fixture = league.fixtures.get(fixture_index)
+            .ok_or_else(|| format!("Fixture index {fixture_index} out of range"))?;
+        vec![fixture.home_team_id.clone(), fixture.away_team_id.clone()]
+    };
+    for team_id in &match_team_ids {
+        if !team_id.is_empty() {
+            roster_stability::repair_team(
+                &mut game,
+                team_id,
+                roster_stability::RosterStabilityReason::PreMatch,
+            )
+            .map_err(|e| {
+                format!(
+                    "Team {team_id} roster is invalid and could not be repaired: {e}"
+                )
+            })?;
+        }
+    }
+    // Sync repaired game back to state so live_match_manager uses current data
+    state.set_game(game.clone());
 
     let match_mode = match mode {
         "spectator" => MatchMode::Spectator,

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -15,6 +15,7 @@ use olm_core::domain::stats::StatsState;
 use olm_core::clock::GameClock;
 use olm_core::game::Game;
 use olm_core::game_setup;
+use olm_core::roster_stability;
 use olm_core::state::StateManager;
 
 use crate::SaveManagerState;
@@ -631,6 +632,31 @@ pub async fn load_game(
         game.champion_masteries.len()
     );
 
+    // Run load migration repair: ensure all AI teams are match eligible
+    // after catalog rehydration and OVR refresh. Only persists when actions occur
+    // to avoid unnecessary save mutations on clean loads.
+    match roster_stability::repair_league(
+        &mut game,
+        roster_stability::RosterStabilityReason::LoadMigration,
+    ) {
+        Ok(reports) => {
+            let total_actions: usize = reports.iter().map(|r| r.actions.len()).sum();
+            if total_actions > 0 {
+                info!(
+                    "[cmd] load_game: load migration repaired {} team(s) with {} action(s)",
+                    reports.len(),
+                    total_actions
+                );
+            }
+        }
+        Err(e) => {
+            warn!(
+                "[cmd] load_game: load migration repair failed for team {}: {}",
+                e.team_id, e
+            );
+        }
+    }
+
     info!("[cmd] load_game: setting state");
     let mgr_name = game.manager.display_name();
     state.set_save_id(save_id);
@@ -677,6 +703,33 @@ pub async fn get_active_game(
         game.champion_patch.hidden_meta.len(),
         game.champion_masteries.len()
     );
+
+    // Run load migration repair after catalog rehydration and OVR refresh.
+    // Only persists to state when the report contains actual repair actions.
+    match roster_stability::repair_league(
+        &mut game,
+        roster_stability::RosterStabilityReason::LoadMigration,
+    ) {
+        Ok(reports) => {
+            let total_actions: usize = reports.iter().map(|r| r.actions.len()).sum();
+            if total_actions > 0 {
+                log::info!(
+                    "[cmd] get_active_game: load migration repaired {} team(s) with {} action(s)",
+                    reports.len(),
+                    total_actions
+                );
+                state.set_game(game.clone());
+            }
+        }
+        Err(e) => {
+            log::warn!(
+                "[cmd] get_active_game: load migration repair failed for team {}: {}",
+                e.team_id,
+                e
+            );
+        }
+    }
+
     Ok(game)
 }
 


### PR DESCRIPTION
Closes #342

## Summary
- Introduces `olm_core::roster_stability` as a centralized domain seam for evaluating and repairing non-player team roster eligibility
- Wires repair into contracts expiry, transfers, season transitions, load migration, pre-match, and background simulation
- All repairs are atomic, bounded, and produce accurate policy-exception reports

## Changes

| File | Change |
|------|--------|
| `src-tauri/crates/olm_core/src/roster_stability.rs` | New core seam: evaluate, repair, types |
| `src-tauri/crates/olm_core/src/lib.rs` | Module export |
| `src-tauri/crates/olm_core/src/contracts.rs` | Wire repair after contract expiry |
| `src-tauri/crates/olm_core/src/transfers.rs` | Wire repair after transfer-out/release |
| `src-tauri/crates/olm_core/src/end_of_season.rs` | Replace replenish with repair_league |
| `src-tauri/crates/olm_core/src/turn/mod.rs` | Repair before background simulation |
| `src-tauri/src/application/live_match.rs` | Repair before engine creation |
| `src-tauri/src/commands/game.rs` | Repair on load/rehydration |
| `src-tauri/crates/olm_core/tests/roster_stability_tests.rs` | 22 unit tests |
| `src-tauri/crates/olm_core/tests/lifecycle_stability_tests.rs` | 7 integration tests |

## Test plan
- [x] `cargo test -p olm_core` — 29/29 passed
- [x] `cargo check --workspace` — passes (pre-existing warnings only)

## Checklist
- [x] Linked an approved issue: #342 (status:approved)
- [x] Added exactly one type:* label: type:bug
- [x] Conventional commit format
