### PR TITLE
feat(olm_core): add two-agent AI decision system

### DIFF
--- a/docs/decisions/adr-014-two-agent-ai-system.md
+++ b/docs/decisions/adr-014-two-agent-ai-system.md
@@ -1,0 +1,80 @@
+# ADR-014: Two-Agent AI Decision System for Non-Player Teams
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-17
+
+## Context
+
+OLManager's non-player (AI) teams lacked proactive decision-making. Before this system, AI teams relied on:
+
+- A passive contract renewal evaluation that only reacted to human-player renewals.
+- A safety net (`roster_stability`) that generated emergency placeholder players when rosters fell below match-ready minimums.
+- No buying, selling, or retention strategy — rosters decayed over time as contracts expired and players left.
+
+The result was that non-player teams became progressively weaker, making league competition unbalanced and reducing the realism of the simulation.
+
+At the same time, players on AI teams had no autonomy:
+- They never requested transfers, even when unhappy or underpaid.
+- They never demanded contract renewals.
+- Their career development was entirely passive.
+
+We needed a system that gave non-player teams and their players autonomous, context-aware decision-making — without schema changes (no new fields on existing models).
+
+## Decision
+
+Adopt a **two-agent architecture** with staggered processing:
+
+### Team Agent (`ai_team_agent.rs`)
+- Manages roster decisions for non-player teams: retention scoring, contract renewals, player sales, and free agent purchases.
+- Processes 2–3 teams per day in round-robin fashion (staggered to spread workload and avoid performance spikes).
+- Retention decisions weigh: `lol_ovr` (35 %), `avg_rating` (20 %), age (15 %), contract security (10 %), wage-value ratio (10 %), and trait bonuses (10 %).
+- Sales decisions flag players via a deadweight score (low OVR + high wage + short contract).
+- Purchase decisions fill role gaps (positions with 0 players) from the free agent pool.
+
+### Player Agent (`ai_player_agent.rs`)
+- Manages player career decisions: satisfaction scoring, transfer requests, renewal demands.
+- Processes players on teams that were processed by the Team Agent **yesterday** (day-offset design).
+- Satisfaction weighs: morale (40 %), manager trust (30 %), wage satisfaction (15 %), ambition alignment (10 %), loyalty (5 %).
+- Actions are limited to setting flags: `transfer_listed` for transfer requests, `renewal_state` for renewal demands. Never modifies roster directly (PA-06).
+
+### Orchestration
+- Day N: Team Agent processes 2-3 AI teams (renewals, sales, purchases).
+- Day N+1: Player Agent processes players on those same teams (satisfaction → decisions).
+- Day N+1 (after Player Agent): Conflict resolution (`resolve_conflicts`) — Team Agent overrides Player Agent for under-contract players who are high-value (retention score ≥ 0.70) or critical depth (only player at a role with > 12 months remaining).
+- Day N+1 (after conflict resolution): News generation (`generate_ai_transfer_news`).
+- Call order in `turn/mod.rs`: `process_ai_team_agents` → `process_ai_player_agents` → `resolve_conflicts` → `generate_ai_transfer_news`.
+
+### Key Design Constraints
+- **No schema changes**: All decisions derive from existing `Player` and `Team` fields (stats, traits, morale, contract, wage, etc.).
+- **Deterministic**: No RNG in agent decisions — same input state always produces same output (OR-06).
+- **Safety net above**: Agents sit ABOVE `roster_stability`. The safety net catches edge cases the agents miss (e.g., mass departures, scenario corner cases).
+- **Under-contract override**: Team Agent overrides Player Agent for under-contract players (OR-03).
+- **Free agent final**: Player Agent decision is final for free agents — no override (OR-04).
+
+## Consequences
+
+### Positive
+- AI teams now proactively manage rosters: renew stars, sell deadweight, fill gaps.
+- Players on AI teams have career autonomy: they leave unhappy situations, demand better contracts.
+- League competition is more realistic — AI teams maintain competitive rosters.
+- No schema changes — zero migration risk.
+- Deterministic decisions make testing and debugging straightforward.
+- Staggered processing (2-3 teams/day) avoids CPU spikes.
+
+### Negative
+- Conflict resolution adds complexity: Team Agent can undo Player Agent decisions.
+- Staggered processing means a team gets full agent attention only every ~10 days (for a 30-team league). This is acceptable because most decisions are not time-critical, but fast-reaction scenarios (e.g., morale crisis) might lag.
+- The system adds ~400 lines of agent logic plus tests.
+
+### Safety Net
+- `roster_stability` remains as the ultimate fallback. If agents fail to maintain a minimum roster (e.g., all players leave, extreme edge case), `roster_stability::repair_league` generates emergency players. The agent system reduces how often this fires but does not replace it.
+
+### Future Considerations
+- If player churn is too low or too high, tune the satisfaction thresholds (`SATISFACTION_LOW`, `SATISFACTION_HIGH`, `TRULY_MISERABLE`).
+- If AI teams over-perform or under-perform, tune retention/deadweight weights.
+- The system can be extended to handle player development desires (playtime, role preference) without schema changes.

--- a/src-tauri/crates/olm_core/src/ai_player_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_player_agent.rs
@@ -1,0 +1,998 @@
+use crate::domain::player::{Player, PlayerTrait};
+use crate::domain::team::{Team, TeamKind};
+use crate::game::Game;
+use chrono::NaiveDate;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Satisfaction scoring weights (spec PA-02)
+// ---------------------------------------------------------------------------
+const W_MORALE: f64 = 0.40;
+const W_MANAGER_TRUST: f64 = 0.30;
+const W_WAGE_SATISFACTION: f64 = 0.15;
+const W_AMBITION_ALIGNMENT: f64 = 0.10;
+const W_LOYALTY: f64 = 0.05;
+
+// ---------------------------------------------------------------------------
+// Thresholds
+// ---------------------------------------------------------------------------
+
+/// Satisfaction below this → transfer request.
+const SATISFACTION_LOW: f64 = 0.35;
+
+/// Satisfaction at or above this → completely happy (Silent).
+const SATISFACTION_HIGH: f64 = 0.70;
+
+/// Contract months remaining below this → renewal demand trigger.
+const RENEWAL_CONTRACT_MONTHS: f64 = 6.0;
+
+/// Wage / market_value ratio at or above this → well paid.
+const WAGE_FAIR_RATIO: f64 = 0.8;
+
+/// Wage / market_value ratio below this → significantly underpaid.
+const WAGE_UNDERPAID_RATIO: f64 = 0.7;
+
+/// Max teams processed per day (mirrors ai_team_agent::TEAMS_PER_DAY).
+const TEAMS_PER_DAY: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Decision enum
+// ---------------------------------------------------------------------------
+
+/// Outcome of a player agent evaluation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum PlayerAgentDecision {
+    /// Player wants to leave — set transfer_listed = true.
+    RequestTransfer,
+    /// Player wants to negotiate a new contract — set renewal_state.
+    RequestRenewal,
+    /// Player is content — no action.
+    Silent,
+}
+
+// ---------------------------------------------------------------------------
+// Internal ambition enums
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum PlayerAmbition {
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum TeamAmbition {
+    High,   // TitleContender
+    Medium, // PlayoffContender / MidTable
+    Low,    // Survival
+}
+
+// ---------------------------------------------------------------------------
+// Helper: contract months remaining
+// ---------------------------------------------------------------------------
+
+fn months_remaining(contract_end: &Option<String>, today: NaiveDate) -> f64 {
+    match contract_end.as_deref() {
+        Some(end_str) => {
+            if let Ok(end) = NaiveDate::parse_from_str(end_str, "%Y-%m-%d") {
+                (end.signed_duration_since(today).num_days() as f64 / 30.44).max(0.0)
+            } else {
+                0.0
+            }
+        }
+        None => 0.0,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Satisfaction components
+// ---------------------------------------------------------------------------
+
+/// Wage satisfaction: how happy the player is with their wage vs market value.
+fn wage_satisfaction(player: &Player) -> f64 {
+    if player.market_value == 0 {
+        return 0.5; // neutral when no market data
+    }
+    let ratio = f64::from(player.wage) / (player.market_value as f64);
+    if ratio >= WAGE_FAIR_RATIO {
+        1.0
+    } else if ratio >= WAGE_UNDERPAID_RATIO {
+        0.5
+    } else {
+        0.2
+    }
+}
+
+/// Derive player's personal ambition from traits and OVR.
+fn derive_player_ambition(player: &Player) -> PlayerAmbition {
+    let has_high_ambition_trait = player
+        .traits
+        .iter()
+        .any(|t| matches!(t, PlayerTrait::HyperCarry | PlayerTrait::Intimidator));
+    if has_high_ambition_trait {
+        return PlayerAmbition::High;
+    }
+
+    if player.lol_ovr >= 75 {
+        PlayerAmbition::High
+    } else if player.lol_ovr >= 60 {
+        PlayerAmbition::Medium
+    } else {
+        PlayerAmbition::Low
+    }
+}
+
+/// Derive team ambition from roster strength (top-5 avg OVR) using a players slice.
+/// Uses the same approach as `board_objectives::team_strength_score`.
+fn derive_team_ambition_from_players(team: &Team, players: &[Player]) -> TeamAmbition {
+    let mut player_ovrs: Vec<f64> = players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some(&team.id))
+        .map(|p| crate::player_rating::natural_ovr(p))
+        .collect();
+
+    if player_ovrs.is_empty() {
+        return if team.reputation >= 75 {
+            TeamAmbition::High
+        } else if team.reputation >= 50 {
+            TeamAmbition::Medium
+        } else {
+            TeamAmbition::Low
+        };
+    }
+
+    player_ovrs.sort_by(|a, b| b.total_cmp(a));
+    let count = player_ovrs.len().min(5) as f64;
+    let avg_strength: f64 = player_ovrs.iter().take(5).sum::<f64>() / count;
+
+    if avg_strength >= 78.0 {
+        TeamAmbition::High
+    } else if avg_strength >= 68.0 {
+        TeamAmbition::Medium
+    } else {
+        TeamAmbition::Low
+    }
+}
+
+/// Derive team ambition from roster strength (convenience wrapper passing game.players).
+fn derive_team_ambition(team: &Team, game: &Game) -> TeamAmbition {
+    derive_team_ambition_from_players(team, &game.players)
+}
+
+/// Ambition alignment: how well player ambition matches team trajectory.
+/// High-ambition trait on low-ambition team → penalty.
+fn ambition_alignment(player: &Player, team_ambition: TeamAmbition) -> f64 {
+    let player_ambition = derive_player_ambition(player);
+
+    match (player_ambition, team_ambition) {
+        (PlayerAmbition::High, TeamAmbition::High) => 1.0,
+        (PlayerAmbition::High, TeamAmbition::Medium) => 0.6,
+        (PlayerAmbition::High, TeamAmbition::Low) => 0.2,
+        (PlayerAmbition::Medium, TeamAmbition::High) => 0.7,
+        (PlayerAmbition::Medium, TeamAmbition::Medium) => 1.0,
+        (PlayerAmbition::Medium, TeamAmbition::Low) => 0.6,
+        (PlayerAmbition::Low, _) => 0.8,
+    }
+}
+
+/// Loyalty factor: career tenure at current club + trait bonus.
+/// TeamPlayer, Sentinel, IceCold traits add loyalty.
+fn loyalty_factor(player: &Player) -> f64 {
+    let team_career_count = player
+        .career
+        .iter()
+        .filter(|entry| entry.team_id.as_deref() == player.team_id.as_deref())
+        .count();
+
+    let tenure_bonus = (team_career_count as f64 / 5.0).min(1.0);
+
+    let trait_bonus = if player
+        .traits
+        .iter()
+        .any(|t| matches!(t, PlayerTrait::TeamPlayer | PlayerTrait::Sentinel | PlayerTrait::IceCold))
+    {
+        0.2
+    } else {
+        0.0
+    };
+
+    (tenure_bonus + trait_bonus).min(1.0)
+}
+
+// ---------------------------------------------------------------------------
+// Composite satisfaction score
+// ---------------------------------------------------------------------------
+
+/// Compute player satisfaction (0.0 = miserable, 1.0 = ecstatic).
+///
+/// Weights per spec PA-02:
+/// - morale × 0.40
+/// - manager_trust × 0.30
+/// - wage_satisfaction × 0.15
+/// - ambition_alignment × 0.10
+/// - loyalty × 0.05
+pub fn compute_satisfaction(player: &Player, team: &Team, game: &Game) -> f64 {
+    let team_ambition = derive_team_ambition(team, game);
+    compute_satisfaction_inner(player, team_ambition)
+}
+
+/// Inner satisfaction computation that avoids a &Game dependency.
+fn compute_satisfaction_inner(player: &Player, team_ambition: TeamAmbition) -> f64 {
+    let morale = f64::from(player.morale) / 100.0;
+    let manager_trust = f64::from(player.morale_core.manager_trust) / 100.0;
+    let wage_sat = wage_satisfaction(player);
+    let ambition = ambition_alignment(player, team_ambition);
+    let loyalty = loyalty_factor(player);
+
+    morale * W_MORALE
+        + manager_trust * W_MANAGER_TRUST
+        + wage_sat * W_WAGE_SATISFACTION
+        + ambition * W_AMBITION_ALIGNMENT
+        + loyalty * W_LOYALTY
+}
+
+// ---------------------------------------------------------------------------
+// Decision logic
+// ---------------------------------------------------------------------------
+
+/// Determine whether a player requests a transfer, demands renewal, or stays silent.
+///
+/// Thresholds:
+/// - satisfaction < 0.35 → transfer request (if contract short or underpaid)
+/// - 0.35 ≤ satisfaction < 0.70 + contract < 6 months → renewal demand
+/// - satisfaction ≥ 0.70 → silent
+///
+/// PA-03: Contender teams suppress transfer requests unless truly miserable (< 0.20).
+pub fn decide_action(
+    satisfaction: f64,
+    player: &Player,
+    team: &Team,
+    game: &Game,
+) -> PlayerAgentDecision {
+    let today = game.clock.current_date.date_naive();
+    let team_ambition = derive_team_ambition(team, game);
+    decide_action_inner(satisfaction, player, team_ambition, today)
+}
+
+/// Inner decision that avoids a &Game dependency (needs pre-computed params).
+fn decide_action_inner(
+    satisfaction: f64,
+    player: &Player,
+    team_ambition: TeamAmbition,
+    today: NaiveDate,
+) -> PlayerAgentDecision {
+    let is_contender = matches!(team_ambition, TeamAmbition::High);
+    let contract_short = months_remaining(&player.contract_end, today) < RENEWAL_CONTRACT_MONTHS;
+    let underpaid = player.market_value > 0
+        && f64::from(player.wage) / (player.market_value as f64) < WAGE_UNDERPAID_RATIO;
+
+    // --- Very low satisfaction → transfer request (PA-04) ---
+    if satisfaction < SATISFACTION_LOW {
+        // PA-03: Contender teams suppress unless truly miserable
+        if is_contender && satisfaction >= 0.20 {
+            if contract_short {
+                return PlayerAgentDecision::RequestRenewal;
+            }
+            return PlayerAgentDecision::Silent;
+        }
+
+        if contract_short || underpaid {
+            return PlayerAgentDecision::RequestTransfer;
+        }
+    }
+
+    // --- Mid-range satisfaction + short contract → renewal demand (PA-05) ---
+    if satisfaction < SATISFACTION_HIGH && contract_short {
+        return PlayerAgentDecision::RequestRenewal;
+    }
+
+    // --- High satisfaction or no trigger → stay (PA-02) ---
+    PlayerAgentDecision::Silent
+}
+
+/// Route a player agent decision to mutate game state.
+///
+/// PA-06: NEVER modifies roster directly — only sets flags.
+pub fn route_decision(decision: &PlayerAgentDecision, player: &mut Player) {
+    match decision {
+        PlayerAgentDecision::RequestTransfer => {
+            player.transfer_listed = true;
+        }
+        PlayerAgentDecision::RequestRenewal => {
+            use crate::domain::player::ContractRenewalState;
+            if player.morale_core.renewal_state.is_none() {
+                player.morale_core.renewal_state = Some(ContractRenewalState {
+                    status: crate::domain::player::RenewalSessionStatus::Open,
+                    ..ContractRenewalState::default()
+                });
+            }
+        }
+        PlayerAgentDecision::Silent => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration — public entry point called from turn/mod.rs
+// ---------------------------------------------------------------------------
+
+/// Select teams that were processed by Team Agent yesterday (day offset - 1).
+fn select_yesterday_ai_teams(game: &Game) -> Vec<String> {
+    let ai_teams: Vec<&Team> = game
+        .teams
+        .iter()
+        .filter(|t| t.team_kind == TeamKind::Main && t.manager_id.is_none())
+        .collect();
+
+    if ai_teams.is_empty() {
+        return Vec::new();
+    }
+
+    // Use day-of-year - 1 to get yesterday's Team Agent batch
+    let day_of_year = game
+        .clock
+        .current_date
+        .format("%j")
+        .to_string()
+        .parse::<usize>()
+        .unwrap_or(0);
+
+    let count = TEAMS_PER_DAY.min(ai_teams.len());
+    // Yesterday's offset: if day > 0, use day-1; otherwise 0 (first day)
+    let start = if day_of_year > 0 {
+        (day_of_year - 1) % ai_teams.len()
+    } else {
+        0
+    };
+
+    (0..count)
+        .map(|i| {
+            let idx = (start + i) % ai_teams.len();
+            ai_teams[idx].id.clone()
+        })
+        .collect()
+}
+
+/// Process player agents for teams that were processed by Team Agent yesterday.
+///
+/// For each player on those teams:
+/// 1. Compute satisfaction
+/// 2. Decide action (stay / renewal demand / transfer request)
+/// 3. Route the decision (set flags only — PA-06)
+pub fn process_ai_player_agents(game: &mut Game) {
+    let today = game.clock.current_date.date_naive();
+    let team_ids = select_yesterday_ai_teams(game);
+
+    if team_ids.is_empty() {
+        return;
+    }
+
+    // Pre-compute team ambitions (needs read from game.players) before
+    // entering the mutable borrow loop.
+    let team_ambitions: HashMap<String, TeamAmbition> = {
+        let players = &game.players;
+        team_ids
+            .iter()
+            .filter_map(|team_id| {
+                game.teams
+                    .iter()
+                    .find(|t| t.id == *team_id)
+                    .map(|team| (team_id.clone(), derive_team_ambition_from_players(team, players)))
+            })
+            .collect()
+    };
+
+    for team_id in &team_ids {
+        let team_ambition = team_ambitions
+            .get(team_id)
+            .copied()
+            .unwrap_or(TeamAmbition::Low);
+
+        for player in game.players.iter_mut() {
+            if player.team_id.as_deref() != Some(team_id) {
+                continue;
+            }
+
+            let satisfaction = compute_satisfaction_inner(player, team_ambition);
+            let decision = decide_action_inner(satisfaction, player, team_ambition, today);
+            route_decision(&decision, player);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::GameClock;
+    use crate::domain::manager::Manager;
+    use crate::domain::player::{
+        LolRole, Player, PlayerAttributes, PlayerMoraleCore,
+    };
+    use crate::domain::team::Team;
+    use chrono::{TimeZone, Utc};
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    fn default_attrs() -> PlayerAttributes {
+        PlayerAttributes {
+            mechanics: 70,
+            laning: 70,
+            teamfighting: 70,
+            macro_play: 70,
+            consistency: 70,
+            shotcalling: 70,
+            champion_pool: 70,
+            discipline: 70,
+            mental_resilience: 70,
+        }
+    }
+
+    fn make_player(
+        id: &str,
+        name: &str,
+        team_id: &str,
+        role: LolRole,
+        lol_ovr: u8,
+        morale: u8,
+        manager_trust: u8,
+        wage: u32,
+        market_value: u64,
+        contract_end: Option<&str>,
+        traits: Vec<PlayerTrait>,
+    ) -> Player {
+        let mut player = Player::new(
+            id.to_string(),
+            name.to_string(),
+            format!("Full {name}"),
+            "2000-01-01".to_string(),
+            "GB".to_string(),
+            role,
+            default_attrs(),
+        );
+        player.team_id = Some(team_id.to_string());
+        player.lol_ovr = lol_ovr;
+        player.morale = morale;
+        player.morale_core = PlayerMoraleCore {
+            manager_trust,
+            ..PlayerMoraleCore::default()
+        };
+        player.wage = wage;
+        player.market_value = market_value;
+        player.contract_end = contract_end.map(|s| s.to_string());
+        player.traits = traits;
+        player
+    }
+
+    fn make_team(id: &str, name: &str, reputation: u32) -> Team {
+        let mut team = Team::new(
+            id.to_string(),
+            name.to_string(),
+            name[..3].to_string(),
+            "DE".to_string(),
+            "Berlin".to_string(),
+            "Arena".to_string(),
+            10_000,
+        );
+        team.reputation = reputation;
+        team
+    }
+
+    #[allow(dead_code)]
+    fn test_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 15).unwrap()
+    }
+
+    /// Build a minimal Game with one AI team and one player.
+    fn make_game_with_single_ai_team(
+        team: Team,
+        players: Vec<Player>,
+    ) -> Game {
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
+        );
+        Game::new(clock, manager, vec![team], players, vec![], vec![])
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 1: Satisfaction scoring
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_compute_satisfaction_happy_player() {
+        // Spec PA-02 "Stay at contender":
+        // GIVEN morale > 70, manager_trust > 60, wage >= market_value × 0.8
+        // THEN player MUST NOT request transfer (satisfaction ≥ 0.70)
+        let team = make_team("t1", "Test Team", 80);
+        let player = make_player(
+            "p1",
+            "Happy",
+            "t1",
+            LolRole::Mid,
+            85,     // lol_ovr
+            85,     // morale > 70
+            70,     // manager_trust > 60
+            80_000, // wage
+            100_000, // market_value → wage / mv = 0.8 → WAGE_FAIR_RATIO
+            Some("2028-06-15"), // long contract
+            vec![PlayerTrait::TeamPlayer],
+        );
+
+        let game = make_game_with_single_ai_team(team.clone(), vec![player]);
+        let p = game.players.iter().find(|p| p.id == "p1").unwrap();
+        let t = game.teams.iter().find(|t| t.id == "t1").unwrap();
+
+        let satisfaction = compute_satisfaction(p, t, &game);
+        // Expected: high morale (0.85*0.40=0.34) + high trust (0.70*0.30=0.21)
+        // + good wage (1.0*0.15=0.15) + ambition alignment (ambitious on strong team = 1.0*0.10=0.10)
+        // + loyalty (TeamPlayer trait bonus = (0+0.2)*0.05 = 0.01)
+        // Total ≈ 0.34 + 0.21 + 0.15 + 0.10 + 0.01 = 0.81
+        assert!(
+            satisfaction >= 0.70,
+            "happy player on contender should have high satisfaction, got {satisfaction}"
+        );
+    }
+
+    #[test]
+    fn test_compute_satisfaction_unhappy_player() {
+        // Spec PA-04 "Leave unhappy team":
+        // GIVEN morale < 30, manager_trust < 25 → low satisfaction
+        let team = make_team("t2", "Low Team", 40);
+        let player = make_player(
+            "p2",
+            "Unhappy",
+            "t2",
+            LolRole::Top,
+            55,     // low OVR → low ambition
+            20,     // morale < 30
+            15,     // manager_trust < 25
+            20_000, // wage
+            80_000, // market_value → wage / mv = 0.25 < 0.7 → underpaid
+            Some("2026-09-15"), // short contract
+            vec![],
+        );
+
+        let game = make_game_with_single_ai_team(team.clone(), vec![player]);
+        let p = game.players.iter().find(|p| p.id == "p2").unwrap();
+        let t = game.teams.iter().find(|t| t.id == "t2").unwrap();
+
+        let satisfaction = compute_satisfaction(p, t, &game);
+        // Expected: low morale (0.20*0.40=0.08) + low trust (0.15*0.30=0.045)
+        // + low wage_satisfaction (0.2*0.15=0.03) + ambition alignment (low ambition on low team = 0.8*0.10=0.08)
+        // + loyalty (0.0*0.05=0.0)
+        // Total ≈ 0.08 + 0.045 + 0.03 + 0.08 + 0.0 = 0.235
+        assert!(
+            satisfaction < 0.35,
+            "unhappy player should have low satisfaction, got {satisfaction}"
+        );
+    }
+
+    #[test]
+    fn test_ambition_alignment_hypercarry_on_survival_penalty() {
+        // Player with HyperCarry trait on a low-ambition team → alignment penalty.
+        // Add filler players with low attrs so natural_ovr avg < 68 → Low ambition.
+        let team = make_team("t3", "Survival Team", 30);
+
+        // Star player: high OVR attrs but team's avg is pulled down by filler
+        let star = make_player(
+            "p3", "Star", "t3", LolRole::Mid,
+            90, 50, 40, 50_000, 200_000,
+            Some("2027-06-15"),
+            vec![PlayerTrait::HyperCarry],
+        );
+
+        // Filler players with low attrs to bring avg below 68
+        let filler_attrs = PlayerAttributes {
+            mechanics: 40, laning: 40, teamfighting: 40,
+            macro_play: 40, consistency: 40, shotcalling: 40,
+            champion_pool: 40, discipline: 40, mental_resilience: 40,
+        };
+        let mut filler1 = Player::new(
+            "f1".to_string(), "Filler1".to_string(), "Full Filler1".to_string(),
+            "2000-01-01".to_string(), "GB".to_string(), LolRole::Top, filler_attrs.clone(),
+        );
+        filler1.team_id = Some("t3".to_string());
+        let mut filler2 = filler1.clone();
+        filler2.id = "f2".to_string();
+        filler2.match_name = "Filler2".to_string();
+        filler2.natural_position = LolRole::Jungle;
+        let mut filler3 = filler1.clone();
+        filler3.id = "f3".to_string();
+        filler3.match_name = "Filler3".to_string();
+        filler3.natural_position = LolRole::Adc;
+        let mut filler4 = filler1.clone();
+        filler4.id = "f4".to_string();
+        filler4.match_name = "Filler4".to_string();
+        filler4.natural_position = LolRole::Support;
+
+        let all_players = vec![star, filler1, filler2, filler3, filler4];
+        // avg natural_ovr = (approx 90 + 40+40+40+40) / 5 = 50 → Low
+
+        let game = make_game_with_single_ai_team(team, all_players);
+        let t = game.teams.iter().find(|t| t.id == "t3").unwrap();
+        let team_ambition = derive_team_ambition(t, &game);
+
+        assert_eq!(
+            team_ambition,
+            TeamAmbition::Low,
+            "team with avg OVR ~50 should be Low ambition, got {:?}",
+            team_ambition
+        );
+
+        let p = game.players.iter().find(|p| p.id == "p3").unwrap();
+        let alignment = ambition_alignment(p, team_ambition);
+        // HyperCarry (High Ambition) on Survival (Low Ambition) → 0.2
+        assert!(
+            (alignment - 0.2).abs() < 0.001,
+            "HyperCarry on Survival should get 0.2 alignment, got {alignment}"
+        );
+    }
+
+    #[test]
+    fn test_loyalty_factor_long_tenure() {
+        use crate::domain::player::CareerEntry;
+
+        let player = make_player(
+            "p4",
+            "Loyal",
+            "t4",
+            LolRole::Support,
+            70, 50, 50,
+            50_000, 100_000,
+            Some("2027-06-15"),
+            vec![],
+        );
+
+        // Add career entries matching current team (5 seasons → full tenure_bonus)
+        let mut loyal_player = player.clone();
+        for season in 1..=5 {
+            loyal_player.career.push(CareerEntry {
+                season,
+                team_id: Some("t4".to_string()),
+                team_name: "Test Team".to_string(),
+                appearances: 30,
+                kills: 0,
+                deaths: 0,
+                assists: 0,
+                avg_rating: 7.0,
+            });
+        }
+
+        let loyalty = loyalty_factor(&loyal_player);
+        // 5 seasons → 1.0 tenure, no trait bonus → total 1.0 (capped)
+        assert!(
+            (loyalty - 1.0).abs() < 0.001,
+            "5-season tenure should give max loyalty, got {loyalty}"
+        );
+    }
+
+    #[test]
+    fn test_loyalty_factor_sentinel_trait_bonus() {
+        // Player with Sentinel trait gets +0.2 bonus
+        let player = make_player(
+            "p5",
+            "Sentinel",
+            "t5",
+            LolRole::Top,
+            70, 50, 50,
+            50_000, 100_000,
+            Some("2027-06-15"),
+            vec![PlayerTrait::Sentinel],
+        );
+
+        // No career entries yet → tenure is 0.0 + trait 0.2 = 0.2
+        let loyalty = loyalty_factor(&player);
+        assert!(
+            (loyalty - 0.2).abs() < 0.001,
+            "Sentinel trait should give 0.2 loyalty, got {loyalty}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2: Stay/leave/negotiate decisions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_decide_action_low_satisfaction_transfer_request() {
+        // Spec PA-05: low satisfaction + short contract + underpaid → transfer request
+        let team = make_team("t1", "Weak Team", 30);
+        let player = make_player(
+            "p1",
+            "Leaver",
+            "t1",
+            LolRole::Mid,
+            60,     // lol_ovr
+            25,     // morale
+            20,     // manager_trust
+            20_000, // wage
+            100_000, // market_value → wage/mv = 0.2 → underpaid
+            Some("2026-09-01"), // < 6 months from test_date
+            vec![],
+        );
+
+        let game = make_game_with_single_ai_team(team.clone(), vec![player]);
+        let p = game.players.iter().find(|p| p.id == "p1").unwrap();
+        let t = game.teams.iter().find(|t| t.id == "t1").unwrap();
+        let satisfaction = compute_satisfaction(p, t, &game);
+
+        let decision = decide_action(satisfaction, p, t, &game);
+        assert_eq!(
+            decision,
+            PlayerAgentDecision::RequestTransfer,
+            "unhappy underpaid player with short contract should request transfer, satisfaction={satisfaction}"
+        );
+    }
+
+    #[test]
+    fn test_decide_action_contender_suppresses_transfer() {
+        // PA-03: Player on TitleContender team should NOT request transfer
+        // even if somewhat dissatisfied (but not miserable).
+        // Setup: moderately unhappy player on a contender team with high avg OVR.
+        let mut team = make_team("t1", "Top Team", 90);
+        team.manager_id = None;
+        team.team_kind = TeamKind::Main;
+
+        // Use high attrs so natural_ovr >= 78 → High ambition
+        let high_attrs = PlayerAttributes {
+            mechanics: 90, laning: 90, teamfighting: 90,
+            macro_play: 90, consistency: 90, shotcalling: 90,
+            champion_pool: 90, discipline: 90, mental_resilience: 90,
+        };
+
+        fn make_high_ovr_player(
+            id: &str, team_id: &str, role: LolRole,
+            morale: u8, trust: u8, attrs: PlayerAttributes,
+        ) -> Player {
+            let mut p = Player::new(
+                id.to_string(), format!("Player {id}"), format!("Full {id}"),
+                "2000-01-01".to_string(), "GB".to_string(), role, attrs,
+            );
+            p.team_id = Some(team_id.to_string());
+            p.lol_ovr = 90;
+            p.morale = morale;
+            p.morale_core = PlayerMoraleCore { manager_trust: trust, ..PlayerMoraleCore::default() };
+            p.wage = 80_000;
+            p.market_value = 100_000;
+            p.contract_end = Some("2026-09-01".to_string());
+            p
+        }
+
+        let players = vec![
+            // p1: very unhappy (morale 20, trust 15) + underpaid (20K/100K) → satisfaction << 0.35
+            {
+                let mut p = make_high_ovr_player("p1", "t1", LolRole::Top, 20, 15, high_attrs.clone());
+                p.wage = 20_000; // very underpaid
+                p.traits = vec![PlayerTrait::HyperCarry];
+                p
+            },
+            make_high_ovr_player("p2", "t1", LolRole::Jungle, 50, 50, high_attrs.clone()),
+            make_high_ovr_player("p3", "t1", LolRole::Mid, 50, 50, high_attrs.clone()),
+            make_high_ovr_player("p4", "t1", LolRole::Adc, 50, 50, high_attrs.clone()),
+            make_high_ovr_player("p5", "t1", LolRole::Support, 50, 50, high_attrs.clone()),
+        ];
+
+        let game = make_game_with_single_ai_team(team, players);
+
+        // Check team ambition (natural_ovr = 90 for all → High)
+        let t = game.teams.iter().find(|t| t.id == "t1").unwrap();
+        let ambition = derive_team_ambition(t, &game);
+        assert_eq!(
+            ambition,
+            TeamAmbition::High,
+            "team with strong roster should be High ambition, got {:?}",
+            ambition
+        );
+
+        // p1 is the moderately unhappy one: morale 35, trust 30
+        let p1 = game.players.iter().find(|p| p.id == "p1").unwrap();
+        let satisfaction = compute_satisfaction(p1, t, &game);
+        let decision = decide_action(satisfaction, p1, t, &game);
+
+        // The satisfaction should be < 0.35 (unhappy) but as a contender,
+        // the transfer should be suppressed
+        assert!(
+            satisfaction < 0.35,
+            "p1 should be dissatisfied, got {satisfaction}"
+        );
+        assert_ne!(
+            decision,
+            PlayerAgentDecision::RequestTransfer,
+            "contender team should suppress transfer request, satisfaction={satisfaction}"
+        );
+    }
+
+    #[test]
+    fn test_decide_action_pa06_no_direct_roster_modification() {
+        // PA-06: Player agent must NOT modify roster directly,
+        // only set flags. Verify route_decision only changes
+        // transfer_listed or renewal_state, never team_id or other roster fields.
+        let _team = make_team("t1", "Test Team", 50);
+        let player = make_player(
+            "p1", "Test", "t1", LolRole::Mid,
+            70, 50, 50, 50_000, 100_000,
+            Some("2026-09-01"),
+            vec![],
+        );
+
+        let mut test_player = player.clone();
+        let original_team_id = test_player.team_id.clone();
+        let original_wage = test_player.wage;
+        let original_lol_ovr = test_player.lol_ovr;
+
+        // Apply each decision type and verify only flags changed
+        route_decision(&PlayerAgentDecision::RequestTransfer, &mut test_player);
+        assert!(test_player.transfer_listed, "transfer_listed should be true");
+        assert_eq!(test_player.team_id, original_team_id, "team_id must not change");
+        assert_eq!(test_player.wage, original_wage, "wage must not change");
+        assert_eq!(test_player.lol_ovr, original_lol_ovr, "lol_ovr must not change");
+
+        // Reset and test renewal
+        let mut test_player2 = player.clone();
+        let original_team_id2 = test_player2.team_id.clone();
+        route_decision(&PlayerAgentDecision::RequestRenewal, &mut test_player2);
+        assert!(
+            test_player2.morale_core.renewal_state.is_some(),
+            "renewal_state should be set"
+        );
+        assert_eq!(test_player2.team_id, original_team_id2, "team_id must not change");
+
+        // Reset and test silent
+        let mut test_player3 = player.clone();
+        route_decision(&PlayerAgentDecision::Silent, &mut test_player3);
+        assert!(
+            !test_player3.transfer_listed,
+            "transfer_listed should remain false"
+        );
+        assert_eq!(test_player3.team_id, original_team_id2, "team_id must not change");
+    }
+
+    #[test]
+    fn test_decide_action_high_satisfaction_silent() {
+        // Happy player → Silent
+        let team = make_team("t1", "Great Team", 80);
+        let player = make_player(
+            "p1", "Happy", "t1", LolRole::Mid,
+            90, 90, 80, 100_000, 110_000,
+            Some("2028-06-15"),
+            vec![PlayerTrait::TeamPlayer],
+        );
+
+        let game = make_game_with_single_ai_team(team.clone(), vec![player]);
+        let p = game.players.iter().find(|p| p.id == "p1").unwrap();
+        let t = game.teams.iter().find(|t| t.id == "t1").unwrap();
+        let satisfaction = compute_satisfaction(p, t, &game);
+        let decision = decide_action(satisfaction, p, t, &game);
+
+        assert_eq!(
+            decision,
+            PlayerAgentDecision::Silent,
+            "happy player should be Silent, satisfaction={satisfaction}"
+        );
+    }
+
+    #[test]
+    fn test_decide_action_mid_satisfaction_renewal() {
+        // Mid satisfaction + short contract → renewal demand
+        let team = make_team("t1", "Okay Team", 50);
+        let player = make_player(
+            "p1",
+            "Mid",
+            "t1",
+            LolRole::Mid,
+            70,     // lol_ovr
+            60,     // morale (mid)
+            55,     // manager_trust (mid)
+            50_000, // wage
+            60_000, // market_value → wage/mv = 0.83 → fairly paid
+            Some("2026-09-01"), // < 6 months
+            vec![],
+        );
+
+        let game = make_game_with_single_ai_team(team.clone(), vec![player]);
+        let p = game.players.iter().find(|p| p.id == "p1").unwrap();
+        let t = game.teams.iter().find(|t| t.id == "t1").unwrap();
+        let satisfaction = compute_satisfaction(p, t, &game);
+        let decision = decide_action(satisfaction, p, t, &game);
+
+        assert_eq!(
+            decision,
+            PlayerAgentDecision::RequestRenewal,
+            "mid-satisfaction player with short contract should demand renewal, satisfaction={satisfaction}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 3: Orchestration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_process_ai_player_agents_no_panic() {
+        // Minimal test: run process_ai_player_agents with empty game state
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
+        );
+        let mut team = make_team("ai_team", "AI Team", 50);
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None;
+
+        let mut game = Game::new(clock, manager, vec![team], vec![], vec![], vec![]);
+        // Should not panic
+        process_ai_player_agents(&mut game);
+    }
+
+    #[test]
+    fn test_process_ai_player_agents_sets_flags() {
+        // Integration: run process_ai_player_agents and verify
+        // that flags are set correctly on applicable players.
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
+        );
+
+        let mut team = make_team("ai_team", "AI Team", 30);
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None;
+
+        // Unhappy player who should request transfer
+        let unhappy = make_player(
+            "p1", "Unhappy", "ai_team", LolRole::Mid,
+            55, 20, 15, 20_000, 100_000,
+            Some("2026-09-01"),
+            vec![],
+        );
+
+        // Happy player
+        let happy = make_player(
+            "p2", "Happy", "ai_team", LolRole::Top,
+            85, 90, 80, 100_000, 100_000,
+            Some("2028-06-15"),
+            vec![PlayerTrait::TeamPlayer],
+        );
+
+        let mut game = Game::new(
+            clock,
+            manager,
+            vec![team],
+            vec![unhappy, happy],
+            vec![],
+            vec![],
+        );
+
+        process_ai_player_agents(&mut game);
+
+        let p1 = game.players.iter().find(|p| p.id == "p1").unwrap();
+        let p2 = game.players.iter().find(|p| p.id == "p2").unwrap();
+
+        // p1 should be transfer_listed (unhappy, underpaid, short contract)
+        // or at minimum have some flag set
+        assert!(
+            p1.transfer_listed || p1.morale_core.renewal_state.is_some(),
+            "unhappy player should have a decision flag set"
+        );
+
+        // p2 should be silent (happy)
+        assert!(
+            !p2.transfer_listed,
+            "happy player should not be transfer listed"
+        );
+    }
+}

--- a/src-tauri/crates/olm_core/src/ai_player_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_player_agent.rs
@@ -23,6 +23,10 @@ const SATISFACTION_LOW: f64 = 0.35;
 /// Satisfaction at or above this → completely happy (Silent).
 const SATISFACTION_HIGH: f64 = 0.70;
 
+/// Satisfaction below this on a contender → truly miserable threshold.
+/// Between [0.20, SATISFACTION_LOW) the contender suppresses transfer requests.
+const TRULY_MISERABLE: f64 = 0.20;
+
 /// Contract months remaining below this → renewal demand trigger.
 const RENEWAL_CONTRACT_MONTHS: f64 = 6.0;
 
@@ -270,7 +274,7 @@ fn decide_action_inner(
     // --- Very low satisfaction → transfer request (PA-04) ---
     if satisfaction < SATISFACTION_LOW {
         // PA-03: Contender teams suppress unless truly miserable
-        if is_contender && satisfaction >= 0.20 {
+        if is_contender && satisfaction >= TRULY_MISERABLE {
             if contract_short {
                 return PlayerAgentDecision::RequestRenewal;
             }
@@ -793,7 +797,8 @@ mod tests {
             ambition
         );
 
-        // p1 is the moderately unhappy one: morale 35, trust 30
+        // p1 is very unhappy (morale 20, trust 15) + underpaid + HyperCarry
+        // on a contender → should be suppressed (not RequestTransfer)
         let p1 = game.players.iter().find(|p| p.id == "p1").unwrap();
         let satisfaction = compute_satisfaction(p1, t, &game);
         let decision = decide_action(satisfaction, p1, t, &game);

--- a/src-tauri/crates/olm_core/src/ai_team_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_team_agent.rs
@@ -2,7 +2,7 @@ use crate::domain::player::{Player, PlayerTrait};
 use crate::domain::team::Team;
 use crate::game::Game;
 use chrono::{Datelike, NaiveDate};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // ---------------------------------------------------------------------------
 // Retention scoring weights (design: retention = Σ(weight × factor))
@@ -586,7 +586,7 @@ pub fn process_ai_team_agents(game: &mut Game) {
 
 /// Resolve conflicts between Player Agent and Team Agent decisions.
 ///
-/// For each transfer-listed player who is under contract:
+/// For each player newly transfer-listed by Player Agent who is under contract:
 /// - If retention_score >= RENEWAL_THRESHOLD → cancel the transfer listing
 /// - If the player is the ONLY player at their role on the team AND
 ///   contract extends > 12 months from today → cancel the transfer listing
@@ -594,7 +594,7 @@ pub fn process_ai_team_agents(game: &mut Game) {
 /// Spec OR-03: Under-contract → Team Agent overrides Player Agent.
 /// Spec OR-04: Free agents (no contract / expired) → Player Agent decision is final;
 ///             this function skips them implicitly.
-pub fn resolve_conflicts(game: &mut Game) {
+pub fn resolve_conflicts(game: &mut Game, previously_transfer_listed: &HashSet<String>) {
     use crate::domain::stats::LolRole;
     use std::collections::HashMap;
 
@@ -615,7 +615,10 @@ pub fn resolve_conflicts(game: &mut Game) {
 
     let mut override_ids: Vec<String> = Vec::new();
 
-    for player in players.iter().filter(|p| p.transfer_listed) {
+    for player in players
+        .iter()
+        .filter(|p| p.transfer_listed && !previously_transfer_listed.contains(&p.id))
+    {
         // Only under-contract players (OR-03)
         let contract_end = match player.contract_end.as_deref() {
             Some(s) => match NaiveDate::parse_from_str(s, "%Y-%m-%d").ok() {
@@ -632,6 +635,9 @@ pub fn resolve_conflicts(game: &mut Game) {
             Some(t) => t,
             None => continue,
         };
+        if team.team_kind != crate::domain::team::TeamKind::Main || team.manager_id.is_some() {
+            continue;
+        }
 
         let r_score = retention_score(player, team, today);
 
@@ -1492,12 +1498,62 @@ mod tests {
         // Set lol_ovr after Game::new refresh
         game.players[0].lol_ovr = 95;
 
-        resolve_conflicts(&mut game);
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
 
         let p = game.players.iter().find(|p| p.id == "p1").unwrap();
         assert!(
             !p.transfer_listed,
             "high retention player should have transfer_listed reset by Team Agent"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_does_not_clear_human_managed_team_listing() {
+        let mut game = make_full_game_for_conflict(
+            vec![make_player(
+                "p_human", "HumanStar", "human_team", LolRole::Mid,
+                95, 8.5, 60_000,
+                Some("2028-06-15"),
+                "2002-01-01", vec![PlayerTrait::HyperCarry],
+            )],
+            vec!["human_team"],
+        );
+        game.teams[0].manager_id = Some("human_manager".to_string());
+        game.players[0].transfer_listed = true;
+        game.players[0].lol_ovr = 95;
+
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
+
+        let player = game.players.iter().find(|p| p.id == "p_human").unwrap();
+        assert!(
+            player.transfer_listed,
+            "human-managed team listings must not be cleared by AI conflict resolution"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_does_not_clear_preexisting_transfer_listing() {
+        let mut game = make_full_game_for_conflict(
+            vec![make_player(
+                "p_preexisting", "PreListedStar", "ai_default", LolRole::Mid,
+                95, 8.5, 60_000,
+                Some("2028-06-15"),
+                "2002-01-01", vec![PlayerTrait::HyperCarry],
+            )],
+            vec!["ai_default"],
+        );
+        game.players[0].transfer_listed = true;
+        game.players[0].lol_ovr = 95;
+
+        let previously_transfer_listed = std::collections::HashSet::from(["p_preexisting".to_string()]);
+        resolve_conflicts(&mut game, &previously_transfer_listed);
+
+        let player = game.players.iter().find(|p| p.id == "p_preexisting").unwrap();
+        assert!(
+            player.transfer_listed,
+            "pre-existing or Team-Agent-created listings must remain listed"
         );
     }
 
@@ -1518,7 +1574,8 @@ mod tests {
         game.players[0].transfer_listed = true;
         game.players[0].lol_ovr = 45;
 
-        resolve_conflicts(&mut game);
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
 
         let p = game.players.iter().find(|p| p.id == "p2").unwrap();
         assert!(
@@ -1548,7 +1605,8 @@ mod tests {
         game.players[0].transfer_listed = true;
         game.players[0].lol_ovr = 80;
 
-        resolve_conflicts(&mut game);
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
 
         let p = game.players.iter().find(|p| p.id == "p3").unwrap();
         assert!(
@@ -1573,7 +1631,8 @@ mod tests {
         game.players[0].transfer_listed = true;
         game.players[0].lol_ovr = 80;
 
-        resolve_conflicts(&mut game);
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
 
         let p = game.players.iter().find(|p| p.id == "p4").unwrap();
         assert!(
@@ -1624,7 +1683,8 @@ mod tests {
             }
         }
 
-        resolve_conflicts(&mut game);
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
 
         let p5 = game.players.iter().find(|p| p.id == "p5").unwrap();
         assert!(
@@ -1666,7 +1726,8 @@ mod tests {
             }
         }
 
-        resolve_conflicts(&mut game);
+        let previously_transfer_listed = std::collections::HashSet::new();
+        resolve_conflicts(&mut game, &previously_transfer_listed);
 
         let p8 = game.players.iter().find(|p| p.id == "p8").unwrap();
         assert!(
@@ -1847,10 +1908,24 @@ mod tests {
         support.morale_core.manager_trust = 15;
         support.wage = 20_000; // underpaid → triggers transfer request
 
-        // Now run agents
+        // Now run agents. Snapshot after Team Agent so conflict resolution only
+        // clears transfer requests that Player Agent created in this cycle.
         crate::ai_team_agent::process_ai_team_agents(&mut game);
+        let previously_transfer_listed: std::collections::HashSet<String> = game.players
+            .iter()
+            .filter(|p| p.transfer_listed)
+            .map(|p| p.id.clone())
+            .collect();
         crate::ai_player_agent::process_ai_player_agents(&mut game);
-        crate::ai_team_agent::resolve_conflicts(&mut game);
+
+        let support_after_player_agent = game.players.iter()
+            .find(|p| p.natural_position == LolRole::Support).unwrap();
+        assert!(
+            support_after_player_agent.transfer_listed,
+            "precondition: Player Agent should request a transfer before conflict resolution"
+        );
+
+        crate::ai_team_agent::resolve_conflicts(&mut game, &previously_transfer_listed);
 
         // Support player should NOT be transfer_listed (critical depth overrides)
         let support_after = game.players.iter()
@@ -1969,8 +2044,13 @@ mod tests {
 
         // ... run agents
         crate::ai_team_agent::process_ai_team_agents(&mut game1);
+        let previously_transfer_listed1: std::collections::HashSet<String> = game1.players
+            .iter()
+            .filter(|p| p.transfer_listed)
+            .map(|p| p.id.clone())
+            .collect();
         crate::ai_player_agent::process_ai_player_agents(&mut game1);
-        crate::ai_team_agent::resolve_conflicts(&mut game1);
+        crate::ai_team_agent::resolve_conflicts(&mut game1, &previously_transfer_listed1);
 
         let result1: Vec<(String, bool, Option<String>)> = game1.players
             .iter()
@@ -1986,8 +2066,13 @@ mod tests {
         game2.players[4].lol_ovr = 75;
 
         crate::ai_team_agent::process_ai_team_agents(&mut game2);
+        let previously_transfer_listed2: std::collections::HashSet<String> = game2.players
+            .iter()
+            .filter(|p| p.transfer_listed)
+            .map(|p| p.id.clone())
+            .collect();
         crate::ai_player_agent::process_ai_player_agents(&mut game2);
-        crate::ai_team_agent::resolve_conflicts(&mut game2);
+        crate::ai_team_agent::resolve_conflicts(&mut game2, &previously_transfer_listed2);
 
         let result2: Vec<(String, bool, Option<String>)> = game2.players
             .iter()

--- a/src-tauri/crates/olm_core/src/ai_team_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_team_agent.rs
@@ -1,0 +1,746 @@
+use crate::domain::player::{Player, PlayerTrait};
+use crate::domain::team::Team;
+use crate::game::Game;
+use chrono::{Datelike, NaiveDate};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Retention scoring weights (design: retention = Σ(weight × factor))
+// ---------------------------------------------------------------------------
+const W_LOL_OVR: f64 = 0.35;
+const W_AVG_RATING: f64 = 0.20;
+const W_AGE: f64 = 0.15;
+const W_CONTRACT_SECURITY: f64 = 0.10;
+const W_WAGE_VALUE: f64 = 0.10;
+const W_TRAIT_BONUS: f64 = 0.10;
+
+/// Soft cap multiplier on wage_budget: we will not exceed 110 % of budget.
+const WAGE_SOFT_CAP_MULTIPLIER: f64 = 1.10;
+
+/// Max teams processed per day in staggered mode.
+const TEAMS_PER_DAY: usize = 3;
+
+// ---------------------------------------------------------------------------
+// Helpers (extracted for REFACTOR)
+// ---------------------------------------------------------------------------
+
+/// Age factor: younger → higher score.
+/// Returns 1.0 for age ≤ 20, linear decrease to 0.0 at age ≥ 35.
+pub fn age_factor(age: u8) -> f64 {
+    if age <= 20 {
+        1.0
+    } else if age >= 35 {
+        0.0
+    } else {
+        1.0 - (age as f64 - 20.0) / 15.0
+    }
+}
+
+/// Contract security: more remaining years → higher score.
+/// Returns 1.0 for ≥ 3 years, linear to 0.0 for 0 years.
+pub fn contract_security(contract_end: Option<&str>, today: NaiveDate) -> f64 {
+    let end = match contract_end.and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok()) {
+        Some(d) => d,
+        None => return 0.0, // no contract = no security
+    };
+    let years_remaining: f64 =
+        (end.signed_duration_since(today).num_days() as f64 / 365.25).clamp(0.0, f64::MAX);
+    (years_remaining / 3.0).clamp(0.0, 1.0)
+}
+
+/// Wage-value ratio: wage ≤ expected → good (≥ 1.0).
+/// Returns 1.0 if wage ≤ expected_wage, down to 0.3 at extreme overpay.
+pub fn wage_value_ratio(wage: u32, expected_wage: u32) -> f64 {
+    if expected_wage == 0 {
+        return 0.5; // unknown baseline
+    }
+    let ratio = wage as f64 / expected_wage as f64;
+    if ratio <= 1.0 {
+        1.0
+    } else {
+        (1.0 - (ratio - 1.0) * 0.5).clamp(0.3, 1.0)
+    }
+}
+
+/// Trait bonus: key traits increase retention score.
+/// HyperCarry, ShotCaller, IceCold, Visionary → +0.2 each.
+/// TeamPlayer, Sentinel, Workhorse → +0.1 each.
+pub fn trait_bonus(traits: &[PlayerTrait]) -> f64 {
+    let mut bonus: f64 = 0.0;
+    for t in traits {
+        match t {
+            PlayerTrait::HyperCarry
+            | PlayerTrait::ShotCaller
+            | PlayerTrait::IceCold
+            | PlayerTrait::Visionary => bonus += 0.2,
+            PlayerTrait::TeamPlayer | PlayerTrait::Sentinel | PlayerTrait::Workhorse => bonus += 0.1,
+            _ => {}
+        }
+    }
+    bonus.clamp(0.0, 1.0)
+}
+
+/// Compute player age from date_of_birth string.
+pub fn player_age(date_of_birth: &str, today: NaiveDate) -> u8 {
+    let birth = match NaiveDate::parse_from_str(date_of_birth, "%Y-%m-%d") {
+        Ok(d) => d,
+        Err(_) => return 25, // fallback
+    };
+    let mut age = today.year() - birth.year();
+    // Birthday check: use month*100+day to avoid leap-year ordinal skew
+    if today.format("%m%d").to_string() < birth.format("%m%d").to_string() {
+        age -= 1;
+    }
+    age.max(0) as u8
+}
+
+// ---------------------------------------------------------------------------
+// Composite retention score
+// ---------------------------------------------------------------------------
+
+/// Compute a 0..1 retention score for a player relative to their team.
+/// Uses EXISTING player/team fields only — no schema changes.
+pub fn retention_score(player: &Player, team: &Team, today: NaiveDate) -> f64 {
+    let lol_ovr = f64::from(player.lol_ovr) / 99.0; // normalise 0..1
+
+    let rating = f64::from(player.stats.avg_rating) / 10.0; // avg_rating is 0..10, normalise
+
+    let age = player_age(&player.date_of_birth, today);
+    let age_f = age_factor(age);
+
+    let cs = contract_security(player.contract_end.as_deref(), today);
+
+    // Expected wage from contracts module
+    let expected = crate::contracts::expected_wage(player, team, today);
+    let wvr = wage_value_ratio(player.wage, expected);
+
+    let tb = trait_bonus(&player.traits);
+
+    lol_ovr * W_LOL_OVR
+        + rating * W_AVG_RATING
+        + age_f * W_AGE
+        + cs * W_CONTRACT_SECURITY
+        + wvr * W_WAGE_VALUE
+        + tb * W_TRAIT_BONUS
+}
+
+// ---------------------------------------------------------------------------
+// Roster report
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct RosterReport {
+    /// Number of players per LolRole
+    pub role_depth: HashMap<crate::domain::stats::LolRole, u32>,
+    /// Average OVR per role
+    pub avg_ovr_by_role: HashMap<crate::domain::stats::LolRole, f64>,
+    /// Player IDs sorted by retention score (descending)
+    pub retention_scores: Vec<(String, f64)>,
+    /// Player IDs whose score suggests renewal
+    pub renewal_candidates: Vec<String>,
+    /// Roles with 0 players
+    pub role_gaps: Vec<crate::domain::stats::LolRole>,
+}
+
+/// Assess a team's roster and produce a RosterReport.
+pub fn assess_roster(team: &Team, players: &[Player], today: NaiveDate) -> RosterReport {
+    use crate::domain::stats::LolRole;
+
+    let mut role_depth: HashMap<LolRole, u32> = HashMap::new();
+    let mut ovr_sum: HashMap<LolRole, u64> = HashMap::new();
+    let mut ovr_count: HashMap<LolRole, u32> = HashMap::new();
+
+    // Initialise all roles
+    for role in &[
+        LolRole::Top,
+        LolRole::Jungle,
+        LolRole::Mid,
+        LolRole::Adc,
+        LolRole::Support,
+    ] {
+        role_depth.insert(*role, 0);
+        ovr_sum.insert(*role, 0);
+        ovr_count.insert(*role, 0);
+    }
+
+    let team_players: Vec<&Player> = players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some(&team.id))
+        .collect();
+
+    for p in &team_players {
+        let role = p.natural_position;
+        *role_depth.entry(role).or_insert(0) += 1;
+        *ovr_sum.entry(role).or_insert(0) += u64::from(p.lol_ovr);
+        *ovr_count.entry(role).or_insert(0) += 1;
+    }
+
+    let avg_ovr_by_role: HashMap<LolRole, f64> = ovr_sum
+        .into_iter()
+        .map(|(role, sum)| {
+            let count = *ovr_count.get(&role).unwrap_or(&1);
+            (role, sum as f64 / count.max(1) as f64)
+        })
+        .collect();
+
+    let mut retention_scores: Vec<(String, f64)> = team_players
+        .iter()
+        .map(|p| {
+            let score = retention_score(p, team, today);
+            (p.id.clone(), score)
+        })
+        .collect();
+    retention_scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let renewal_candidates: Vec<String> = retention_scores
+        .iter()
+        .filter(|(_, score)| *score >= 0.7)
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    let role_gaps: Vec<LolRole> = role_depth
+        .iter()
+        .filter(|&(_, &count)| count == 0)
+        .map(|(role, _)| *role)
+        .collect();
+
+    RosterReport {
+        role_depth,
+        avg_ovr_by_role,
+        retention_scores,
+        renewal_candidates,
+        role_gaps,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Renewal decisions
+// ---------------------------------------------------------------------------
+
+/// Evaluate which players on a team should get renewal offers.
+/// Sets `player.morale_core.renewal_state` for eligible players.
+pub fn evaluate_renewals(team: &Team, players: &mut [Player], report: &RosterReport, today: NaiveDate) {
+    use crate::domain::player::{ContractRenewalState, RenewalSessionStatus};
+
+    let soft_cap_wage = (team.wage_budget as f64 * WAGE_SOFT_CAP_MULTIPLIER) as i64;
+    let current_wage_bill: i64 = players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some(&team.id))
+        .map(|p| i64::from(p.wage))
+        .sum();
+
+    let mut processed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for player in players.iter_mut() {
+        if player.team_id.as_deref() != Some(&team.id) {
+            continue;
+        }
+
+        // No-deadlock guard: skip already processed
+        if !processed.insert(player.id.clone()) {
+            continue;
+        }
+
+        // Find their retention score from the report
+        let score = report
+            .retention_scores
+            .iter()
+            .find(|(id, _)| id == &player.id)
+            .map(|(_, s)| *s)
+            .unwrap_or(0.5);
+
+        // Spec TA-02: Skip underperformer
+        let is_underperformer =
+            player.stats.avg_rating < 6.0 || player.lol_ovr < 65;
+        if is_underperformer {
+            continue;
+        }
+
+        // Skip players with zero wage (data anomaly / free agent edge case)
+        if player.wage == 0 {
+            continue;
+        }
+
+        // Check budget headroom
+        let projected_wage = if player.wage > 0 {
+            // Offer slight increase
+            (player.wage as f64 * 1.10) as i64
+        } else {
+            player.wage as i64
+        };
+
+        let projected_bill = current_wage_bill - i64::from(player.wage) + projected_wage;
+        if projected_bill > soft_cap_wage {
+            continue; // budget exhausted
+        }
+
+        // Spec TA-02: Renew high performer
+        let is_high_performer = player.stats.avg_rating > 7.5
+            && player.lol_ovr > 80
+            && contract_security(player.contract_end.as_deref(), today) < 0.5; // < ~18 months
+
+        if score >= 0.7 || is_high_performer {
+            if player.morale_core.renewal_state.is_none() {
+                player.morale_core.renewal_state = Some(ContractRenewalState {
+                    status: RenewalSessionStatus::Open,
+                    ..ContractRenewalState::default()
+                });
+            } else if let Some(ref mut state) = player.morale_core.renewal_state {
+                if state.status == RenewalSessionStatus::Idle {
+                    state.status = RenewalSessionStatus::Open;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Staggered processing
+// ---------------------------------------------------------------------------
+
+/// Select non-player, non-academy teams for processing today using round-robin.
+fn select_ai_teams_for_today(game: &Game) -> Vec<String> {
+    let ai_teams: Vec<&Team> = game
+        .teams
+        .iter()
+        .filter(|t| {
+            t.team_kind == crate::domain::team::TeamKind::Main && t.manager_id.is_none()
+        })
+        .collect();
+
+    if ai_teams.is_empty() {
+        return Vec::new();
+    }
+
+    // Use day-of-year as round-robin offset
+    let day_of_year = game
+        .clock
+        .current_date
+        .format("%j")
+        .to_string()
+        .parse::<usize>()
+        .unwrap_or(0);
+    let count = TEAMS_PER_DAY.min(ai_teams.len());
+    let start = day_of_year % ai_teams.len();
+
+    (0..count)
+        .map(|i| {
+            let idx = (start + i) % ai_teams.len();
+            ai_teams[idx].id.clone()
+        })
+        .collect()
+}
+
+/// Public entry point called from turn/mod.rs.
+/// Processes up to 3 AI teams per day: assess roster + evaluate renewals.
+pub fn process_ai_team_agents(game: &mut Game) {
+    let today = game.clock.current_date.date_naive();
+
+    let team_ids = select_ai_teams_for_today(game);
+
+    for team_id in &team_ids {
+        // Borrow team from game — the borrow checker allows
+        // simultaneous &game.teams + &mut game.players since they
+        // are distinct struct fields.
+        let team = match game.teams.iter().find(|t| t.id == *team_id) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let report = assess_roster(team, &game.players, today);
+
+        // Apply renewal decisions (mutable borrow of game.players)
+        evaluate_renewals(team, &mut game.players, &report, today);
+
+        // Stub: evaluate_sales (PR 2), evaluate_purchases (PR 2)
+        // No-ops for now.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clock::GameClock;
+    use crate::domain::manager::Manager;
+    use crate::domain::player::{
+        LolRole, Player, PlayerAttributes, PlayerSeasonStats,
+    };
+    use crate::domain::player::RenewalSessionStatus;
+    use crate::domain::team::Team;
+    use chrono::{TimeZone, Utc};
+
+    fn default_attrs() -> PlayerAttributes {
+        PlayerAttributes {
+            mechanics: 70,
+            laning: 70,
+            teamfighting: 70,
+            macro_play: 70,
+            consistency: 70,
+            shotcalling: 70,
+            champion_pool: 70,
+            discipline: 70,
+            mental_resilience: 70,
+        }
+    }
+
+    fn make_player(
+        id: &str,
+        name: &str,
+        team_id: &str,
+        role: LolRole,
+        lol_ovr: u8,
+        avg_rating: f32,
+        wage: u32,
+        contract_end: Option<&str>,
+        age: &str,
+        traits: Vec<PlayerTrait>,
+    ) -> Player {
+        let mut player = Player::new(
+            id.to_string(),
+            name.to_string(),
+            format!("Full {}", name),
+            age.to_string(),
+            "GB".to_string(),
+            role,
+            default_attrs(),
+        );
+        player.team_id = Some(team_id.to_string());
+        player.lol_ovr = lol_ovr;
+        player.stats = PlayerSeasonStats {
+            avg_rating,
+            ..PlayerSeasonStats::default()
+        };
+        player.wage = wage;
+        player.contract_end = contract_end.map(|s| s.to_string());
+        player.traits = traits;
+        player
+    }
+
+    fn make_team(id: &str, name: &str) -> Team {
+        let mut team = Team::new(
+            id.to_string(),
+            name.to_string(),
+            name[..3].to_string(),
+            "DE".to_string(),
+            "Berlin".to_string(),
+            "Arena".to_string(),
+            10_000,
+        );
+        team.wage_budget = 500_000;
+        team.transfer_budget = 200_000;
+        team
+    }
+
+    fn test_date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 15).unwrap()
+    }
+
+    // Phase 1 — Scoring core
+
+    #[test]
+    fn test_age_factor_young() {
+        assert!((age_factor(20) - 1.0).abs() < 0.001);
+        assert!((age_factor(18) - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_age_factor_old() {
+        assert!((age_factor(35) - 0.0).abs() < 0.001);
+        assert!((age_factor(40) - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_age_factor_mid() {
+        let f = age_factor(27);
+        assert!(f > 0.0 && f < 1.0);
+        assert!((f - (1.0 - 7.0 / 15.0)).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_contract_security_no_contract() {
+        assert!((contract_security(None, test_date()) - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_contract_security_long() {
+        let end = "2029-06-15";
+        let sec = contract_security(Some(end), test_date());
+        assert!(sec > 0.9);
+    }
+
+    #[test]
+    fn test_contract_security_short() {
+        let end = "2026-09-15";
+        let sec = contract_security(Some(end), test_date());
+        assert!(sec > 0.0 && sec < 0.3);
+    }
+
+    #[test]
+    fn test_wage_value_ratio_good_value() {
+        assert!((wage_value_ratio(50_000, 60_000) - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_wage_value_ratio_overpaid() {
+        let r = wage_value_ratio(100_000, 50_000);
+        assert!(r < 1.0 && r >= 0.3);
+    }
+
+    #[test]
+    fn test_trait_bonus_key_traits() {
+        let traits = vec![PlayerTrait::HyperCarry, PlayerTrait::ShotCaller];
+        let bonus = trait_bonus(&traits);
+        assert!((bonus - 0.4).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_trait_bonus_no_traits() {
+        let bonus = trait_bonus(&[]);
+        assert!((bonus - 0.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn test_retention_score_high_performer() {
+        let team = make_team("t1", "Test Team");
+        let player = make_player(
+            "p1", "Star", "t1", LolRole::Mid,
+            95,   // lol_ovr
+            8.5,  // avg_rating
+            60_000, // wage
+            Some("2027-06-15"), // contract_end
+            "2002-01-01", // age ~24
+            vec![PlayerTrait::HyperCarry],
+        );
+        let score = retention_score(&player, &team, test_date());
+        assert!(score > 0.7, "retention_score should be high for star, got {score}");
+    }
+
+    #[test]
+    fn test_retention_score_low_performer() {
+        let team = make_team("t1", "Test Team");
+        let player = make_player(
+            "p2", "Bust", "t1", LolRole::Top,
+            55,   // low lol_ovr
+            5.0,  // low avg_rating
+            80_000, // overpaid
+            Some("2026-09-15"), // contract ending soon
+            "1995-01-01", // age ~31
+            vec![],
+        );
+        let score = retention_score(&player, &team, test_date());
+        assert!(score < 0.5, "retention_score should be low for bust, got {score}");
+    }
+
+    // Phase 1 — assess_roster
+
+    #[test]
+    fn test_assess_roster_basic() {
+        let team = make_team("t1", "Test Team");
+        let player = make_player(
+            "p1", "Star", "t1", LolRole::Mid,
+            90, 8.0, 60_000, Some("2027-06-15"), "2002-01-01", vec![],
+        );
+        let report = assess_roster(&team, &[player], test_date());
+        assert_eq!(*report.role_depth.get(&LolRole::Mid).unwrap(), 1);
+        assert!(*report.role_depth.get(&LolRole::Top).unwrap() == 0);
+        assert!(report.role_gaps.contains(&LolRole::Top));
+        assert!(!report.retention_scores.is_empty());
+    }
+
+    #[test]
+    fn test_assess_roster_empty() {
+        let team = make_team("t1", "Test Team");
+        let report = assess_roster(&team, &[], test_date());
+        assert_eq!(report.role_gaps.len(), 5); // all roles are gaps
+    }
+
+    #[test]
+    fn test_assess_roster_role_gaps_identified() {
+        let team = make_team("t1", "Test Team");
+        let players = vec![
+            make_player("p1", "Top", "t1", LolRole::Top, 80, 7.0, 50_000, Some("2027-06-15"), "2002-01-01", vec![]),
+            make_player("p2", "Mid", "t1", LolRole::Mid, 85, 7.5, 55_000, Some("2027-06-15"), "2002-01-01", vec![]),
+        ];
+        let report = assess_roster(&team, &players, test_date());
+        assert!(report.role_gaps.contains(&LolRole::Jungle));
+        assert!(report.role_gaps.contains(&LolRole::Adc));
+        assert!(report.role_gaps.contains(&LolRole::Support));
+        assert!(!report.role_gaps.contains(&LolRole::Top));
+        assert!(!report.role_gaps.contains(&LolRole::Mid));
+    }
+
+    // Phase 2 — Renewal decisions
+
+    #[test]
+    fn test_evaluate_renewals_high_performer_gets_offer() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+        let mut players = vec![
+            make_player(
+                "p1", "Star", "t1", LolRole::Mid,
+                85, 8.0, 50_000,
+                Some("2026-09-15"), // < 6 months
+                "2002-01-01",
+                vec![],
+            ),
+        ];
+        let report = assess_roster(&team, &players, today);
+        evaluate_renewals(&team, &mut players, &report, today);
+
+        let state = players[0].morale_core.renewal_state.as_ref();
+        assert!(state.is_some(), "high performer should get renewal state");
+        if let Some(s) = state {
+            assert_eq!(s.status, RenewalSessionStatus::Open);
+        }
+    }
+
+    #[test]
+    fn test_evaluate_renewals_skip_underperformer() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+        let mut players = vec![
+            make_player(
+                "p2", "Bust", "t1", LolRole::Top,
+                55, 5.0, 50_000,
+                Some("2026-09-15"),
+                "1995-01-01",
+                vec![],
+            ),
+        ];
+        let report = assess_roster(&team, &players, today);
+        evaluate_renewals(&team, &mut players, &report, today);
+
+        assert!(
+            players[0].morale_core.renewal_state.is_none(),
+            "underperformer should NOT get renewal state"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_renewals_budget_exhausted() {
+        let mut team = make_team("t1", "Poor Team");
+        team.wage_budget = 50_000; // tight budget
+        let today = test_date();
+        let mut players = vec![
+            make_player(
+                "p1", "Star", "t1", LolRole::Mid,
+                85, 8.0, 90_000, // already expensive
+                Some("2026-09-15"),
+                "2002-01-01",
+                vec![PlayerTrait::HyperCarry],
+            ),
+        ];
+        // Override lol_ovr since assess_roster reads it directly (no Game::new refresh here)
+        players[0].lol_ovr = 85;
+
+        let report = assess_roster(&team, &players, today);
+        evaluate_renewals(&team, &mut players, &report, today);
+
+        // Soft cap = 50_000 * 1.10 = 55_000, projected = 90_000 * 1.10 = 99_000 > 55_000
+        let state = &players[0].morale_core.renewal_state;
+        let is_open = matches!(state, Some(s) if s.status == RenewalSessionStatus::Open);
+        assert!(!is_open, "renewal should be skipped when budget is exhausted");
+    }
+
+    #[test]
+    fn test_no_deadlock_same_player_not_processed_twice() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+        let mut players = vec![
+            make_player(
+                "p1", "Star", "t1", LolRole::Mid,
+                85, 8.0, 50_000,
+                Some("2026-09-15"),
+                "2002-01-01",
+                vec![],
+            ),
+            // Duplicate same player ID to test deadlock guard
+            make_player(
+                "p1", "Star Clone", "t1", LolRole::Mid,
+                85, 8.0, 50_000,
+                Some("2026-09-15"),
+                "2002-01-01",
+                vec![],
+            ),
+        ];
+        // Override lol_ovr since assess_roster reads it directly (no Game::new refresh here)
+        players[0].lol_ovr = 85;
+        players[1].lol_ovr = 85;
+
+        let report = assess_roster(&team, &players, today);
+        evaluate_renewals(&team, &mut players, &report, today);
+
+        // Both have same ID, but the no-deadlock guard ensures
+        // only one is processed (players[0]). The second is skipped,
+        // so it retains its default state (None) — spec I-04.
+        // Verify no panic, and first entry gets processed.
+        assert!(
+            players[0].morale_core.renewal_state.is_some(),
+            "first occurrence should get renewal state"
+        );
+        assert!(
+            players[1].morale_core.renewal_state.is_none(),
+            "duplicate should be skipped by deadlock guard"
+        );
+    }
+
+    #[test]
+    fn test_process_ai_team_agents_no_panic() {
+        use crate::domain::team::TeamKind;
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+        let mut team = make_team("ai_team", "AI Team");
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None; // AI team
+
+        let player = make_player(
+            "p1", "Star", "ai_team", LolRole::Mid,
+            85, 8.0, 50_000, Some("2026-09-15"), "2002-01-01", vec![],
+        );
+        let mut game = Game::new(clock, manager, vec![team], vec![player], vec![], vec![]);
+        // Game::new refreshes lol_ovr from attributes — override to test high performer logic
+        game.players[0].lol_ovr = 85;
+        process_ai_team_agents(&mut game);
+
+        // Verify no panic, renewal states set
+        let star = game.players.iter().find(|p| p.id == "p1").unwrap();
+        assert!(
+            star.morale_core.renewal_state.is_some(),
+            "star player should have renewal state set"
+        );
+    }
+
+    #[test]
+    fn test_process_ai_team_agents_empty_roster() {
+        use crate::domain::team::TeamKind;
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+        let mut team = make_team("ai_team", "AI Team");
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None;
+
+        let mut game = Game::new(clock, manager, vec![team], vec![], vec![], vec![]);
+        process_ai_team_agents(&mut game);
+        // Should not panic with 0 eligible players
+    }
+
+    #[test]
+    fn test_player_age_computation() {
+        let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        assert_eq!(player_age("2000-01-01", today), 26);
+        assert_eq!(player_age("1995-06-15", today), 31);
+        assert_eq!(player_age("2020-06-15", today), 6);
+    }
+}

--- a/src-tauri/crates/olm_core/src/ai_team_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_team_agent.rs
@@ -21,6 +21,37 @@ const WAGE_SOFT_CAP_MULTIPLIER: f64 = 1.10;
 const TEAMS_PER_DAY: usize = 3;
 
 // ---------------------------------------------------------------------------
+// Threshold constants (spec-driven, single source of truth for tuning)
+// ---------------------------------------------------------------------------
+
+/// Retention score threshold: players at or above this get a renewal offer.
+const RENEWAL_THRESHOLD: f64 = 0.70;
+
+/// Underperformer detection: players below these thresholds are skipped for renewal.
+const UNDERPERFORMER_RATING: f32 = 6.0;
+const UNDERPERFORMER_OVR: u8 = 65;
+
+/// High-performer bypass: players above these thresholds get a renewal offer
+/// regardless of retention score, provided their contract is short (< 18 months).
+const HIGH_PERFORMER_RATING: f32 = 7.5;
+const HIGH_PERFORMER_OVR: u8 = 80;
+
+// Deadweight score weights
+const DW_OVR_WEIGHT: f64 = 0.40;
+const DW_WAGE_WEIGHT: f64 = 0.35;
+const DW_CONTRACT_WEIGHT: f64 = 0.25;
+
+/// Sale thresholds: players meeting these criteria are transfer-listed.
+const SALE_AGE_THRESHOLD: u8 = 28;
+const SALE_RATING_THRESHOLD: f32 = 6.5;
+
+/// Fraction of top wages used for sale eligibility (top 25 %).
+const TOP_WAGE_QUARTILE: f64 = 0.25;
+
+/// Deadweight score threshold: players scoring at or above this are transfer-listed.
+const DEADWEIGHT_THRESHOLD: f64 = 0.60;
+
+// ---------------------------------------------------------------------------
 // Helpers (extracted for REFACTOR)
 // ---------------------------------------------------------------------------
 
@@ -194,7 +225,7 @@ pub fn assess_roster(team: &Team, players: &[Player], today: NaiveDate) -> Roste
 
     let renewal_candidates: Vec<String> = retention_scores
         .iter()
-        .filter(|(_, score)| *score >= 0.7)
+        .filter(|(_, score)| *score >= RENEWAL_THRESHOLD)
         .map(|(id, _)| id.clone())
         .collect();
 
@@ -251,7 +282,7 @@ pub fn evaluate_renewals(team: &Team, players: &mut [Player], report: &RosterRep
 
         // Spec TA-02: Skip underperformer
         let is_underperformer =
-            player.stats.avg_rating < 6.0 || player.lol_ovr < 65;
+            player.stats.avg_rating < UNDERPERFORMER_RATING || player.lol_ovr < UNDERPERFORMER_OVR;
         if is_underperformer {
             continue;
         }
@@ -275,11 +306,11 @@ pub fn evaluate_renewals(team: &Team, players: &mut [Player], report: &RosterRep
         }
 
         // Spec TA-02: Renew high performer
-        let is_high_performer = player.stats.avg_rating > 7.5
-            && player.lol_ovr > 80
+        let is_high_performer = player.stats.avg_rating > HIGH_PERFORMER_RATING
+            && player.lol_ovr > HIGH_PERFORMER_OVR
             && contract_security(player.contract_end.as_deref(), today) < 0.5; // < ~18 months
 
-        if score >= 0.7 || is_high_performer {
+        if score >= RENEWAL_THRESHOLD || is_high_performer {
             if player.morale_core.renewal_state.is_none() {
                 player.morale_core.renewal_state = Some(ContractRenewalState {
                     status: RenewalSessionStatus::Open,
@@ -291,6 +322,186 @@ pub fn evaluate_renewals(team: &Team, players: &mut [Player], report: &RosterRep
                 }
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Deadweight score computation
+// ---------------------------------------------------------------------------
+
+/// Compute a deadweight score (0..1) indicating how much of a burden
+/// this player is on the team's finances relative to their contribution.
+/// High score = candidate for sale.
+/// Factors: low lol_ovr, high wage, short contract.
+fn compute_deadweight_score(player: &Player, today: NaiveDate) -> f64 {
+    // Normalise lol_ovr: lower = more deadweight (invert)
+    let ovr_factor = 1.0 - (f64::from(player.lol_ovr) / 99.0);
+
+    // Wage factor: higher wage relative to reasonable baseline = more deadweight
+    let wage_factor = (f64::from(player.wage) / 100_000.0).min(1.0);
+
+    // Contract factor: shorter remaining = more deadweight
+    let contract_factor = match player.contract_end.as_deref() {
+        Some(end_str) => {
+            if let Ok(end) = NaiveDate::parse_from_str(end_str, "%Y-%m-%d") {
+                let months_remaining =
+                    (end.signed_duration_since(today).num_days() as f64 / 30.44).max(0.0);
+                // 0 months → 1.0 (deadweight), 24+ months → 0.0
+                1.0 - (months_remaining / 24.0).clamp(0.0, 1.0)
+            } else {
+                1.0
+            }
+        }
+        None => 1.0,
+    };
+
+    ovr_factor * DW_OVR_WEIGHT + wage_factor * DW_WAGE_WEIGHT + contract_factor * DW_CONTRACT_WEIGHT
+}
+
+// ---------------------------------------------------------------------------
+// Selling decisions
+// ---------------------------------------------------------------------------
+
+/// Evaluate which players on a team should be put on the transfer list.
+/// Sets `player.transfer_listed = true` for eligible players.
+///
+/// Spec TA-03: age > 28 + top-25% wage + avg_rating < 6.5 + contract_end > 12 months.
+/// Also marks players with high deadweight score.
+/// Edge cases: new signings protected, injured/out-of-form players protected.
+pub fn evaluate_sales(team: &Team, players: &mut [Player], today: NaiveDate) {
+    // Compute top-25% wage threshold for this team
+    let mut wages: Vec<u32> = players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some(&team.id))
+        .map(|p| p.wage)
+        .collect();
+    wages.sort_unstable_by(|a, b| b.cmp(a));
+    let top_25_threshold = if wages.is_empty() {
+        u32::MAX
+    } else {
+        let idx = ((wages.len().saturating_sub(1)) as f64 * TOP_WAGE_QUARTILE) as usize;
+        wages[idx]
+    };
+
+    let mut processed: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for player in players.iter_mut() {
+        if player.team_id.as_deref() != Some(&team.id) {
+            continue;
+        }
+
+        // No-deadlock guard
+        if !processed.insert(player.id.clone()) {
+            continue;
+        }
+
+        // Edge case: new signing (protected from immediate sale)
+        if let Some(ref date_str) = player.can_be_transferred_until {
+            if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+                if date > today {
+                    continue;
+                }
+            }
+        }
+
+        // Edge case: injured / out of form (condition < 40)
+        if player.condition < 40 {
+            continue;
+        }
+
+        // Spec TA-03 explicit criteria
+        let age = player_age(&player.date_of_birth, today);
+        let contract_months_remaining = match player.contract_end.as_deref() {
+            Some(end_str) => {
+                if let Ok(end) = NaiveDate::parse_from_str(end_str, "%Y-%m-%d") {
+                    (end.signed_duration_since(today).num_days() as f64 / 30.44).max(0.0)
+                } else {
+                    0.0
+                }
+            }
+            None => 0.0,
+        };
+
+        let meets_sale_criteria = age > SALE_AGE_THRESHOLD
+            && player.wage >= top_25_threshold
+            && player.stats.avg_rating < SALE_RATING_THRESHOLD
+            && contract_months_remaining > 12.0;
+
+        // Deadweight score (design: low lol_ovr + high wage + short contract)
+        let deadweight = compute_deadweight_score(player, today);
+        let is_deadweight = deadweight > DEADWEIGHT_THRESHOLD;
+
+        if meets_sale_criteria || is_deadweight {
+            player.transfer_listed = true;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Buying decisions
+// ---------------------------------------------------------------------------
+
+/// Evaluate whether a team should purchase players to fill roster gaps.
+/// Checks transfer budget, role gaps from the report, and wage budget headroom.
+/// Takes `team_id` to avoid borrow conflicts with `&mut Game`.
+pub fn evaluate_purchases(team_id: &str, game: &mut Game, report: &RosterReport) {
+    use crate::domain::season::TransferWindowStatus;
+
+    // Look up team
+    let (transfer_budget, wage_budget) = match game.teams.iter().find(|t| t.id == team_id) {
+        Some(t) => (t.transfer_budget, t.wage_budget),
+        None => return,
+    };
+
+    // Zero budget check — TA-05 budget respect
+    if transfer_budget == 0 {
+        return;
+    }
+
+    // Respect league transfer windows
+    let transfer_open = matches!(
+        game.season_context.transfer_window.status,
+        TransferWindowStatus::Open | TransferWindowStatus::DeadlineDay
+    );
+    if !transfer_open {
+        return;
+    }
+
+    // No role gaps — nothing to buy
+    if report.role_gaps.is_empty() {
+        return;
+    }
+
+    // Check wage budget headroom
+    let soft_cap_wage = (wage_budget as f64 * WAGE_SOFT_CAP_MULTIPLIER) as i64;
+    let current_wage_bill: i64 = game
+        .players
+        .iter()
+        .filter(|p| p.team_id.as_deref() == Some(team_id))
+        .map(|p| i64::from(p.wage))
+        .sum();
+
+    // Compute cheapest available free agent wage + estimate for headroom
+    let cheapest_fa_wage = game
+        .players
+        .iter()
+        .filter(|p| p.team_id.is_none())
+        .map(|p| p.wage)
+        .min()
+        .unwrap_or(0);
+
+    let projected_bill = current_wage_bill + i64::from(cheapest_fa_wage);
+    if projected_bill > soft_cap_wage {
+        return; // no wage budget headroom
+    }
+
+    // For each role gap, try to purchase an affordable free agent
+    for role in &report.role_gaps {
+        if *role == crate::domain::stats::LolRole::Unknown {
+            continue;
+        }
+        let role_str = crate::transfers::lol_role_to_string(role);
+        crate::transfers::ai_agent_purchase(game, team_id, role_str);
     }
 }
 
@@ -332,16 +543,14 @@ fn select_ai_teams_for_today(game: &Game) -> Vec<String> {
 }
 
 /// Public entry point called from turn/mod.rs.
-/// Processes up to 3 AI teams per day: assess roster + evaluate renewals.
+/// Processes up to 3 AI teams per day: assess roster, renewals, sales, purchases.
 pub fn process_ai_team_agents(game: &mut Game) {
     let today = game.clock.current_date.date_naive();
 
     let team_ids = select_ai_teams_for_today(game);
 
+    // --- Phase 1: Renewals + Sales (borrow team + players mutably) ---
     for team_id in &team_ids {
-        // Borrow team from game — the borrow checker allows
-        // simultaneous &game.teams + &mut game.players since they
-        // are distinct struct fields.
         let team = match game.teams.iter().find(|t| t.id == *team_id) {
             Some(t) => t,
             None => continue,
@@ -352,8 +561,22 @@ pub fn process_ai_team_agents(game: &mut Game) {
         // Apply renewal decisions (mutable borrow of game.players)
         evaluate_renewals(team, &mut game.players, &report, today);
 
-        // Stub: evaluate_sales (PR 2), evaluate_purchases (PR 2)
-        // No-ops for now.
+        // Apply sale decisions (mutable borrow of game.players)
+        evaluate_sales(team, &mut game.players, today);
+    }
+
+    // --- Phase 2: Purchases (need &mut Game for transfers module) ---
+    // Separate loop so the &Team borrow from game.teams ends before &mut Game.
+    for team_id in &team_ids {
+        let report = {
+            let team = match game.teams.iter().find(|t| t.id == *team_id) {
+                Some(t) => t,
+                None => continue,
+            };
+            assess_roster(team, &game.players, today)
+        }; // team borrow ends here
+
+        evaluate_purchases(team_id, &mut *game, &report);
     }
 }
 
@@ -737,10 +960,387 @@ mod tests {
     }
 
     #[test]
+    fn test_process_ai_team_agents_full_integration() {
+        use crate::domain::player::LolRole;
+        use crate::domain::season::TransferWindowStatus;
+        use crate::domain::team::TeamKind;
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use chrono::{TimeZone, Utc};
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        // AI team with budget + a role gap (no Support)
+        let mut team = make_team("ai_team", "AI Team");
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None;
+        team.transfer_budget = 500_000;
+        team.wage_budget = 500_000;
+
+        let base_players = vec![
+            make_player("p1", "Top", "ai_team", LolRole::Top, 80, 7.0, 40_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player("p2", "Jg", "ai_team", LolRole::Jungle, 75, 6.8, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player("p3", "Mid", "ai_team", LolRole::Mid, 85, 8.5, 50_000, Some("2026-09-15"), "2002-01-01", vec![]), // high performer, short contract
+            make_player("p4", "Adc", "ai_team", LolRole::Adc, 78, 7.2, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            // Expendable veteran on high wage who should get transfer_listed
+            make_player("p5", "Vet", "ai_team", LolRole::Top, 60, 5.5, 120_000, Some("2028-06-15"), "1995-01-01", vec![]),
+        ];
+
+        let mut game = Game::new(clock, manager, vec![team], base_players, vec![], vec![]);
+        game.season_context.transfer_window.status = TransferWindowStatus::Open;
+
+        // Add a free agent Support
+        let mut fa = make_player(
+            "fa1", "FreeSupp", "none", LolRole::Support,
+            70, 6.5, 30_000, None, "2001-01-01", vec![],
+        );
+        fa.market_value = 100_000;
+        fa.team_id = None;
+        game.players.push(fa);
+
+        // Override lol_ovr values that Game::new resets
+        game.players[0].lol_ovr = 80;
+        game.players[1].lol_ovr = 75;
+        game.players[2].lol_ovr = 85;
+        game.players[3].lol_ovr = 78;
+        game.players[4].lol_ovr = 60;
+
+        process_ai_team_agents(&mut game);
+
+        // 1. High performer (p3) should get renewal state
+        let p3 = game.players.iter().find(|p| p.id == "p3").unwrap();
+        assert!(
+            p3.morale_core.renewal_state.is_some(),
+            "high performer should get renewal offer"
+        );
+
+        // 2. Expendable veteran (p5) should be transfer_listed
+        let p5 = game.players.iter().find(|p| p.id == "p5").unwrap();
+        assert!(
+            p5.transfer_listed,
+            "expendable veteran should be transfer listed"
+        );
+
+        // 3. The team should not crash — full integration runs without panics
+        //    and game state is internally consistent
+        if let Some(team) = game.teams.iter().find(|t| t.id == "ai_team") {
+            assert!(team.transfer_budget >= 0, "budget should not go negative");
+        }
+    }
+
+    #[test]
     fn test_player_age_computation() {
         let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
         assert_eq!(player_age("2000-01-01", today), 26);
         assert_eq!(player_age("1995-06-15", today), 31);
         assert_eq!(player_age("2020-06-15", today), 6);
+    }
+
+    #[test]
+    fn test_compute_deadweight_score_high_ovr_low_wage() {
+        let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        let player = make_player(
+            "p1", "Star", "t1", LolRole::Mid,
+            99, 8.0, 50_000, Some("2028-06-15"), "2000-01-01", vec![],
+        );
+        let score = compute_deadweight_score(&player, today);
+        assert!(
+            score < 0.3,
+            "star player with long contract should have low deadweight score, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_compute_deadweight_score_low_ovr_high_wage() {
+        let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        let player = make_player(
+            "p2", "Bust", "t1", LolRole::Top,
+            40, 5.0, 200_000, Some("2026-09-15"), "1995-01-01", vec![],
+        );
+        let score = compute_deadweight_score(&player, today);
+        assert!(
+            score > 0.6,
+            "bust player with high wage should have high deadweight score, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_compute_deadweight_score_no_contract() {
+        let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        let player = make_player(
+            "p3", "Expiring", "t1", LolRole::Support,
+            60, 6.0, 80_000, None, "1998-01-01", vec![],
+        );
+        let score = compute_deadweight_score(&player, today);
+        assert!(
+            score > 0.4,
+            "player with no contract should have moderate deadweight score, got {score}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2 — Sell decisions
+    // -----------------------------------------------------------------------
+
+    /// Helper: compute top-25% wage threshold for a team's players.
+    fn top_25_wage_threshold(team_id: &str, players: &[Player]) -> u32 {
+        let mut wages: Vec<u32> = players
+            .iter()
+            .filter(|p| p.team_id.as_deref() == Some(team_id))
+            .map(|p| p.wage)
+            .collect();
+        wages.sort_unstable_by(|a, b| b.cmp(a));
+        if wages.is_empty() {
+            return 0;
+        }
+        let idx = ((wages.len().saturating_sub(1)) as f64 * TOP_WAGE_QUARTILE) as usize;
+        wages[idx]
+    }
+
+    #[test]
+    fn test_evaluate_sales_transfer_list_expendable_veteran() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+
+        // Player: age 30 (>28), avg_rating 5.5 (<6.5), contract until 2028 (>12 months)
+        let mut players = vec![
+            make_player(
+                "p1", "Veteran", "t1", LolRole::Top,
+                65, 5.5, 120_000, // top wage
+                Some("2028-06-15"), // >12 months
+                "1996-01-01", // age 30
+                vec![],
+            ),
+            // Second player, lower wage, so p1 is top 25%
+            make_player(
+                "p2", "Youngster", "t1", LolRole::Mid,
+                80, 7.5, 30_000,
+                Some("2027-06-15"),
+                "2002-01-01",
+                vec![],
+            ),
+        ];
+        // Override lol_ovr
+        players[0].lol_ovr = 65;
+        players[1].lol_ovr = 80;
+
+        evaluate_sales(&team, &mut players, today);
+
+        // p1 meets TA-03 criteria → should be transfer_listed
+        assert!(
+            players[0].transfer_listed,
+            "expendable veteran should be transfer_listed"
+        );
+        // p2 is young, performing, low wage → should NOT be transfer_listed
+        assert!(
+            !players[1].transfer_listed,
+            "young performer should NOT be transfer_listed"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_sales_new_signing_not_sold() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+
+        let mut players = vec![
+            make_player(
+                "p1", "RecentSigning", "t1", LolRole::Jungle,
+                70, 6.0, 100_000,
+                Some("2028-06-15"),
+                "1995-01-01", // age 31
+                vec![],
+            ),
+        ];
+        players[0].lol_ovr = 70;
+        // Protected from transfer until future date
+        players[0].can_be_transferred_until = Some("2026-12-01".to_string());
+
+        evaluate_sales(&team, &mut players, today);
+
+        assert!(
+            !players[0].transfer_listed,
+            "new signing should NOT be sold even if they meet sale criteria"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2 — Buy decisions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_evaluate_purchases_initiates_when_budget_and_gap_exist() {
+        // Integration-level: set up a team with budget + role gap + free agent
+        // and verify a purchase happens through the transfers module.
+        use crate::domain::player::LolRole;
+        use crate::domain::season::TransferWindowStatus;
+        use crate::domain::team::TeamKind;
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use chrono::{TimeZone, Utc};
+
+        let today = test_date();
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        let mut team = make_team("t1", "Test Team");
+        team.team_kind = TeamKind::Main;
+        team.transfer_budget = 500_000;
+        team.wage_budget = 500_000;
+        team.finance = 500_000;
+
+        // Team has 4 roles — no Support → gap
+        let base_players = vec![
+            make_player("p1", "Top", "t1", LolRole::Top, 80, 7.0, 40_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player("p2", "Jg", "t1", LolRole::Jungle, 75, 6.8, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player("p3", "Mid", "t1", LolRole::Mid, 85, 7.5, 50_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player("p4", "Adc", "t1", LolRole::Adc, 78, 7.2, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
+        ];
+
+        let mut game = Game::new(clock, manager, vec![team], base_players, vec![], vec![]);
+        game.season_context.transfer_window.status = TransferWindowStatus::Open;
+
+        // Add a free agent Support with low market_value to guarantee purchase
+        let mut fa = make_player(
+            "fa1", "FreeSupp", "none", LolRole::Support,
+            70, 6.5, 30_000,
+            None, "2001-01-01", vec![],
+        );
+        fa.market_value = 100_000;
+        fa.team_id = None;
+        game.players.push(fa);
+
+        // Build report & execute purchase
+        let report = assess_roster(
+            game.teams.iter().find(|t| t.id == "t1").unwrap(),
+            &game.players,
+            today,
+        );
+
+        assert!(
+            report.role_gaps.contains(&LolRole::Support),
+            "precondition: Support should be a gap"
+        );
+
+        evaluate_purchases("t1", &mut game, &report);
+
+        // After purchase, team should have exactly one Support player
+        let support_count = game.players
+            .iter()
+            .filter(|p| p.team_id.as_deref() == Some("t1") && p.natural_position == LolRole::Support)
+            .count();
+        assert_eq!(
+            support_count, 1,
+            "team should have acquired a Support free agent, got {support_count}"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_purchases_no_budget_no_purchase_attempts() {
+        use crate::domain::season::TransferWindowStatus;
+        use crate::domain::team::TeamKind;
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use chrono::{TimeZone, Utc};
+
+        let today = test_date();
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        let mut team = make_team("t1", "Broke Team");
+        team.team_kind = TeamKind::Main;
+        team.transfer_budget = 0; // zero budget
+
+        let players = vec![
+            make_player("p1", "OnlyPlayer", "t1", LolRole::Top, 70, 6.5, 30_000, Some("2027-06-15"), "2000-01-01", vec![]),
+        ];
+
+        let mut game = Game::new(clock, manager, vec![team], players, vec![], vec![]);
+        game.season_context.transfer_window.status = TransferWindowStatus::Open;
+
+        let report = assess_roster(
+            game.teams.iter().find(|t| t.id == "t1").unwrap(),
+            &game.players,
+            today,
+        );
+
+        // Even with gaps, zero budget must prevent purchases (TA-05)
+        evaluate_purchases("t1", &mut game, &report);
+        // No panic = function handled zero budget gracefully
+        // The game state should be unchanged
+        assert_eq!(
+            game.players.iter().filter(|p| p.team_id.as_deref() == Some("t1")).count(),
+            1,
+            "no new players should be added with zero budget"
+        );
+    }
+
+    #[test]
+    fn test_evaluate_sales_no_deadlock_duplicate_player_skipped() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+
+        // Two players with same ID but different wage — only the first
+        // should be processed; the duplicate should be skipped.
+        let mut players = vec![
+            make_player(
+                "p1", "Star", "t1", LolRole::Top,
+                60, 6.0, 120_000,
+                Some("2028-06-15"),
+                "1995-01-01", // age 31, >28
+                vec![],
+            ),
+            make_player(
+                "p1", "Clone", "t1", LolRole::Top,
+                60, 6.0, 120_000,
+                Some("2028-06-15"),
+                "1995-01-01",
+                vec![],
+            ),
+        ];
+        players[0].lol_ovr = 60;
+        players[1].lol_ovr = 60;
+
+        evaluate_sales(&team, &mut players, today);
+
+        // First occurrence should be processed
+        assert!(players[0].transfer_listed, "first occurrence should be evaluated");
+        // Duplicate should be skipped (deadlock guard)
+        assert!(!players[1].transfer_listed, "duplicate should be skipped");
+    }
+
+    #[test]
+    fn test_evaluate_sales_injured_player_not_sold() {
+        let team = make_team("t1", "Test Team");
+        let today = test_date();
+
+        let mut players = vec![
+            make_player(
+                "p1", "InjuredStar", "t1", LolRole::Adc,
+                75, 6.0, 100_000,
+                Some("2028-06-15"),
+                "1995-01-01", // age 31
+                vec![],
+            ),
+        ];
+        players[0].lol_ovr = 75;
+        players[0].condition = 30; // injured/poor form
+
+        evaluate_sales(&team, &mut players, today);
+
+        assert!(
+            !players[0].transfer_listed,
+            "injured player should NOT be sold"
+        );
     }
 }

--- a/src-tauri/crates/olm_core/src/ai_team_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_team_agent.rs
@@ -581,6 +581,88 @@ pub fn process_ai_team_agents(game: &mut Game) {
 }
 
 // ---------------------------------------------------------------------------
+// Conflict resolution — Team Agent overrides Player Agent
+// ---------------------------------------------------------------------------
+
+/// Resolve conflicts between Player Agent and Team Agent decisions.
+///
+/// For each transfer-listed player who is under contract:
+/// - If retention_score >= RENEWAL_THRESHOLD → cancel the transfer listing
+/// - If the player is the ONLY player at their role on the team AND
+///   contract extends > 12 months from today → cancel the transfer listing
+///
+/// Spec OR-03: Under-contract → Team Agent overrides Player Agent.
+/// Spec OR-04: Free agents (no contract / expired) → Player Agent decision is final;
+///             this function skips them implicitly.
+pub fn resolve_conflicts(game: &mut Game) {
+    use crate::domain::stats::LolRole;
+    use std::collections::HashMap;
+
+    let today = game.clock.current_date.date_naive();
+
+    // Phase 1: Collect info needed to decide overrides.
+    // Use separate references to avoid borrow conflicts.
+    let teams = &game.teams;
+    let players = &game.players;
+
+    // Pre-compute role depth per team
+    let mut role_depth: HashMap<(String, LolRole), u32> = HashMap::new();
+    for p in players {
+        if let Some(ref tid) = p.team_id {
+            *role_depth.entry((tid.clone(), p.natural_position)).or_insert(0) += 1;
+        }
+    }
+
+    let mut override_ids: Vec<String> = Vec::new();
+
+    for player in players.iter().filter(|p| p.transfer_listed) {
+        // Only under-contract players (OR-03)
+        let contract_end = match player.contract_end.as_deref() {
+            Some(s) => match NaiveDate::parse_from_str(s, "%Y-%m-%d").ok() {
+                Some(d) => d,
+                None => continue,
+            },
+            None => continue, // free agent → Player Agent decision is final (OR-04)
+        };
+        if contract_end <= today {
+            continue; // expired contract → free agent
+        }
+
+        let team = match teams.iter().find(|t| player.team_id.as_deref() == Some(&t.id)) {
+            Some(t) => t,
+            None => continue,
+        };
+
+        let r_score = retention_score(player, team, today);
+
+        // Check if critical depth (only player at role)
+        let team_id = match player.team_id.as_deref() {
+            Some(id) => id,
+            None => continue,
+        };
+        let role = player.natural_position;
+        let count_at_role = *role_depth.get(&(team_id.to_string(), role)).unwrap_or(&0);
+        let is_only = count_at_role <= 1;
+
+        // Under-contract rule (1.3): contract > 12 months + critical depth
+        let months_remaining =
+            (contract_end.signed_duration_since(today).num_days() as f64 / 30.44).max(0.0);
+        let long_contract_critical = months_remaining > 12.0 && is_only;
+
+        if r_score >= RENEWAL_THRESHOLD || long_contract_critical {
+            override_ids.push(player.id.clone());
+        }
+    }
+
+    // Phase 2: Reset transfer_listed for overridden players
+    for player in &mut game.players {
+        if override_ids.iter().any(|id| id == &player.id) {
+            player.transfer_listed = false;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -1341,6 +1423,581 @@ mod tests {
         assert!(
             !players[0].transfer_listed,
             "injured player should NOT be sold"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 4: Conflict resolution (PR4)
+    // -----------------------------------------------------------------------
+
+    fn make_full_game_for_conflict(
+        players: Vec<Player>,
+        ai_team_ids: Vec<&str>,
+    ) -> Game {
+        use crate::domain::team::TeamKind;
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use chrono::{TimeZone, Utc};
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        let mut teams: Vec<Team> = ai_team_ids
+            .iter()
+            .map(|id| {
+                let mut t = make_team(id, &format!("Team {id}"));
+                t.team_kind = TeamKind::Main;
+                t.manager_id = None;
+                t
+            })
+            .collect();
+        // Ensure at least one team exists
+        if teams.is_empty() {
+            let mut t = make_team("ai_default", "Default AI");
+            t.team_kind = TeamKind::Main;
+            t.manager_id = None;
+            teams.push(t);
+        }
+
+        let mut game = Game::new(clock, manager, teams, players, vec![], vec![]);
+        // Game::new refreshes lol_ovr — set it back for test assertions
+        for p in &mut game.players {
+            if p.lol_ovr == 0 {
+                p.lol_ovr = 70;
+            }
+        }
+        game
+    }
+
+    #[test]
+    fn test_resolve_conflicts_high_retention_resets_transfer_listed() {
+        // Scenario: player under contract, transfer_listed, high retention score
+        // Team Agent should override → reset transfer_listed
+        let mut game = make_full_game_for_conflict(
+            vec![make_player(
+                "p1", "Star", "ai_default", LolRole::Mid,
+                95, 8.5, 60_000, // high ovr, high rating
+                Some("2028-06-15"), // long contract
+                "2002-01-01", vec![PlayerTrait::HyperCarry],
+            )],
+            vec!["ai_default"],
+        );
+
+        // Mark as transfer_listed (Player Agent decision)
+        game.players[0].transfer_listed = true;
+
+        // Set lol_ovr after Game::new refresh
+        game.players[0].lol_ovr = 95;
+
+        resolve_conflicts(&mut game);
+
+        let p = game.players.iter().find(|p| p.id == "p1").unwrap();
+        assert!(
+            !p.transfer_listed,
+            "high retention player should have transfer_listed reset by Team Agent"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_low_retention_keeps_transfer_listed() {
+        // Scenario: player under contract, transfer_listed, LOW retention score
+        // Team Agent should NOT override → transfer_listed stays true
+        let mut game = make_full_game_for_conflict(
+            vec![make_player(
+                "p2", "Bust", "ai_default", LolRole::Top,
+                45, 4.0, 100_000, // low ovr, low rating, overpaid
+                Some("2026-09-15"), // short contract
+                "1995-01-01", vec![], // old, no traits
+            )],
+            vec!["ai_default"],
+        );
+
+        game.players[0].transfer_listed = true;
+        game.players[0].lol_ovr = 45;
+
+        resolve_conflicts(&mut game);
+
+        let p = game.players.iter().find(|p| p.id == "p2").unwrap();
+        assert!(
+            p.transfer_listed,
+            "low retention player should remain transfer_listed"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_free_agent_not_overridden() {
+        // Spec OR-04: Free agent → Player Agent decision is final
+        // Player with no contract_end should NOT have transfer_listed reset
+        let mut game = make_full_game_for_conflict(
+            vec![{
+                let mut p = make_player(
+                    "p3", "FreeAgent", "ai_default", LolRole::Jungle,
+                    80, 7.0, 50_000,
+                    None, // no contract
+                    "2000-01-01", vec![],
+                );
+                p.team_id = Some("ai_default".to_string());
+                p
+            }],
+            vec!["ai_default"],
+        );
+
+        game.players[0].transfer_listed = true;
+        game.players[0].lol_ovr = 80;
+
+        resolve_conflicts(&mut game);
+
+        let p = game.players.iter().find(|p| p.id == "p3").unwrap();
+        assert!(
+            p.transfer_listed,
+            "free agent's transfer_listed must NOT be overridden (OR-04)"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_expired_contract_not_overridden() {
+        // Player with expired contract (end <= today) → free agent, not overridden
+        let mut game = make_full_game_for_conflict(
+            vec![make_player(
+                "p4", "Expired", "ai_default", LolRole::Support,
+                80, 7.0, 50_000,
+                Some("2025-06-15"), // expired before test date
+                "2000-01-01", vec![],
+            )],
+            vec!["ai_default"],
+        );
+
+        game.players[0].transfer_listed = true;
+        game.players[0].lol_ovr = 80;
+
+        resolve_conflicts(&mut game);
+
+        let p = game.players.iter().find(|p| p.id == "p4").unwrap();
+        assert!(
+            p.transfer_listed,
+            "expired contract player's transfer_listed must NOT be overridden"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_only_player_at_role_critical_depth() {
+        // Player is the ONLY player at their role on the team + contract > 12 months
+        // → Team Agent overrides transfer_listed
+        let mut game = make_full_game_for_conflict(
+            vec![
+                make_player(
+                    "p5", "OnlySupport", "ai_default", LolRole::Support,
+                    70, 6.5, 40_000,
+                    Some("2028-06-15"), // long contract > 12 months
+                    "2000-01-01", vec![],
+                ),
+                // Other roles
+                make_player(
+                    "p6", "Top", "ai_default", LolRole::Top,
+                    75, 7.0, 45_000,
+                    Some("2028-06-15"),
+                    "2000-01-01", vec![],
+                ),
+                make_player(
+                    "p7", "Jungle", "ai_default", LolRole::Jungle,
+                    75, 7.0, 45_000,
+                    Some("2028-06-15"),
+                    "2000-01-01", vec![],
+                ),
+            ],
+            vec!["ai_default"],
+        );
+
+        // Mark only Support player as transfer_listed
+        for p in &mut game.players {
+            if p.id == "p5" {
+                p.transfer_listed = true;
+            }
+        }
+        // Set lol_ovr values
+        for p in &mut game.players {
+            if p.lol_ovr == 0 {
+                p.lol_ovr = if p.id == "p5" { 70 } else { 75 };
+            }
+        }
+
+        resolve_conflicts(&mut game);
+
+        let p5 = game.players.iter().find(|p| p.id == "p5").unwrap();
+        assert!(
+            !p5.transfer_listed,
+            "only Support player should have transfer_listed reset (critical depth)"
+        );
+    }
+
+    #[test]
+    fn test_resolve_conflicts_short_contract_not_critical_depth() {
+        // Player is only at role but contract is SHORT (< 12 months)
+        // → Not critical depth, transfer_listed stays
+        let mut game = make_full_game_for_conflict(
+            vec![
+                make_player(
+                    "p8", "TempOnlySupport", "ai_default", LolRole::Support,
+                    70, 6.5, 40_000,
+                    Some("2026-12-01"), // only ~5 months from test date
+                    "2000-01-01", vec![],
+                ),
+                make_player(
+                    "p9", "Top", "ai_default", LolRole::Top,
+                    75, 7.0, 45_000,
+                    Some("2028-06-15"),
+                    "2000-01-01", vec![],
+                ),
+            ],
+            vec!["ai_default"],
+        );
+
+        for p in &mut game.players {
+            if p.id == "p8" {
+                p.transfer_listed = true;
+            }
+        }
+        for p in &mut game.players {
+            if p.lol_ovr == 0 {
+                p.lol_ovr = if p.id == "p8" { 70 } else { 75 };
+            }
+        }
+
+        resolve_conflicts(&mut game);
+
+        let p8 = game.players.iter().find(|p| p.id == "p8").unwrap();
+        assert!(
+            p8.transfer_listed,
+            "short-contract only-at-role player should stay transfer_listed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 2: Integration tests (PR4)
+    // -----------------------------------------------------------------------
+
+    /// Build a Game with `num_teams` AI teams, each with `players_per_team` players
+    /// covering all 5 roles. Returns a fully initialised Game ready for process_day.
+    fn build_integration_game(num_teams: usize, players_per_team: usize) -> Game {
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use crate::domain::team::TeamKind;
+        use chrono::{TimeZone, Utc};
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        let roles = [LolRole::Top, LolRole::Jungle, LolRole::Mid, LolRole::Adc, LolRole::Support];
+        let mut teams = Vec::with_capacity(num_teams);
+        let mut players = Vec::with_capacity(num_teams * players_per_team);
+
+        for ti in 0..num_teams {
+            let tid = format!("ai_team_{ti}");
+            let mut team = Team::new(
+                tid.clone(), format!("AI Team {ti}"), format!("AT{ti}"),
+                "DE".to_string(), "Berlin".to_string(), "Arena".to_string(), 10_000,
+            );
+            team.team_kind = TeamKind::Main;
+            team.manager_id = None;
+            team.wage_budget = 500_000;
+            team.transfer_budget = 200_000;
+            teams.push(team);
+
+            for pi in 0..players_per_team {
+                let role = roles[pi % 5];
+                let pid = format!("p_{tid}_{pi}");
+                let mut p = make_player(
+                    &pid, &format!("Player {tid} {pi}"), &tid, role,
+                    (70 + (pi as u8 * 3) % 25), // varied OVR 70-92
+                    6.5 + (pi as f32 * 0.3).min(2.5), // varied rating 6.5-8.5
+                    40_000 + (pi as u32 * 10_000), // varied wage
+                    Some("2028-06-15"), // standard 2-year contract
+                    "2000-01-01",
+                    if pi == 0 { vec![PlayerTrait::HyperCarry] } else { vec![] },
+                );
+                p.condition = 80; // healthy
+                p.market_value = 100_000 + (pi as u64 * 50_000);
+                players.push(p);
+            }
+        }
+
+        let mut game = Game::new(clock, manager, teams, players, vec![], vec![]);
+        // Override lol_ovr since Game::new refreshes it from attrs
+        for p in &mut game.players {
+            if p.lol_ovr == 0 || p.lol_ovr < 30 {
+                p.lol_ovr = 70 + (p.id.len() as u8 % 25);
+            }
+        }
+        game
+    }
+
+    #[test]
+    fn test_full_lifecycle_30_days_no_crash() {
+        // Spec 2.1: Create Game with 10+ teams, run 30 process_day calls
+        // Assert no crashes, budget compliance, roster_stability fires
+        let mut game = build_integration_game(10, 7); // 10 teams, 7 players each = 70 players
+
+        for day in 0..30 {
+            crate::turn::process_day(&mut game);
+
+            // Assert no crash — we're still running at day {day}
+            // Budget compliance: no negative budgets
+            for team in &game.teams {
+                assert!(
+                    team.wage_budget >= 0,
+                    "Team {} wage_budget went negative on day {}",
+                    team.name, day
+                );
+                assert!(
+                    team.transfer_budget >= 0,
+                    "Team {} transfer_budget went negative on day {}",
+                    team.name, day
+                );
+            }
+
+            // Invariant I-01: minimum 5 players per team (roster_stability safety net)
+            for team in &game.teams {
+                let count = game.players
+                    .iter()
+                    .filter(|p| p.team_id.as_deref() == Some(&team.id))
+                    .count();
+                assert!(
+                    count >= 5,
+                    "Team {} has only {count} players on day {} (below minimum)",
+                    team.name, day
+                );
+            }
+        }
+
+        // Verify at least 25 days elapsed (should be 30 + initial offset)
+        let day_of_year = game.clock.current_date.format("%j").to_string().parse::<u32>().unwrap_or(0);
+        // Started June 15 (day 166), after 30 days = day ~196
+        assert!(
+            day_of_year >= 190,
+            "Expected day_of_year >= 190 after 30 days, got {day_of_year}"
+        );
+    }
+
+    #[test]
+    fn test_conflict_resolution_scenario_player_stays() {
+        // Spec 2.2: Player requests transfer (low satisfaction),
+        // Team Agent rejects due to no depth (only player at role), player stays
+        // Use a single AI team with 4 players — one Support only
+        use crate::domain::player::LolRole;
+        use crate::domain::team::TeamKind;
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use chrono::{TimeZone, Utc};
+
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        let mut team = make_team("reject_team", "Reject Team");
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None;
+        team.wage_budget = 500_000;
+        team.transfer_budget = 200_000;
+
+        // 4 players: Top, Jungle, Mid, Support (only Support — critical depth)
+        let roles = [LolRole::Top, LolRole::Jungle, LolRole::Mid, LolRole::Support];
+        let mut base_players: Vec<Player> = roles.iter().enumerate().map(|(i, &role)| {
+            let pid = format!("p_role_{i}");
+            let mut p = make_player(
+                &pid, &format!("RolePlayer{i}"), "reject_team", role,
+                75, 7.0, 40_000,
+                Some("2028-06-15"), // long contract
+                "2000-01-01", vec![],
+            );
+            p.morale = 60;
+            p.morale_core.manager_trust = 55;
+            p.market_value = 200_000;
+            p
+        }).collect();
+
+        // Add a 5th player at Top (so only Support has depth 1)
+        let mut extra_top = make_player(
+            "p_extra_top", "ExtraTop", "reject_team", LolRole::Top,
+            70, 6.5, 35_000,
+            Some("2028-06-15"), "2000-01-01", vec![],
+        );
+        extra_top.market_value = 150_000;
+        base_players.push(extra_top);
+
+        let mut game = Game::new(clock, manager, vec![team], base_players, vec![], vec![]);
+        // Fix lol_ovr
+        for p in &mut game.players {
+            if p.lol_ovr == 0 || p.lol_ovr < 30 { p.lol_ovr = 75; }
+        }
+
+        // Run the full agent pipeline (Team Agent → Player Agent → resolve_conflicts)
+        // The Support player (only one at role) might be unhappy due to setup.
+        // We manually ensure the Support player has low morale to trigger Player Agent transfer request.
+        let support = game.players.iter_mut()
+            .find(|p| p.natural_position == LolRole::Support).unwrap();
+        support.morale = 20;
+        support.morale_core.manager_trust = 15;
+        support.wage = 20_000; // underpaid → triggers transfer request
+
+        // Now run agents
+        crate::ai_team_agent::process_ai_team_agents(&mut game);
+        crate::ai_player_agent::process_ai_player_agents(&mut game);
+        crate::ai_team_agent::resolve_conflicts(&mut game);
+
+        // Support player should NOT be transfer_listed (critical depth overrides)
+        let support_after = game.players.iter()
+            .find(|p| p.natural_position == LolRole::Support).unwrap();
+        assert!(
+            !support_after.transfer_listed,
+            "Support player must stay (critical depth — Team Agent overrides transfer request)"
+        );
+    }
+
+    #[test]
+    fn test_invariants_across_random_rosters() {
+        // Spec 2.3: Property invariants across varied rosters
+        // Create several different game configurations and verify invariants
+        for roster_size in [5, 6, 7, 8] {
+            let mut game = build_integration_game(6, roster_size);
+
+            // Run a few days
+            for _ in 0..5 {
+                crate::turn::process_day(&mut game);
+            }
+
+            // I-01: Never below 5 players per team
+            for team in &game.teams {
+                let count = game.players
+                    .iter()
+                    .filter(|p| p.team_id.as_deref() == Some(&team.id))
+                    .count();
+                assert!(
+                    count >= 5,
+                    "I-01 violated: Team {} has {count} players (roster_size={roster_size})",
+                    team.name,
+                );
+            }
+
+            // I-02: Budget never negative
+            for team in &game.teams {
+                assert!(
+                    team.wage_budget >= 0,
+                    "I-02 violated: Team {} wage_budget is {}",
+                    team.name, team.wage_budget
+                );
+                assert!(
+                    team.transfer_budget >= 0,
+                    "I-02 violated: Team {} transfer_budget is {}",
+                    team.name, team.transfer_budget
+                );
+            }
+
+            // I-03/04: No deadlock loops — if we reached here without panic, it passed
+            // (process_day doesn't infinite-loop)
+        }
+    }
+
+    #[test]
+    fn test_determinism_identical_state_identical_decisions() {
+        use crate::domain::season::TransferWindowStatus;
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
+        use crate::domain::team::TeamKind;
+        use chrono::{TimeZone, Utc};
+
+        // Spec 2.4/OR-06: Identical game state produces identical decisions
+        // Build game manually for precise control
+        let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+        let manager = Manager::new(
+            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+            "1980-01-01".to_string(), "GB".to_string(),
+        );
+
+        let mut team = make_team("det_team", "Determinism Team");
+        team.team_kind = TeamKind::Main;
+        team.manager_id = None;
+        team.wage_budget = 500_000;
+        team.transfer_budget = 200_000;
+
+        let players = vec![
+            make_player("p1", "Star", "det_team", LolRole::Mid, 90, 8.5, 60_000, Some("2027-06-15"), "2002-01-01", vec![PlayerTrait::HyperCarry]),
+            make_player("p2", "Mediocre", "det_team", LolRole::Top, 70, 6.5, 40_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player("p3", "Vet", "det_team", LolRole::Jungle, 60, 5.5, 120_000, Some("2028-06-15"), "1995-01-01", vec![]),
+            make_player("p4", "Young", "det_team", LolRole::Adc, 80, 7.5, 30_000, Some("2028-06-15"), "2003-01-01", vec![]),
+            make_player("p5", "Supp", "det_team", LolRole::Support, 75, 7.0, 45_000, Some("2027-06-15"), "2001-01-01", vec![]),
+        ];
+
+        // Build game state once, then snapshot
+        fn build_det_game(
+            team: Team, players: Vec<Player>,
+        ) -> Game {
+            let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
+            let manager = Manager::new(
+                "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
+                "1980-01-01".to_string(), "GB".to_string(),
+            );
+            let mut g = Game::new(clock, manager, vec![team], players, vec![], vec![]);
+            g.season_context.transfer_window.status = TransferWindowStatus::Open;
+            for p in &mut g.players {
+                if p.lol_ovr == 0 || p.lol_ovr < 30 { p.lol_ovr = 70; }
+            }
+            g
+        }
+
+        // Run 1
+        let mut game1 = build_det_game(team.clone(), players.clone());
+        // Fix lol_ovr for game1
+        game1.players[0].lol_ovr = 90;
+        game1.players[1].lol_ovr = 70;
+        game1.players[2].lol_ovr = 60;
+        game1.players[3].lol_ovr = 80;
+        game1.players[4].lol_ovr = 75;
+
+        // Snapshot player state
+        let snapshot1: Vec<(String, bool, Option<String>)> = game1.players
+            .iter()
+            .map(|p| (p.id.clone(), p.transfer_listed, p.morale_core.renewal_state.as_ref().map(|s| format!("{:?}", s.status))))
+            .collect();
+
+        // ... run agents
+        crate::ai_team_agent::process_ai_team_agents(&mut game1);
+        crate::ai_player_agent::process_ai_player_agents(&mut game1);
+        crate::ai_team_agent::resolve_conflicts(&mut game1);
+
+        let result1: Vec<(String, bool, Option<String>)> = game1.players
+            .iter()
+            .map(|p| (p.id.clone(), p.transfer_listed, p.morale_core.renewal_state.as_ref().map(|s| format!("{:?}", s.status))))
+            .collect();
+
+        // Run 2 — identical setup
+        let mut game2 = build_det_game(team.clone(), players.clone());
+        game2.players[0].lol_ovr = 90;
+        game2.players[1].lol_ovr = 70;
+        game2.players[2].lol_ovr = 60;
+        game2.players[3].lol_ovr = 80;
+        game2.players[4].lol_ovr = 75;
+
+        crate::ai_team_agent::process_ai_team_agents(&mut game2);
+        crate::ai_player_agent::process_ai_player_agents(&mut game2);
+        crate::ai_team_agent::resolve_conflicts(&mut game2);
+
+        let result2: Vec<(String, bool, Option<String>)> = game2.players
+            .iter()
+            .map(|p| (p.id.clone(), p.transfer_listed, p.morale_core.renewal_state.as_ref().map(|s| format!("{:?}", s.status))))
+            .collect();
+
+        // Compare — must be identical
+        assert_eq!(
+            result1, result2,
+            "OR-06 violated: identical game state produced different decisions"
         );
     }
 }

--- a/src-tauri/crates/olm_core/src/champions.rs
+++ b/src-tauri/crates/olm_core/src/champions.rs
@@ -1661,25 +1661,15 @@ mod tests {
 
     fn attrs() -> PlayerAttributes {
         PlayerAttributes {
-            pace: 60,
-            mental_resilience: 60,
-            strength: 60,
-            champion_pool: 60,
-            passing: 60,
-            laning: 60,
-            tackling: 60,
             mechanics: 60,
-            defending: 60,
-            positioning: 60,
+            laning: 60,
+            teamfighting: 60,
             macro_play: 60,
             consistency: 60,
-            discipline: 60,
-            aggression: 60,
-            teamfighting: 60,
             shotcalling: 60,
-            handling: 20,
-            reflexes: 20,
-            aerial: 20,
+            champion_pool: 60,
+            discipline: 60,
+            mental_resilience: 60,
         }
     }
 

--- a/src-tauri/crates/olm_core/src/db/save_manager.rs
+++ b/src-tauri/crates/olm_core/src/db/save_manager.rs
@@ -371,7 +371,7 @@ mod tests {
     use crate::domain::league::{Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry};
     use crate::domain::manager::Manager;
     use crate::domain::player::{Player, PlayerAttributes};
-    use crate::domain::staff::{StaffAttributes, StaffRole};
+    use crate::domain::staff::{Staff, StaffAttributes, StaffRole};
     use crate::domain::team::Team;
     use crate::clock::GameClock;
     use crate::game::BoardObjective;
@@ -512,6 +512,10 @@ mod tests {
             ],
             competition_id: None,
             league_kind: LeagueKind::Main,
+            logo: None,
+            split_index: 0,
+            tier: 0,
+            active: false,
         };
 
         let mut game = Game::new(

--- a/src-tauri/crates/olm_core/src/end_of_season.rs
+++ b/src-tauri/crates/olm_core/src/end_of_season.rs
@@ -809,7 +809,7 @@ fn renew_contracts_for_retained_players(game: &mut Game) {
 mod tests {
     use super::*;
     use crate::clock::GameClock;
-    use crate::generator::definitions::{ScheduleConfig, SeasonStart, SplitConfig};
+    use crate::generator::definitions::{CompetitionManifest, SeasonStart, SplitConfig};
 
     fn make_team(id: &str) -> crate::domain::team::Team {
         let team = crate::domain::team::Team::new(
@@ -848,18 +848,36 @@ mod tests {
         }
     }
 
-    fn sample_schedule_config() -> ScheduleConfig {
-        ScheduleConfig {
-            format: "single_round_robin".to_string(),
-            team_count: 2,
-            splits: vec![SplitConfig {
-                name: "Spring".to_string(),
-                season_start: SeasonStart { month: 1, day: 15 },
-                superweek_offsets: vec![0],
-                best_of: 1,
-                playoffs: None,
-            }],
-            preseason_friendlies: 0,
+    fn sample_schedule_config() -> CompetitionManifest {
+        CompetitionManifest {
+            id: "lck".to_string(),
+            name: "LCK".to_string(),
+            region: "KR".to_string(),
+            schedule: crate::generator::definitions::ScheduleConfig {
+                format: "single_round_robin".to_string(),
+                team_count: 2,
+                splits: vec![SplitConfig {
+                    name: "Spring".to_string(),
+                    season_start: SeasonStart { month: 1, day: 15 },
+                    superweek_offsets: vec![0],
+                    best_of: 1,
+                    playoffs: None,
+                }],
+                preseason_friendlies: 0,
+            },
+            teams_file: "teams.json".to_string(),
+            players_file: "players.json".to_string(),
+            staff_file: None,
+            championships_file: None,
+            full_name: None,
+            country: None,
+            tier: None,
+            logo: None,
+            erls: vec![],
+            reputation: None,
+            nearby_country_codes: vec![],
+            legacy: false,
+            active: true,
         }
     }
 

--- a/src-tauri/crates/olm_core/src/lib.rs
+++ b/src-tauri/crates/olm_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod academy;
+pub mod ai_player_agent;
 pub mod ai_team_agent;
 pub mod db;
 pub mod domain;

--- a/src-tauri/crates/olm_core/src/lib.rs
+++ b/src-tauri/crates/olm_core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod academy;
+pub mod ai_team_agent;
 pub mod db;
 pub mod domain;
 pub mod engine;

--- a/src-tauri/crates/olm_core/src/live_match_manager/team_builder.rs
+++ b/src-tauri/crates/olm_core/src/live_match_manager/team_builder.rs
@@ -265,25 +265,15 @@ mod tests {
 
     fn attrs(value: u8) -> PlayerAttributes {
         PlayerAttributes {
-            pace: value,
-            mental_resilience: value,
-            strength: value,
-            champion_pool: value,
-            passing: value,
-            laning: value,
-            tackling: value,
             mechanics: value,
-            defending: value,
-            positioning: value,
+            laning: value,
+            teamfighting: value,
             macro_play: value,
             consistency: value,
-            discipline: value,
-            aggression: value,
-            teamfighting: value,
             shotcalling: value,
-            handling: value,
-            reflexes: value,
-            aerial: value,
+            champion_pool: value,
+            discipline: value,
+            mental_resilience: value,
         }
     }
 

--- a/src-tauri/crates/olm_core/src/potential.rs
+++ b/src-tauri/crates/olm_core/src/potential.rs
@@ -228,7 +228,7 @@ mod tests {
     use crate::game::Game;
     use chrono::{TimeZone, Utc};
     use crate::domain::manager::Manager;
-    use crate::domain::player::{Player, PlayerAttributes};
+    use crate::domain::player::{LolRole, Player, PlayerAttributes};
     use crate::domain::team::Team;
 
     fn attrs(stat: u8) -> PlayerAttributes {
@@ -252,7 +252,7 @@ mod tests {
             name.to_string(),
             "2001-01-01".to_string(),
             "GB".to_string(),
-            Position::Midfielder,
+            LolRole::Mid,
             attrs(stat),
         );
         player.team_id = Some(team_id.to_string());

--- a/src-tauri/crates/olm_core/src/roster_stability.rs
+++ b/src-tauri/crates/olm_core/src/roster_stability.rs
@@ -155,6 +155,12 @@ pub fn evaluate_team(
     })
 }
 
+/// Ensure a team has a match-eligible roster by repairing any gaps.
+///
+/// Agent sits ABOVE this — `roster_stability` is the safety net for edge cases
+/// the agent misses (mass departures, initial setup, corrupted saves, etc.).
+/// The AI agent system (`ai_team_agent`, `ai_player_agent`) should prevent most
+/// roster issues; this function catches whatever slips through.
 pub fn repair_team(
     game: &mut Game,
     team_id: &str,
@@ -204,6 +210,11 @@ pub fn repair_team(
     })
 }
 
+/// Ensure ALL AI teams are match-eligible by repairing roster gaps across the league.
+///
+/// Agent sits ABOVE this — `roster_stability` is the safety net for edge cases
+/// the agent misses. Called before background league simulation to guarantee
+/// every AI team has a valid lineup.
 pub fn repair_league(
     game: &mut Game,
     reason: RosterStabilityReason,

--- a/src-tauri/crates/olm_core/src/season_awards.rs
+++ b/src-tauri/crates/olm_core/src/season_awards.rs
@@ -164,7 +164,7 @@ mod tests {
     use super::compute_season_awards;
     use chrono::{TimeZone, Utc};
     use crate::domain::manager::Manager;
-    use crate::domain::player::{Player, PlayerAttributes, PlayerSeasonStats};
+    use crate::domain::player::{LolRole, Player, PlayerAttributes, PlayerSeasonStats};
 
     use crate::domain::team::Team;
 

--- a/src-tauri/crates/olm_core/src/season_context.rs
+++ b/src-tauri/crates/olm_core/src/season_context.rs
@@ -108,7 +108,7 @@ mod tests {
     use crate::game::Game;
     use chrono::{TimeZone, Utc};
     use crate::domain::league::{
-        Fixture, MatchType, FixtureStatus, League, MatchResult, StandingEntry,
+        Fixture, LeagueKind, MatchType, FixtureStatus, League, MatchResult, StandingEntry,
     };
     use crate::domain::manager::Manager;
     use crate::domain::season::{SeasonPhase, TransferWindowStatus};
@@ -194,6 +194,11 @@ mod tests {
                 StandingEntry::new("team1".to_string()),
                 StandingEntry::new("team2".to_string()),
             ],
+            logo: None,
+            league_kind: LeagueKind::Main,
+            split_index: 0,
+            tier: 0,
+            active: false,
         };
         let game = make_game((2026, 7, 10), Some(league));
 
@@ -223,6 +228,11 @@ mod tests {
                 StandingEntry::new("team1".to_string()),
                 StandingEntry::new("team2".to_string()),
             ],
+            logo: None,
+            league_kind: LeagueKind::Main,
+            split_index: 0,
+            tier: 0,
+            active: false,
         };
         let game = make_game((2026, 8, 1), Some(league));
 
@@ -251,6 +261,11 @@ mod tests {
                 1,
             )],
             standings: vec![alpha, beta],
+            logo: None,
+            league_kind: LeagueKind::Main,
+            split_index: 0,
+            tier: 0,
+            active: false,
         };
         let game = make_game((2026, 8, 5), Some(league));
 
@@ -277,6 +292,11 @@ mod tests {
                 make_fixture("fx2", "2026-08-08", FixtureStatus::Completed, 2),
             ],
             standings: vec![alpha, beta],
+            logo: None,
+            league_kind: LeagueKind::Main,
+            split_index: 0,
+            tier: 0,
+            active: false,
         };
         let game = make_game((2026, 8, 9), Some(league));
 

--- a/src-tauri/crates/olm_core/src/state.rs
+++ b/src-tauri/crates/olm_core/src/state.rs
@@ -164,18 +164,13 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use crate::domain::league::{Fixture, MatchType, FixtureStatus, League, StandingEntry};
     use crate::domain::manager::Manager;
-    use crate::domain::player::{Player, PlayerAttributes};
+    use crate::domain::player::{LolRole, Player, PlayerAttributes};
     use crate::domain::team::Team;
 
-    fn default_attrs(pos: Position) -> PlayerAttributes {
-        let group = pos.to_group_position();
-        let is_gk = matches!(group, Position::Goalkeeper);
-        let is_def = matches!(group, Position::Defender);
-        let is_fwd = matches!(group, LolRole::Mid);
-
+    fn default_attrs() -> PlayerAttributes {
         PlayerAttributes {
-            mechanics: if is_gk { 30 } else { 65 },
-            laning: if is_gk { 30 } else { 65 },
+            mechanics: 65,
+            laning: 65,
             teamfighting: 65,
             macro_play: 65,
             consistency: 65,
@@ -186,15 +181,15 @@ mod tests {
         }
     }
 
-    fn make_player(id: &str, name: &str, team_id: &str, position: Position) -> Player {
+    fn make_player(id: &str, name: &str, team_id: &str, role: LolRole) -> Player {
         let mut player = Player::new(
             id.to_string(),
             name.to_string(),
             format!("Full {}", name),
             "1995-01-01".to_string(),
             "GB".to_string(),
-            position.clone(),
-            default_attrs(position),
+            role,
+            default_attrs(),
         );
         player.team_id = Some(team_id.to_string());
         player.morale = 70;
@@ -219,19 +214,19 @@ mod tests {
 
         for idx in 0..2 {
             players.push(make_player(
-                &format!("{}_gk{}", team_id, idx),
-                &format!("GK{}", idx),
+                &format!("{}_support{}", team_id, idx),
+                &format!("Support{}", idx),
                 team_id,
-                Position::Goalkeeper,
+                LolRole::Support,
             ));
         }
 
         for idx in 0..7 {
             players.push(make_player(
-                &format!("{}_def{}", team_id, idx),
-                &format!("Def{}", idx),
+                &format!("{}_top{}", team_id, idx),
+                &format!("Top{}", idx),
                 team_id,
-                Position::Defender,
+                LolRole::Top,
             ));
         }
 
@@ -240,16 +235,16 @@ mod tests {
                 &format!("{}_mid{}", team_id, idx),
                 &format!("Mid{}", idx),
                 team_id,
-                Position::Midfielder,
+                LolRole::Mid,
             ));
         }
 
         for idx in 0..6 {
             players.push(make_player(
-                &format!("{}_fwd{}", team_id, idx),
-                &format!("Fwd{}", idx),
+                &format!("{}_jungle{}", team_id, idx),
+                &format!("Jungle{}", idx),
                 team_id,
-                LolRole::Mid,
+                LolRole::Jungle,
             ));
         }
 
@@ -295,6 +290,11 @@ mod tests {
                 StandingEntry::new("team1".to_string()),
                 StandingEntry::new("team2".to_string()),
             ],
+            logo: None,
+            league_kind: crate::domain::league::LeagueKind::Main,
+            split_index: 0,
+            tier: 0,
+            active: false,
         };
 
         let mut game = Game::new(clock, manager, vec![team1, team2], players, vec![], vec![]);

--- a/src-tauri/crates/olm_core/src/transfers.rs
+++ b/src-tauri/crates/olm_core/src/transfers.rs
@@ -882,6 +882,39 @@ fn simulate_ai_free_agent_signings(game: &mut Game, user_team_id: &str) {
     }
 }
 
+/// Public wrapper for the Team Agent to purchase a free agent for a specific
+/// role. Returns `true` if a signing was executed.
+pub fn ai_agent_purchase(game: &mut Game, team_id: &str, role: &str) -> bool {
+    let Some(team) = game.teams.iter().find(|t| t.id == team_id) else {
+        return false;
+    };
+    let budget_cap = team.transfer_budget.min(team.finance);
+    if budget_cap <= 25_000 {
+        return false;
+    }
+
+    let candidate = game
+        .players
+        .iter()
+        .filter(|player| player.team_id.is_none())
+        .filter(|player| lol_role_to_string(&player.natural_position) == role)
+        .filter_map(|player| {
+            let asking_price = (player.market_value as i64).max(25_000) / 5;
+            (asking_price > 0 && asking_price <= budget_cap).then_some((
+                player.id.clone(),
+                asking_price as u64,
+                player.market_value,
+            ))
+        })
+        .max_by_key(|(_, fee, _)| *fee);
+
+    if let Some((player_id, fee, _market_value)) = candidate {
+        execute_free_agent_signing(game, &player_id, team_id, fee).is_ok()
+    } else {
+        false
+    }
+}
+
 fn simulate_ai_club_to_club_transfers(game: &mut Game, user_team_id: &str) {
     let current_date = game.clock.current_date.date_naive();
 
@@ -2739,7 +2772,7 @@ pub fn release_player_contract(game: &mut Game, player_id: &str) -> Result<i64, 
     Ok(penalty)
 }
 
-fn lol_role_to_string(role: &LolRole) -> &'static str {
+pub(crate) fn lol_role_to_string(role: &LolRole) -> &'static str {
     match role {
         LolRole::Top => "TOP",
         LolRole::Jungle => "JUNGLE",

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -82,6 +82,7 @@ where
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    crate::ai_player_agent::process_ai_player_agents(game);
     news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
@@ -123,6 +124,7 @@ pub fn finish_live_match_day(game: &mut Game) {
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    crate::ai_player_agent::process_ai_player_agents(game);
     news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -21,7 +21,7 @@ use crate::domain::stats::StatsState;
 use crate::domain::team::{Team, TeamKind, TeamSeasonRecord};
 use crate::engine::LolRole as EngineLolRole;
 use log::{debug, info};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 fn params(pairs: &[(&str, &str)]) -> HashMap<String, String> {
@@ -42,6 +42,14 @@ pub use round_summary::{
 /// Process a single day advance.
 pub fn process_day(game: &mut Game) {
     process_day_with_capture(game, &mut |_| {});
+}
+
+fn snapshot_transfer_listed_player_ids(game: &Game) -> HashSet<String> {
+    game.players
+        .iter()
+        .filter(|player| player.transfer_listed)
+        .map(|player| player.id.clone())
+        .collect()
 }
 
 pub fn process_day_with_capture<F>(game: &mut Game, on_capture: &mut F)
@@ -82,8 +90,9 @@ where
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    let previously_transfer_listed = snapshot_transfer_listed_player_ids(game);
     crate::ai_player_agent::process_ai_player_agents(game);
-    crate::ai_team_agent::resolve_conflicts(game);
+    crate::ai_team_agent::resolve_conflicts(game, &previously_transfer_listed);
     news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
@@ -125,8 +134,9 @@ pub fn finish_live_match_day(game: &mut Game) {
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    let previously_transfer_listed = snapshot_transfer_listed_player_ids(game);
     crate::ai_player_agent::process_ai_player_agents(game);
-    crate::ai_team_agent::resolve_conflicts(game);
+    crate::ai_team_agent::resolve_conflicts(game, &previously_transfer_listed);
     news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
@@ -1894,4 +1904,3 @@ mod tests {
         assert_eq!(game.leagues[1].fixtures[0].status, FixtureStatus::Scheduled);
     }
 }
-

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -83,6 +83,7 @@ where
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
     crate::ai_player_agent::process_ai_player_agents(game);
+    crate::ai_team_agent::resolve_conflicts(game);
     news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
@@ -125,6 +126,7 @@ pub fn finish_live_match_day(game: &mut Game) {
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
     crate::ai_player_agent::process_ai_player_agents(game);
+    crate::ai_team_agent::resolve_conflicts(game);
     news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -82,6 +82,7 @@ where
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
     maybe_push_weekly_academy_report(game, &today);
@@ -122,6 +123,7 @@ pub fn finish_live_match_day(game: &mut Game) {
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    news::generate_ai_transfer_news(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
     maybe_push_weekly_academy_report(game, &today);

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -81,6 +81,7 @@ where
     random_events::check_random_events(game);
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
+    crate::ai_team_agent::process_ai_team_agents(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
     maybe_push_weekly_academy_report(game, &today);
@@ -120,6 +121,7 @@ pub fn finish_live_match_day(game: &mut Game) {
     random_events::check_random_events(game);
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
+    crate::ai_team_agent::process_ai_team_agents(game);
     maybe_simulate_parallel_academy_leagues(game);
     process_background_leagues(game, &today);
     maybe_push_weekly_academy_report(game, &today);
@@ -881,6 +883,7 @@ fn maybe_simulate_parallel_academy_leagues(game: &mut Game) {
         }
     }
 }
+
 fn maybe_schedule_playoffs(game: &mut Game) {
     let Some(league) = game.leagues.first_mut() else {
         return;
@@ -1618,7 +1621,7 @@ mod tests {
         let season = 2025;
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(&mut game.teams, &game.players, league, &today_str, season);
+        simulate_background_league(&mut game.teams, &mut game.players, league, &today_str, season);
 
         // The fixture should now be Completed with a result
         let fixture = &league.fixtures[0];
@@ -1636,7 +1639,7 @@ mod tests {
         let season = 2025;
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(&mut game.teams, &game.players, league, &today_str, season);
+        simulate_background_league(&mut game.teams, &mut game.players, league, &today_str, season);
 
         // Both teams should have played=1
         let home_entry = league
@@ -1666,10 +1669,11 @@ mod tests {
         let (mut game, today_str) = bg_test_game(today);
         let season = 2025;
 
+        let league = game.leagues.first_mut().unwrap();
         simulate_background_league(
             &mut game.teams,
-            &game.players,
-            game.active_league_mut().unwrap(),
+            &mut game.players,
+            league,
             &today_str,
             season,
         );
@@ -1698,10 +1702,11 @@ mod tests {
             .map(|p| (p.id.clone(), p.stats.clone()))
             .collect();
 
+        let league = game.leagues.first_mut().unwrap();
         simulate_background_league(
             &mut game.teams,
-            &game.players,
-            game.active_league_mut().unwrap(),
+            &mut game.players,
+            league,
             &today_str,
             season,
         );
@@ -1727,10 +1732,11 @@ mod tests {
         let before_msgs = game.messages.len();
         let before_news = game.news.len();
 
+        let league = game.leagues.first_mut().unwrap();
         simulate_background_league(
             &mut game.teams,
-            &game.players,
-            game.active_league_mut().unwrap(),
+            &mut game.players,
+            league,
             &today_str,
             season,
         );
@@ -1767,10 +1773,11 @@ mod tests {
             });
         }
 
+        let league = game.leagues.first_mut().unwrap();
         simulate_background_league(
             &mut game.teams,
-            &game.players,
-            game.active_league_mut().unwrap(),
+            &mut game.players,
+            league,
             "2025-06-15",
             season,
         );

--- a/src-tauri/crates/olm_core/src/turn/news.rs
+++ b/src-tauri/crates/olm_core/src/turn/news.rs
@@ -3,6 +3,7 @@ use crate::messages;
 use crate::news;
 use chrono::Datelike;
 use crate::domain::league::{Fixture, FixtureStatus, League, StandingEntry};
+use std::collections::HashMap;
 
 fn completed_fixtures_for_day<'a>(league: &'a League, today: &str) -> Vec<&'a Fixture> {
     league
@@ -390,11 +391,66 @@ pub(super) fn generate_pre_match_messages(game: &mut Game, today: &str) {
     }
 }
 
+/// Generate news articles for AI team free agent signings.
+/// Must be called AFTER `process_ai_team_agents()` in the turn pipeline.
+pub(super) fn generate_ai_transfer_news(game: &mut Game) {
+    for entry in &game.transfer_history.entries {
+        // Skip if the user's team is involved (user's own transfers
+        // already have dedicated inbox messages)
+        if entry.is_user_involved {
+            continue;
+        }
+
+        // Skip club-to-club transfers — free agents only
+        // (free agent signings have empty from_team_id)
+        if !entry.from_team_id.is_empty() {
+            continue;
+        }
+
+        let article_id = format!("ai_fa_signed_{}_{}", entry.player_id, entry.date);
+
+        // Deduplicate: skip if article already exists
+        if game.news.iter().any(|n| n.id == article_id) {
+            continue;
+        }
+
+        let player_name = player_match_name_or_id(game, &entry.player_id);
+        let team_name = team_name(game, &entry.to_team_id);
+
+        let date = game.clock.current_date.to_rfc3339();
+        let mut params = HashMap::new();
+        params.insert("player".to_string(), player_name);
+        params.insert("team".to_string(), team_name);
+        params.insert("years".to_string(), entry.contract_years.to_string());
+        params.insert("wage".to_string(), entry.annual_wage.to_string());
+
+        let article =
+            crate::domain::news::NewsArticle::new(
+                article_id,
+                String::new(),
+                String::new(),
+                String::new(),
+                date,
+                crate::domain::news::NewsCategory::TransferRumour,
+            )
+            .with_i18n(
+                "be.news.freeAgentSigned.headline",
+                "be.news.freeAgentSigned.body",
+                "be.source.leagueChronicle",
+                params,
+            )
+            .with_teams(vec![entry.to_team_id.clone()])
+            .with_players(vec![entry.player_id.clone()]);
+
+        game.news.push(article);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        generate_match_news, generate_matchday_news, generate_pre_match_messages,
-        generate_weekly_digest_news,
+        generate_ai_transfer_news, generate_match_news, generate_matchday_news,
+        generate_pre_match_messages, generate_weekly_digest_news,
     };
     use crate::clock::GameClock;
     use crate::game::Game;
@@ -408,7 +464,8 @@ mod tests {
     use crate::domain::player::{LolRole, Player, PlayerAttributes};
     use crate::domain::team::Team;
     use crate::engine::{KillDetail, MatchReport, MatchReportEndReason, Side, TeamStats};
-    use std::collections::HashMap;
+        use crate::domain::transfer_history::TransferHistoryEntry;
+        use std::collections::HashMap;
 
     fn make_team(id: &str, name: &str) -> Team {
         Team::new(
@@ -995,6 +1052,153 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // AI Transfer News tests
+    // -----------------------------------------------------------------------
+
+    fn make_transfer_entry(
+        id: &str,
+        player_id: &str,
+        from_team_id: &str,
+        to_team_id: &str,
+        is_user_involved: bool,
+    ) -> TransferHistoryEntry {
+        TransferHistoryEntry {
+            id: id.to_string(),
+            player_id: player_id.to_string(),
+            player_name: String::new(),
+            player_ovr: 75,
+            player_position: String::new(),
+            player_profile_image_url: None,
+            from_team_id: from_team_id.to_string(),
+            from_team_name: String::new(),
+            to_team_id: to_team_id.to_string(),
+            to_team_name: String::new(),
+            fee: 0,
+            annual_wage: 50_000,
+            contract_years: 2,
+            date: "2025-08-12".to_string(),
+            is_user_involved,
+            is_user_buying: false,
+            was_negotiated: false,
+            initial_offer_fee: None,
+            negotiation_rounds: 0,
+            included_players: vec![],
+        }
+    }
+
+    #[test]
+    fn generate_ai_transfer_news_creates_article_for_ai_free_agent_signing() {
+        let mut game = make_game("2025-08-12", FixtureStatus::Completed);
+        game.transfer_history.entries.push(make_transfer_entry(
+            "th1", "p1", "", "team2", false,
+        ));
+        // Add a player and team for name resolution
+        game.players.push(make_player("p1", "Alice", "team2"));
+        game.teams.push(make_team("team2", "Beta FC"));
+
+        generate_ai_transfer_news(&mut game);
+
+        assert_eq!(game.news.len(), 1);
+        let article = &game.news[0];
+        assert!(article.id.starts_with("ai_fa_signed_p1_"));
+        assert_eq!(article.category, NewsCategory::TransferRumour);
+        assert_eq!(
+            article.headline_key.as_deref(),
+            Some("be.news.freeAgentSigned.headline")
+        );
+        assert_eq!(
+            article.body_key.as_deref(),
+            Some("be.news.freeAgentSigned.body")
+        );
+        assert_eq!(
+            article.source_key.as_deref(),
+            Some("be.source.leagueChronicle")
+        );
+        assert_eq!(article.team_ids, vec!["team2".to_string()]);
+        assert_eq!(article.player_ids, vec!["p1".to_string()]);
+        assert_eq!(article.i18n_params.get("player"), Some(&"Alice".to_string()));
+        assert_eq!(
+            article.i18n_params.get("team"),
+            Some(&"Beta FC".to_string())
+        );
+        assert_eq!(article.i18n_params.get("years"), Some(&"2".to_string()));
+        assert_eq!(
+            article.i18n_params.get("wage"),
+            Some(&"50000".to_string())
+        );
+    }
+
+    #[test]
+    fn generate_ai_transfer_news_skips_user_team_signing() {
+        let mut game = make_game("2025-08-12", FixtureStatus::Completed);
+        game.transfer_history
+            .entries
+            .push(make_transfer_entry("th1", "p1", "", "team1", true));
+
+        game.players.push(make_player("p1", "Alice", "team1"));
+
+        generate_ai_transfer_news(&mut game);
+
+        assert!(game.news.is_empty());
+    }
+
+    #[test]
+    fn generate_ai_transfer_news_skips_club_to_club_transfer() {
+        let mut game = make_game("2025-08-12", FixtureStatus::Completed);
+        game.transfer_history.entries.push(make_transfer_entry(
+            "th1", "p1", "team3", "team2", false,
+        ));
+
+        game.players.push(make_player("p1", "Alice", "team2"));
+
+        generate_ai_transfer_news(&mut game);
+
+        assert!(game.news.is_empty());
+    }
+
+    #[test]
+    fn generate_ai_transfer_news_deduplicates_on_repeat_call() {
+        let mut game = make_game("2025-08-12", FixtureStatus::Completed);
+        game.transfer_history.entries.push(make_transfer_entry(
+            "th1", "p1", "", "team2", false,
+        ));
+        game.players.push(make_player("p1", "Alice", "team2"));
+        game.teams.push(make_team("team2", "Beta FC"));
+
+        generate_ai_transfer_news(&mut game);
+        generate_ai_transfer_news(&mut game);
+
+        assert_eq!(game.news.len(), 1);
+    }
+
+    #[test]
+    fn generate_ai_transfer_news_handles_multiple_signings() {
+        let mut game = make_game("2025-08-12", FixtureStatus::Completed);
+        game.transfer_history.entries.push(make_transfer_entry(
+            "th1", "p1", "", "team2", false,
+        ));
+        game.transfer_history.entries.push(make_transfer_entry(
+            "th2", "p2", "", "team3", false,
+        ));
+        game.transfer_history.entries.push(make_transfer_entry(
+            "th3", "p3", "", "team2", false,
+        ));
+        game.players.push(make_player("p1", "Alice", "team2"));
+        game.players.push(make_player("p2", "Bob", "team3"));
+        game.players.push(make_player("p3", "Carol", "team2"));
+        game.teams.push(make_team("team2", "Beta FC"));
+        game.teams.push(make_team("team3", "Gamma FC"));
+
+        generate_ai_transfer_news(&mut game);
+
+        assert_eq!(game.news.len(), 3);
+        let ids: Vec<&str> = game.news.iter().map(|a| a.id.as_str()).collect();
+        assert!(ids.iter().any(|id| id.starts_with("ai_fa_signed_p1_")));
+        assert!(ids.iter().any(|id| id.starts_with("ai_fa_signed_p2_")));
+        assert!(ids.iter().any(|id| id.starts_with("ai_fa_signed_p3_")));
     }
 }
 

--- a/src-tauri/crates/olm_core/src/turn/news.rs
+++ b/src-tauri/crates/olm_core/src/turn/news.rs
@@ -405,7 +405,7 @@ mod tests {
     use crate::domain::manager::Manager;
     use crate::domain::message::{MessageCategory, MessagePriority};
     use crate::domain::news::NewsCategory;
-    use crate::domain::player::{Player, PlayerAttributes};
+    use crate::domain::player::{LolRole, Player, PlayerAttributes};
     use crate::domain::team::Team;
     use crate::engine::{KillDetail, MatchReport, MatchReportEndReason, Side, TeamStats};
     use std::collections::HashMap;
@@ -549,6 +549,11 @@ mod tests {
                 ),
             ],
             standings: vec![alpha, beta, gamma],
+            logo: None,
+            league_kind: crate::domain::league::LeagueKind::Main,
+            split_index: 0,
+            tier: 0,
+            active: false,
         }];
 
         game

--- a/src-tauri/crates/olm_core/tests/contracts_tests.rs
+++ b/src-tauri/crates/olm_core/tests/contracts_tests.rs
@@ -1,15 +1,15 @@
 use chrono::{TimeZone, Utc};
-use domain::manager::Manager;
-use domain::player::{ContractRenewalState, Player, PlayerAttributes, RenewalSessionStatus};
-use domain::staff::{Staff, StaffAttributes, StaffRole};
-use domain::stats::LolRole;
-use domain::team::Team;
-use ofm_core::clock::GameClock;
-use ofm_core::contracts::{
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{ContractRenewalState, Player, PlayerAttributes, RenewalSessionStatus};
+use olm_core::domain::staff::{Staff, StaffAttributes, StaffRole};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::clock::GameClock;
+use olm_core::contracts::{
     DelegatedRenewalOptions, DelegatedRenewalResultStatus, RenewalDecision, RenewalOffer,
     delegate_renewals, evaluate_renewal_offer, propose_renewal,
 };
-use ofm_core::game::Game;
+use olm_core::game::Game;
 
 fn default_attrs() -> PlayerAttributes {
     PlayerAttributes {

--- a/src-tauri/crates/olm_core/tests/live_match_manager_tests.rs
+++ b/src-tauri/crates/olm_core/tests/live_match_manager_tests.rs
@@ -1,12 +1,12 @@
 use chrono::{TimeZone, Utc};
-use domain::league::{Fixture, MatchType, FixtureStatus, League, StandingEntry};
-use domain::manager::Manager;
-use domain::player::{Player, PlayerAttributes};
-use domain::stats::LolRole;
-use domain::team::Team;
-use ofm_core::clock::GameClock;
-use ofm_core::game::Game;
-use ofm_core::live_match_manager::{self, MatchMode};
+use olm_core::domain::league::{Fixture, MatchType, FixtureStatus, League, StandingEntry};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::clock::GameClock;
+use olm_core::game::Game;
+use olm_core::live_match_manager::{self, MatchMode};
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/src-tauri/crates/olm_core/tests/messages_tests.rs
+++ b/src-tauri/crates/olm_core/tests/messages_tests.rs
@@ -1,4 +1,4 @@
-use ofm_core::messages;
+use olm_core::messages;
 
 // ---------------------------------------------------------------------------
 // welcome_message

--- a/src-tauri/crates/olm_core/tests/multileague_tests.rs
+++ b/src-tauri/crates/olm_core/tests/multileague_tests.rs
@@ -1,12 +1,12 @@
 use chrono::{TimeZone, Utc};
-use domain::league::{Fixture, League, LeagueKind, MatchType, FixtureStatus, StandingEntry};
-use domain::manager::Manager;
-use domain::player::{Player, PlayerAttributes};
-use domain::stats::LolRole;
-use domain::team::Team;
-use ofm_core::clock::GameClock;
-use ofm_core::game::Game;
-use ofm_core::turn;
+use olm_core::domain::league::{Fixture, League, LeagueKind, MatchType, FixtureStatus, StandingEntry};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::clock::GameClock;
+use olm_core::game::Game;
+use olm_core::turn;
 use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/crates/olm_core/tests/narrative_media_events.rs
+++ b/src-tauri/crates/olm_core/tests/narrative_media_events.rs
@@ -1,4 +1,4 @@
-use ofm_core::random_events::{
+use olm_core::random_events::{
     build_fan_petition_from_narrative, build_media_story_from_narrative,
 };
 

--- a/src-tauri/crates/olm_core/tests/narrative_news.rs
+++ b/src-tauri/crates/olm_core/tests/narrative_news.rs
@@ -1,4 +1,4 @@
-use ofm_core::news::{
+use olm_core::news::{
     league_roundup_article, season_preview_article, standings_update_article,
     title_race_storyline_article, unbeaten_streak_storyline_article, weekly_digest_article,
 };

--- a/src-tauri/crates/olm_core/tests/narrative_player_conversations.rs
+++ b/src-tauri/crates/olm_core/tests/narrative_player_conversations.rs
@@ -1,4 +1,4 @@
-use ofm_core::player_events::build_player_conversation_from_narrative;
+use olm_core::player_events::build_player_conversation_from_narrative;
 
 #[test]
 fn low_morale_conversation_uses_lol_competitive_registry_copy_and_effect_id() {

--- a/src-tauri/crates/olm_core/tests/narrative_registry.rs
+++ b/src-tauri/crates/olm_core/tests/narrative_registry.rs
@@ -1,4 +1,4 @@
-use ofm_core::narrative::{
+use olm_core::narrative::{
     NarrativeContentPack, NarrativeSelector, load_default_content_pack, validate_content_pack,
 };
 

--- a/src-tauri/crates/olm_core/tests/random_events_tests.rs
+++ b/src-tauri/crates/olm_core/tests/random_events_tests.rs
@@ -1,16 +1,16 @@
 use chrono::{TimeZone, Utc};
-use domain::league::{Fixture, FixtureStatus, League, MatchResult, MatchType, StandingEntry};
-use domain::manager::Manager;
-use domain::message::{
+use olm_core::domain::league::{Fixture, FixtureStatus, League, MatchResult, MatchType, StandingEntry};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::message::{
     ActionOption, ActionType, InboxMessage, MessageAction, MessageCategory, MessageContext,
     MessagePriority,
 };
-use domain::player::{Player, PlayerAttributes};
-use domain::stats::LolRole;
-use domain::team::{SponsorshipBonusCriterion, Team};
-use ofm_core::clock::GameClock;
-use ofm_core::game::Game;
-use ofm_core::random_events::{apply_event_response, check_random_events, rival_interest_weight};
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::{SponsorshipBonusCriterion, Team};
+use olm_core::clock::GameClock;
+use olm_core::game::Game;
+use olm_core::random_events::{apply_event_response, check_random_events, rival_interest_weight};
 use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/crates/olm_core/tests/scouting_tests.rs
+++ b/src-tauri/crates/olm_core/tests/scouting_tests.rs
@@ -1,13 +1,13 @@
 use chrono::{TimeZone, Utc};
-use domain::manager::Manager;
-use domain::message::*;
-use domain::player::{Player, PlayerAttributes};
-use domain::staff::{Staff, StaffAttributes, StaffRole};
-use domain::stats::LolRole;
-use domain::team::Team;
-use ofm_core::clock::GameClock;
-use ofm_core::game::Game;
-use ofm_core::scouting::{process_scouting, scout_max_assignments, send_scout};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::message::*;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::staff::{Staff, StaffAttributes, StaffRole};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::clock::GameClock;
+use olm_core::game::Game;
+use olm_core::scouting::{process_scouting, scout_max_assignments, send_scout};
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/src-tauri/crates/olm_core/tests/scrim_flow_tests.rs
+++ b/src-tauri/crates/olm_core/tests/scrim_flow_tests.rs
@@ -1,4 +1,4 @@
-use ofm_core::scrim_flow::{
+use olm_core::scrim_flow::{
     DailyScrimFlowEvent as E, DailyScrimFlowState as S, ScrimResultQuality as Q,
     transition_daily_scrim_flow,
 };

--- a/src-tauri/crates/olm_core/tests/training_tests.rs
+++ b/src-tauri/crates/olm_core/tests/training_tests.rs
@@ -1,16 +1,16 @@
 use chrono::{TimeZone, Utc};
-use domain::manager::Manager;
-use domain::player::LolRole;
-use domain::player::{Player, PlayerAttributes};
-use domain::staff::{Staff, StaffAttributes, StaffRole};
-use domain::team::{
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::LolRole;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::staff::{Staff, StaffAttributes, StaffRole};
+use olm_core::domain::team::{
     PostScrimDecision, ScrimChampionPick, ScrimFocus, ScrimIssue, ScrimReport, ScrimStatus, Team,
     TrainingFocus, TrainingIntensity, TrainingSchedule,
 };
-use ofm_core::champions::{ChampionMasteryEntry, ChampionMetaEntry};
-use ofm_core::clock::GameClock;
-use ofm_core::game::Game;
-use ofm_core::training;
+use olm_core::champions::{ChampionMasteryEntry, ChampionMetaEntry};
+use olm_core::clock::GameClock;
+use olm_core::game::Game;
+use olm_core::training;
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -3198,7 +3198,7 @@
         "body": "{{to}} have completed the signing of {{player}} from {{from}} for {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} unterschreibt bei {{team}}",
+        "headline": "{{player}} unterschreibt bei {{team}}",
         "body": "Der vereinslose Spieler {{player}} hat einen {{years}}-Jahres-Vertrag bei {{team}} für €{{wage}}/Jahr unterschrieben."
       }
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3376,7 +3376,7 @@
         "body": "{{to}} have completed the signing of {{player}} from {{from}} for {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} signs with {{team}}",
+        "headline": "{{player}} signs with {{team}}",
         "body": "Free agent {{player}} has signed a {{years}}-year contract with {{team}} at €{{wage}}/year."
       }
     }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -3342,7 +3342,7 @@
         "body": "{{to}} cerró el fichaje de {{player}} desde {{from}} por {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} ficha por {{team}}",
+        "headline": "{{player}} ficha por {{team}}",
         "body": "El agente libre {{player}} ha firmado un contrato de {{years}} año(s) con {{team}} por €{{wage}}/año."
       }
     }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -3198,7 +3198,7 @@
         "body": "{{to}} a finalisé la signature de {{player}} en provenance de {{from}} pour {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} signe avec {{team}}",
+        "headline": "{{player}} signe avec {{team}}",
         "body": "L'agent libre {{player}} a signé un contrat de {{years}} an(s) avec {{team}} à €{{wage}}/an."
       }
     }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -3033,7 +3033,7 @@
         "body": "{{to}} have completed the signing of {{player}} from {{from}} for {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} firma con {{team}}",
+        "headline": "{{player}} firma con {{team}}",
         "body": "Il giocatore svincolato {{player}} ha firmato un contratto di {{years}} anno(i) con {{team}} a €{{wage}}/anno."
       }
     }

--- a/src/i18n/locales/pt-BR.json
+++ b/src/i18n/locales/pt-BR.json
@@ -3198,7 +3198,7 @@
         "body": "{{to}} concluiu a contratação de {{player}}, vindo de {{from}}, por {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} assina com {{team}}",
+        "headline": "{{player}} assina com {{team}}",
         "body": "O agente livre {{player}} assinou um contrato de {{years}} ano(s) com {{team}} por €{{wage}}/ano."
       }
     }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -3197,7 +3197,7 @@
         "body": "{{to}} concluiu a contratação de {{player}}, vindo de {{from}}, por {{fee}}."
       },
       "freeAgentSigned": {
-        "subject": "{{player}} assina com {{team}}",
+        "headline": "{{player}} assina com {{team}}",
         "body": "O agente livre {{player}} assinou um contrato de {{years}} ano(s) com {{team}} por €{{wage}}/ano."
       }
     }

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -3198,7 +3198,7 @@
         "body": "{{to}}, {{player}} transferini {{fee}} karşılığında {{from}} takımından tamamladı."
       },
       "freeAgentSigned": {
-        "subject": "{{player}}, {{team}} ile anlaştı",
+        "headline": "{{player}}, {{team}} ile anlaştı",
         "body": "Boşta oyuncu {{player}}, {{team}} ile {{years}} yıllık sözleşme imzaladı. Maaş: €{{wage}}/yıl."
       }
     }


### PR DESCRIPTION
## Approved issue

Closes #344

- [x] The linked issue has `status:approved`.
- [x] This PR targets `develop` (repo base branch; template says `development`).
- [x] This PR has exactly one `type:*` label.

## Summary

- Adds a Team Agent for AI-managed team retention, renewals, sales, purchases, and staggered roster processing.
- Adds a Player Agent for satisfaction scoring, transfer requests, renewal demands, and day-offset processing.
- Adds AI transfer news, conflict resolution, integration tests, roster-stability documentation, and ADR-014.

## Changes

| File | Change |
|------|--------|
| `src-tauri/crates/olm_core/src/ai_team_agent.rs` | Team Agent scoring, roster assessment, sales/purchases, conflict resolution, and tests. |
| `src-tauri/crates/olm_core/src/ai_player_agent.rs` | Player Agent satisfaction scoring, decisions, routing, day-offset processing, and tests. |
| `src-tauri/crates/olm_core/src/transfers.rs` | AI purchase wrapper and shared role-string helper. |
| `src-tauri/crates/olm_core/src/turn/mod.rs` | Agent/news/conflict-resolution turn wiring. |
| `src-tauri/crates/olm_core/src/turn/news.rs` | AI free-agent signing news generation. |
| `src/i18n/locales/*.json` | Aligns `freeAgentSigned.headline/body` keys. |
| `src-tauri/crates/olm_core/src/roster_stability.rs` | Documents safety-net role beneath agents. |
| `docs/decisions/adr-014-two-agent-ai-system.md` | Records the two-agent architecture decision. |

## Checks run

Required/stable PR checks are intentionally lightweight and production-build-free:

- [ ] `frontend-install` passed (dependency installation validation).
- [ ] `rust-check` passed (`cargo fmt --check` and `cargo check`).
- [ ] Not applicable locally; docs/templates only.

Manual/experimental full checks are available for maintainer-requested validation and current debt tracking:

- Focused: `cargo test -p olm_core --lib ai_team_agent::tests -- --nocapture` ✅
- Focused: `cargo test -p olm_core --lib ai_player_agent::tests -- --nocapture` ✅
- Full lib: `cargo test --lib -p olm_core` ⚠️ 261 passed, 12 pre-existing failures.
- `turn::tests` ⚠️ 2 known failures remain and will be fixed separately.

Do not mark the experimental full checks as required for this PR unless a maintainer explicitly asks.

## Documentation and provenance

- [x] Documentation was updated or no docs change is needed.
- [x] Data provenance was updated or no provenance change is needed.
- [x] No unclear third-party data, generated cache, secret, signing key, or private credential is included.

## Release impact

- [x] Changelog entry added or not needed.
- [x] Version changes are synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` when applicable.