### PR TITLE
fix(match): align press conference result source

### DIFF
--- a/src/ui-v2/_legacy/components/match/LolMatchLive.tsx
+++ b/src/ui-v2/_legacy/components/match/LolMatchLive.tsx
@@ -32,6 +32,7 @@ export interface ChampionSelectionByPlayer {
 interface Props {
   snapshot: MatchSnapshot;
   gameState: GameStateData | null;
+  blueTeamId?: string;
   championSelections?: ChampionSelectionByPlayer | null;
   onSnapshotUpdate: (snap: MatchSnapshot) => void;
   onImportantEvent: (evt: MatchEvent) => void;
@@ -374,7 +375,7 @@ function sideFromActorLabel(
   return match.team === "red" ? "red" : "blue";
 }
 
-export default function LolMatchLive({ gameState, snapshot, championSelections, onSnapshotUpdate, onImportantEvent, onFullTime }: Props) {
+export default function LolMatchLive({ gameState, snapshot, blueTeamId, championSelections, onSnapshotUpdate, onImportantEvent, onFullTime }: Props) {
   const { t } = useTranslation();
   const walls = useMemo(() => getWalls(), []);
   const nav = useMemo(() => new NavGrid(walls), [walls]);
@@ -719,10 +720,13 @@ export default function LolMatchLive({ gameState, snapshot, championSelections, 
 
       if (state.winner && !finishedRef.current) {
         finishedRef.current = true;
+        const effectiveBlueTeamId = blueTeamId ?? snapshot.home_team.id;
+        const homeIsBlue = snapshot.home_team.id === effectiveBlueTeamId;
+        const homeWon = (homeIsBlue && state.winner === "blue") || (!homeIsBlue && state.winner === "red");
         const evt: MatchEvent = {
           minute: Math.floor(state.timeSec / 60),
           event_type: "NexusDestroyed",
-          side: state.winner === "blue" ? "Home" : "Away",
+          side: homeWon ? "Home" : "Away",
           zone: "Midfield",
           player_id: null,
           secondary_player_id: null,
@@ -732,10 +736,10 @@ export default function LolMatchLive({ gameState, snapshot, championSelections, 
           ...snapshot,
           phase: "Finished",
           current_minute: Math.floor(state.timeSec / 60),
-          home_score: state.winner === "blue" ? 1 : 0,
-          away_score: state.winner === "red" ? 1 : 0,
+          home_score: homeWon ? 1 : 0,
+          away_score: homeWon ? 0 : 1,
           events: mergeMatchEvents(snapshot.events, [
-            ...mapRuntimeEventsToMatchEvents(state.events),
+            ...mapRuntimeEventsToMatchEvents(state.events, effectiveBlueTeamId, snapshot.home_team.id),
             evt,
           ]),
         });

--- a/src/ui-v2/_legacy/components/match/PressConference.test.tsx
+++ b/src/ui-v2/_legacy/components/match/PressConference.test.tsx
@@ -34,9 +34,14 @@ vi.mock("react-i18next", () => ({
         "content.lol.social.responses.demandReset.label": "Demand reset",
         "content.lol.social.responses.demandReset.text":
           "We have to reset standards immediately; pressure is part of playing at this level.",
+        "content.lol.social.responses.takeResponsibility.label": "Take responsibility",
+        "content.lol.social.responses.takeResponsibility.text":
+          "We own this result. The team will review it and come back stronger.",
         "content.lol.social.responses.stayMeasured.label": "Stay measured",
         "content.lol.social.responses.stayMeasured.text":
           "One result does not define our form. We review it and move forward.",
+        "content.lol.social.questions.mentalResetAfterLoss.text":
+          "This loss stings. How do you reset the squad mentally before the next match?",
         "match.pressConference": "Press Conference",
         "match.pressSubtitle": "Post-match media for Fnatic",
         "match.nextQuestion": "Next Question",
@@ -427,4 +432,153 @@ describe("PressConference LoL social content", () => {
       ]),
     );
   });
+
+  it("uses explicit winnerSide/context to frame questions as a win even when snapshot scores are 0-0", () => {
+    const questions = buildPressConferenceQuestions({
+      snapshot: makeSnapshot({ home_score: 0, away_score: 0, events: [] }),
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "blue",
+      winnerSide: "blue",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((question) => !question.id.toLowerCase().includes("loss"))).toBe(true);
+    expect(questions.every((question) => !question.id.toLowerCase().includes("underperformance"))).toBe(true);
+  });
+
+  it("keeps result screen and press context aligned when winnerSide matches the displayed result", () => {
+    const snapshot = makeSnapshot({ home_score: 0, away_score: 1 });
+    const pressQuestions = buildPressConferenceQuestions({
+      snapshot,
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "red",
+      winnerSide: "red",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(pressQuestions.length).toBeGreaterThan(0);
+    expect(pressQuestions.every((question) => !question.id.toLowerCase().includes("loss"))).toBe(true);
+    expect(pressQuestions.every((question) => !question.id.toLowerCase().includes("underperformance"))).toBe(true);
+  });
+
+  it("recognises a win when the canonical home team controls red side and wins red", () => {
+    const snapshot = makeSnapshot({ home_score: 0, away_score: 1 });
+    const questions = buildPressConferenceQuestions({
+      snapshot,
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "red",
+      winnerSide: "red",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((question) => !question.id.toLowerCase().includes("loss"))).toBe(true);
+    expect(questions.every((question) => !question.id.toLowerCase().includes("underperformance"))).toBe(true);
+  });
+
+  it("excludes win-framed questions from loss contexts", () => {
+    const lossQuestions = buildPressConferenceQuestions({
+      snapshot: makeSnapshot({ home_score: 1, away_score: 0 }),
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "red",
+      winnerSide: "blue",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(lossQuestions.length).toBeGreaterThan(0);
+    expect(lossQuestions.every((question) => !question.id.toLowerCase().includes("win"))).toBe(true);
+    expect(lossQuestions.every((question) => !question.id.toLowerCase().includes("objective-domination"))).toBe(true);
+    expect(lossQuestions.every((question) => !question.id.toLowerCase().includes("clean-win"))).toBe(true);
+  });
+
+  it("attributes Home-side events to the user when canonical Home controls red", () => {
+    const questions = buildPressConferenceQuestions({
+      snapshot: makeSnapshot({
+        home_score: 1,
+        away_score: 0,
+        events: [
+          { minute: 10, event_type: "Dragon", side: "Home", zone: "River", player_id: "adc1", secondary_player_id: null },
+          { minute: 14, event_type: "Baron", side: "Home", zone: "River", player_id: "sup1", secondary_player_id: null },
+        ],
+      }),
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "red",
+      winnerSide: "red",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(questions.map((question) => question.id)).toContain("clean-win-objectives");
+    expect(questions.every((question) => !question.id.toLowerCase().includes("loss"))).toBe(true);
+  });
+
+  it("attributes Away-side events to the user when canonical Away controls blue", () => {
+    const questions = buildPressConferenceQuestions({
+      snapshot: makeSnapshot({
+        home_score: 0,
+        away_score: 1,
+        events: [
+          { minute: 10, event_type: "Dragon", side: "Away", zone: "River", player_id: "enemy1", secondary_player_id: null },
+          { minute: 14, event_type: "Baron", side: "Away", zone: "River", player_id: "enemy1", secondary_player_id: null },
+        ],
+      }),
+      gameState: makeGameState(),
+      userSide: "Away",
+      controlledSide: "blue",
+      winnerSide: "blue",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(questions.map((question) => question.id)).toContain("clean-win-objectives");
+    expect(questions.every((question) => !question.id.toLowerCase().includes("loss"))).toBe(true);
+  });
+
+  it("does not misattribute enemy objectives to the user under controlled-side swaps", () => {
+    const questions = buildPressConferenceQuestions({
+      snapshot: makeSnapshot({
+        home_score: 1,
+        away_score: 0,
+        events: [
+          { minute: 10, event_type: "Dragon", side: "Away", zone: "River", player_id: "enemy1", secondary_player_id: null },
+          { minute: 14, event_type: "Baron", side: "Away", zone: "River", player_id: "enemy1", secondary_player_id: null },
+        ],
+      }),
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "red",
+      winnerSide: "red",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(questions.map((question) => question.id)).not.toContain("clean-win-objectives");
+  });
+
+  it("regression: live red win is framed as a user win when canonical Home controls red", () => {
+    const questions = buildPressConferenceQuestions({
+      snapshot: makeSnapshot({ home_score: 1, away_score: 0 }),
+      gameState: makeGameState(),
+      userSide: "Home",
+      controlledSide: "red",
+      winnerSide: "red",
+      t: (key: string) => key,
+      random: () => 0,
+    });
+
+    expect(questions.length).toBeGreaterThan(0);
+    expect(questions.every((question) => !question.id.toLowerCase().includes("loss"))).toBe(true);
+    expect(questions.every((question) => !question.id.toLowerCase().includes("underperformance"))).toBe(true);
+  });
+
 });

--- a/src/ui-v2/_legacy/components/match/PressConference.tsx
+++ b/src/ui-v2/_legacy/components/match/PressConference.tsx
@@ -12,6 +12,12 @@ interface PressConferenceProps {
   snapshot: MatchSnapshot;
   gameState: GameStateData;
   userSide: "Home" | "Away";
+  /** The user's actual in-game side (blue/red). */
+  controlledSide?: "blue" | "red";
+  /** The actual winning side (blue/red). */
+  winnerSide?: "blue" | "red";
+  /** Optional explicit result override. */
+  userResult?: "win" | "loss";
   onFinish: () => void;
   onGameUpdate?: (game: GameStateData) => void;
 }
@@ -62,6 +68,9 @@ export default function PressConference({
   snapshot,
   gameState,
   userSide,
+  controlledSide,
+  winnerSide,
+  userResult,
   onFinish,
   onGameUpdate,
 }: PressConferenceProps) {
@@ -71,6 +80,9 @@ export default function PressConference({
       snapshot,
       userSide,
       gameState,
+      controlledSide,
+      winnerSide,
+      userResult,
       t,
       recentQuestionIds: readRecentPressQuestionIds(),
     }),

--- a/src/ui-v2/_legacy/components/match/matchRuntimeEvents.test.ts
+++ b/src/ui-v2/_legacy/components/match/matchRuntimeEvents.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mapRuntimeEventsToMatchEvents,
+  mergeRuntimeEventsIntoSnapshot,
+} from "@/ui-v2/_legacy/components/match/matchRuntimeEvents";
+import type { MatchSnapshot } from "@/ui-v2/_legacy/components/match/types";
+
+function makeSnapshot(overrides: Partial<MatchSnapshot> = {}): MatchSnapshot {
+  return {
+    phase: "FullTime",
+    current_minute: 35,
+    home_score: 1,
+    away_score: 0,
+    possession: "Home",
+    ball_zone: "Midfield",
+    home_team: {
+      id: "home-team",
+      name: "Home Team",
+      draft_strategy: "Objective control",
+      players: [],
+    },
+    away_team: {
+      id: "away-team",
+      name: "Away Team",
+      draft_strategy: "Skirmish",
+      players: [],
+    },
+    home_bench: [],
+    away_bench: [],
+    home_possession_pct: 55,
+    away_possession_pct: 45,
+    events: [],
+    home_subs_made: 0,
+    away_subs_made: 0,
+    max_subs: 0,
+    home_roles: { captain: null, shotcaller: null },
+    away_roles: { captain: null, shotcaller: null },
+    substitutions: [],
+    allows_extra_time: false,
+    home_yellows: {},
+    away_yellows: {},
+    sent_off: [],
+    ...overrides,
+  };
+}
+
+describe("mapRuntimeEventsToMatchEvents", () => {
+  it("maps BLUE/RED to Home/Away by default", () => {
+    const events = mapRuntimeEventsToMatchEvents([
+      { t: 180, type: "kill", text: "BLUE bot lane killed RED ADC" },
+      { t: 360, type: "dragon", text: "RED secured Infernal Dragon" },
+    ]);
+
+    expect(events.map((event) => [event.event_type, event.side])).toEqual([
+      ["Kill", "Home"],
+      ["Dragon", "Away"],
+    ]);
+  });
+
+  it("maps BLUE to Away and RED to Home when the blue team is the canonical away team", () => {
+    const blueTeamId = "away-team";
+    const homeTeamId = "home-team";
+    const events = mapRuntimeEventsToMatchEvents(
+      [
+        { t: 180, type: "kill", text: "BLUE bot lane killed RED ADC" },
+        { t: 360, type: "dragon", text: "RED secured Infernal Dragon" },
+      ],
+      blueTeamId,
+      homeTeamId,
+    );
+
+    expect(events.map((event) => [event.event_type, event.side])).toEqual([
+      ["Kill", "Away"],
+      ["Dragon", "Home"],
+    ]);
+  });
+
+  it("keeps HOME/AWAY mapping even when blueTeamId is provided", () => {
+    const events = mapRuntimeEventsToMatchEvents(
+      [
+        { t: 180, type: "kill", text: "HOME team scored" },
+        { t: 360, type: "dragon", text: "AWAY team secured dragon" },
+      ],
+      "away-team",
+      "home-team",
+    );
+
+    expect(events.map((event) => [event.event_type, event.side])).toEqual([
+      ["Kill", "Home"],
+      ["Dragon", "Away"],
+    ]);
+  });
+});
+
+describe("mergeRuntimeEventsIntoSnapshot", () => {
+  it("merges runtime events using the snapshot's blue side mapping", () => {
+    const snapshot = makeSnapshot({
+      events: [{ minute: 1, event_type: "Kill", side: "Away", zone: "Top", player_id: null, secondary_player_id: null }],
+    });
+
+    const merged = mergeRuntimeEventsIntoSnapshot(
+      snapshot,
+      [
+        { t: 600, type: "dragon", text: "BLUE secured Infernal Dragon" },
+        { t: 1500, type: "baron", text: "RED secured Baron Nashor" },
+      ],
+      snapshot.home_team.id,
+    );
+
+    expect(merged.events).toHaveLength(3);
+    expect(merged.events.slice(1).map((event) => [event.event_type, event.side])).toEqual([
+      ["Dragon", "Home"],
+      ["Baron", "Away"],
+    ]);
+  });
+
+  it("maps BLUE events to the canonical away team when the blue team is away", () => {
+    const snapshot = makeSnapshot();
+
+    const merged = mergeRuntimeEventsIntoSnapshot(
+      snapshot,
+      [{ t: 600, type: "dragon", text: "BLUE secured Infernal Dragon" }],
+      snapshot.away_team.id,
+    );
+
+    expect(merged.events).toEqual([
+      { minute: 10, event_type: "Dragon", side: "Away", zone: "mid", player_id: null, secondary_player_id: null },
+    ]);
+  });
+});

--- a/src/ui-v2/_legacy/components/match/matchRuntimeEvents.ts
+++ b/src/ui-v2/_legacy/components/match/matchRuntimeEvents.ts
@@ -3,9 +3,26 @@ import type { MatchEvent, MatchSnapshot } from "@/ui-v2/_legacy/components/match
 
 type RuntimeEvent = NonNullable<LolSimV1RuntimeState["events"]>[number];
 
-function runtimeEventSide(event: RuntimeEvent): MatchEvent["side"] {
+function runtimeEventSide(
+  event: RuntimeEvent,
+  blueTeamId?: string,
+  homeTeamId?: string,
+): MatchEvent["side"] {
   const text = (event.text ?? "").toUpperCase();
   const firstSideToken = text.match(/\b(BLUE|HOME|RED|AWAY)\b/)?.[1];
+
+  if (!firstSideToken) return "Home";
+
+  // Runtime BLUE/RED refers to in-game sides. When the caller supplies the
+  // active blue team ID, map those tokens to canonical Home/Away so that
+  // side-swapped snapshots still attribute events to the correct fixture side.
+  if (blueTeamId && homeTeamId && (firstSideToken === "BLUE" || firstSideToken === "RED")) {
+    const blueIsHome = blueTeamId === homeTeamId;
+    if (firstSideToken === "BLUE") return blueIsHome ? "Home" : "Away";
+    return blueIsHome ? "Away" : "Home";
+  }
+
+  // Legacy fallback for HOME/AWAY or when the mapping context is unavailable.
   if (firstSideToken === "RED" || firstSideToken === "AWAY") return "Away";
   return "Home";
 }
@@ -57,11 +74,15 @@ function eventKey(event: MatchEvent): string {
  * post-match systems. Runtime events only expose timestamp/type/text today, so
  * side and semantic event type are derived from the broadcast text locally here.
  */
-export function mapRuntimeEventsToMatchEvents(events: LolSimV1RuntimeState["events"] | undefined): MatchEvent[] {
+export function mapRuntimeEventsToMatchEvents(
+  events: LolSimV1RuntimeState["events"] | undefined,
+  blueTeamId?: string,
+  homeTeamId?: string,
+): MatchEvent[] {
   return (events ?? []).map((event) => ({
     minute: Math.max(0, Math.floor((event.t ?? 0) / 60)),
     event_type: runtimeEventType(event),
-    side: runtimeEventSide(event),
+    side: runtimeEventSide(event, blueTeamId, homeTeamId),
     zone: "mid",
     player_id: null,
     secondary_player_id: null,
@@ -85,9 +106,13 @@ export function mergeMatchEvents(existingEvents: MatchEvent[] | undefined, incom
 export function mergeRuntimeEventsIntoSnapshot(
   snapshot: MatchSnapshot,
   runtimeEvents: LolSimV1RuntimeState["events"] | undefined,
+  blueTeamId?: string,
 ): MatchSnapshot {
   return {
     ...snapshot,
-    events: mergeMatchEvents(snapshot.events, mapRuntimeEventsToMatchEvents(runtimeEvents)),
+    events: mergeMatchEvents(
+      snapshot.events,
+      mapRuntimeEventsToMatchEvents(runtimeEvents, blueTeamId, snapshot.home_team.id),
+    ),
   };
 }

--- a/src/ui-v2/_legacy/components/match/pressConferenceContent.ts
+++ b/src/ui-v2/_legacy/components/match/pressConferenceContent.ts
@@ -2,7 +2,7 @@ import type { TFunction } from "i18next";
 
 import { SOCIAL_CONTENT_PACK } from "@/content/lol/social/content";
 import { extractMatchContext, type CompatibleMatchSummary } from "@/content/lol/social/matchContext";
-import { DEFAULT_LEAGUE_ID, registrySide, type UserSide } from "@/content/lol/social/shared";
+import { DEFAULT_LEAGUE_ID, registrySide, type RegistrySide, type UserSide } from "@/content/lol/social/shared";
 import {
   filterEligibleOutlets,
   filterEligiblePersonas,
@@ -68,14 +68,25 @@ interface BuildPressConferenceQuestionsParams {
   t: TFunction | ((key: string) => string);
   random?: () => number;
   recentQuestionIds?: string[];
+  /** The user's actual in-game side (blue/red). Defaults to registrySide(userSide). */
+  controlledSide?: RegistrySide;
+  /** The actual winning side (blue/red). When omitted it is inferred from snapshot scores. */
+  winnerSide?: RegistrySide;
+  /** Optional explicit result override. Takes precedence over winnerSide inference. */
+  userResult?: "win" | "loss";
 }
 
 const PRESS_CONFERENCE_QUESTION_TARGET = 3;
 
-function countEvents(events: MatchEvent[], side: UserSide, names: string[]): number {
+function eventRegistrySide(eventSide: MatchEvent["side"], homeIsBlue: boolean): RegistrySide {
+  if (eventSide === "Home") return homeIsBlue ? "blue" : "red";
+  return homeIsBlue ? "red" : "blue";
+}
+
+function countEvents(events: MatchEvent[], side: RegistrySide, names: string[], homeIsBlue: boolean): number {
   const normalized = new Set(names.map((name) => name.toLowerCase()));
   return events.filter(
-    (event) => event.side === side && normalized.has(event.event_type.toLowerCase()),
+    (event) => eventRegistrySide(event.side, homeIsBlue) === side && normalized.has(event.event_type.toLowerCase()),
   ).length;
 }
 
@@ -116,42 +127,61 @@ function eventTypeToTimelineType(eventType: string): string {
   }
 }
 
-function snapshotToSummary(snapshot: MatchSnapshot, userSide: UserSide): CompatibleMatchSummary {
-  const enemySide = userSide === "Home" ? "Away" : "Home";
+function otherRegistrySide(side: RegistrySide): RegistrySide {
+  return side === "blue" ? "red" : "blue";
+}
+
+function snapshotToSummary(
+  snapshot: MatchSnapshot,
+  userSide: UserSide,
+  controlledSide?: RegistrySide,
+  forcedWinnerSide?: RegistrySide,
+): CompatibleMatchSummary {
   const userTeam = userSide === "Home" ? snapshot.home_team : snapshot.away_team;
   const enemyTeam = userSide === "Home" ? snapshot.away_team : snapshot.home_team;
-  const userRegistrySide = registrySide(userSide);
-  const enemyRegistrySide = registrySide(enemySide);
-  const userKills = countEvents(snapshot.events, userSide, ["Kill", "FirstBlood", "Goal", "PenaltyGoal"]);
-  const enemyKills = countEvents(snapshot.events, enemySide, ["Kill", "FirstBlood", "Goal", "PenaltyGoal"]);
+  const userRegistrySide = controlledSide ?? registrySide(userSide);
+  const enemyRegistrySide = otherRegistrySide(userRegistrySide);
+
+  // Determine which canonical team is playing blue side. When controlledSide is
+  // supplied we can map Home/Away events to the correct blue/red side even if
+  // the active snapshot was side-swapped.
+  const blueTeamId = userSide === "Home"
+    ? (userRegistrySide === "blue" ? snapshot.home_team.id : snapshot.away_team.id)
+    : (userRegistrySide === "blue" ? snapshot.away_team.id : snapshot.home_team.id);
+  const homeIsBlue = snapshot.home_team.id === blueTeamId;
+
+  const userKills = countEvents(snapshot.events, userRegistrySide, ["Kill", "FirstBlood", "Goal", "PenaltyGoal"], homeIsBlue);
+  const enemyKills = countEvents(snapshot.events, enemyRegistrySide, ["Kill", "FirstBlood", "Goal", "PenaltyGoal"], homeIsBlue);
 
   const userRegistrySideData: DraftTeamObjectives = {
-    voidgrubs: countEvents(snapshot.events, userSide, ["VoidGrub", "VoidGrubs"]),
-    dragons: countEvents(snapshot.events, userSide, ["Dragon"]),
-    dragonSoul: countEvents(snapshot.events, userSide, ["DragonSoul"]) > 0,
-    elderDragons: countEvents(snapshot.events, userSide, ["ElderDragon"]),
-    heralds: countEvents(snapshot.events, userSide, ["Herald"]),
-    barons: countEvents(snapshot.events, userSide, ["Baron"]),
-    towers: countEvents(snapshot.events, userSide, ["Tower"]),
-    inhibitors: countEvents(snapshot.events, userSide, ["Inhibitor"]),
+    voidgrubs: countEvents(snapshot.events, userRegistrySide, ["VoidGrub", "VoidGrubs"], homeIsBlue),
+    dragons: countEvents(snapshot.events, userRegistrySide, ["Dragon"], homeIsBlue),
+    dragonSoul: countEvents(snapshot.events, userRegistrySide, ["DragonSoul"], homeIsBlue) > 0,
+    elderDragons: countEvents(snapshot.events, userRegistrySide, ["ElderDragon"], homeIsBlue),
+    heralds: countEvents(snapshot.events, userRegistrySide, ["Herald"], homeIsBlue),
+    barons: countEvents(snapshot.events, userRegistrySide, ["Baron"], homeIsBlue),
+    towers: countEvents(snapshot.events, userRegistrySide, ["Tower"], homeIsBlue),
+    inhibitors: countEvents(snapshot.events, userRegistrySide, ["Inhibitor"], homeIsBlue),
   };
 
   const enemyRegistrySideData: DraftTeamObjectives = {
-    voidgrubs: countEvents(snapshot.events, enemySide, ["VoidGrub", "VoidGrubs"]),
-    dragons: countEvents(snapshot.events, enemySide, ["Dragon"]),
-    dragonSoul: countEvents(snapshot.events, enemySide, ["DragonSoul"]) > 0,
-    elderDragons: countEvents(snapshot.events, enemySide, ["ElderDragon"]),
-    heralds: countEvents(snapshot.events, enemySide, ["Herald"]),
-    barons: countEvents(snapshot.events, enemySide, ["Baron"]),
-    towers: countEvents(snapshot.events, enemySide, ["Tower"]),
-    inhibitors: countEvents(snapshot.events, enemySide, ["Inhibitor"]),
+    voidgrubs: countEvents(snapshot.events, enemyRegistrySide, ["VoidGrub", "VoidGrubs"], homeIsBlue),
+    dragons: countEvents(snapshot.events, enemyRegistrySide, ["Dragon"], homeIsBlue),
+    dragonSoul: countEvents(snapshot.events, enemyRegistrySide, ["DragonSoul"], homeIsBlue) > 0,
+    elderDragons: countEvents(snapshot.events, enemyRegistrySide, ["ElderDragon"], homeIsBlue),
+    heralds: countEvents(snapshot.events, enemyRegistrySide, ["Herald"], homeIsBlue),
+    barons: countEvents(snapshot.events, enemyRegistrySide, ["Baron"], homeIsBlue),
+    towers: countEvents(snapshot.events, enemyRegistrySide, ["Tower"], homeIsBlue),
+    inhibitors: countEvents(snapshot.events, enemyRegistrySide, ["Inhibitor"], homeIsBlue),
   };
 
+  const inferredWinnerSide =
+    (userSide === "Home" ? snapshot.home_score > snapshot.away_score : snapshot.away_score > snapshot.home_score)
+      ? userRegistrySide
+      : enemyRegistrySide;
+
   return {
-    winnerSide:
-      (userSide === "Home" ? snapshot.home_score > snapshot.away_score : snapshot.away_score > snapshot.home_score)
-        ? userRegistrySide
-        : enemyRegistrySide,
+    winnerSide: forcedWinnerSide ?? inferredWinnerSide,
     blueKills: userRegistrySide === "blue" ? userKills : enemyKills,
     redKills: userRegistrySide === "red" ? userKills : enemyKills,
     objectives: {
@@ -181,7 +211,7 @@ function snapshotToSummary(snapshot: MatchSnapshot, userSide: UserSide): Compati
     ],
     timelineEvents: snapshot.events.map((event) => ({
       minute: event.minute,
-      side: registrySide(event.side),
+      side: eventRegistrySide(event.side, homeIsBlue),
       type: eventTypeToTimelineType(event.event_type),
     })),
   };
@@ -315,49 +345,83 @@ export function buildPressConferenceQuestions({
   t,
   random = Math.random,
   recentQuestionIds = [],
+  controlledSide,
+  winnerSide,
+  userResult,
 }: BuildPressConferenceQuestionsParams): PressQuestion[] {
   const userLeague = gameState.user_competition_id
     ? gameState.leagues?.find((l) => l.competition_id === gameState.user_competition_id)
     : undefined;
   const leagueId = userLeague?.id ?? gameState.leagues?.[0]?.id ?? DEFAULT_LEAGUE_ID;
+
+  const effectiveUserSide = controlledSide ?? registrySide(userSide);
+  const inferredWinnerSide =
+    userResult === "win"
+      ? effectiveUserSide
+      : userResult === "loss"
+        ? otherRegistrySide(effectiveUserSide)
+        : undefined;
+  const effectiveWinnerSide = winnerSide ?? inferredWinnerSide;
+
+  const summary = snapshotToSummary(snapshot, userSide, effectiveUserSide, effectiveWinnerSide);
   const context = extractMatchContext({
-    match: snapshotToSummary(snapshot, userSide),
-    userSide: registrySide(userSide),
+    match: summary,
+    userSide: effectiveUserSide,
     leagueId,
   });
+  const result = context.facts.result as "win" | "loss";
   const candidates = buildCandidates({
     questions: SOCIAL_CONTENT_PACK.questions,
     leagueId,
     contextTags: context.tags,
     contextFacts: context.facts,
   });
-  const coherentCandidates = candidates.filter((candidate) => isQuestionCoherentWithResult(candidate, context.facts.result as "win" | "loss"));
+  const coherentCandidates = candidates.filter((candidate) => isQuestionCoherentWithResult(candidate, result));
   const selectedCandidates = selectPressConferenceCandidates(coherentCandidates, random, recentQuestionIds);
 
-  const fallbackResponses: PressResponse[] = [
-    {
-      id: "credit-preparation",
-      tone: t("content.lol.social.responses.creditPreparation.label"),
-      text: t("content.lol.social.responses.creditPreparation.text"),
-      effectId: "press_squad_morale_small_up",
-      target: "squad",
-    },
-    {
-      id: "stay-measured",
-      tone: t("content.lol.social.responses.stayMeasured.label"),
-      text: t("content.lol.social.responses.stayMeasured.text"),
-      effectId: "press_no_effect",
-      target: "none",
-    },
-  ];
+  const fallbackResponses: PressResponse[] = result === "win"
+    ? [
+        {
+          id: "credit-preparation",
+          tone: t("content.lol.social.responses.creditPreparation.label"),
+          text: t("content.lol.social.responses.creditPreparation.text"),
+          effectId: "press_squad_morale_small_up",
+          target: "squad",
+        },
+        {
+          id: "stay-measured",
+          tone: t("content.lol.social.responses.stayMeasured.label"),
+          text: t("content.lol.social.responses.stayMeasured.text"),
+          effectId: "press_no_effect",
+          target: "none",
+        },
+      ]
+    : [
+        {
+          id: "take-responsibility",
+          tone: t("content.lol.social.responses.takeResponsibility.label"),
+          text: t("content.lol.social.responses.takeResponsibility.text"),
+          effectId: "press_squad_morale_small_up",
+          target: "squad",
+        },
+        {
+          id: "stay-measured",
+          tone: t("content.lol.social.responses.stayMeasured.label"),
+          text: t("content.lol.social.responses.stayMeasured.text"),
+          effectId: "press_no_effect",
+          target: "none",
+        },
+      ];
 
   if (selectedCandidates.length === 0) {
     return [
       {
-        id: "fallback-post-match",
+        id: `fallback-post-match-${result}`,
         journalist: "Verified Analyst",
         outlet: "Rift Desk",
-        question: t("content.lol.social.questions.cleanWinObjectives.text"),
+        question: result === "win"
+          ? t("content.lol.social.questions.cleanWinObjectives.text")
+          : t("content.lol.social.questions.mentalResetAfterLoss.text"),
         responses: fallbackResponses,
       },
     ];

--- a/src/ui-v2/_legacy/pages/MatchSimulation.resultMapping.test.ts
+++ b/src/ui-v2/_legacy/pages/MatchSimulation.resultMapping.test.ts
@@ -3,45 +3,6 @@ import { describe, expect, it } from "vitest";
 import { mapRuntimeWinnerToCanonicalScores } from "@/ui-v2/_legacy/pages/MatchSimulation.resultMapping";
 import type { MatchSnapshot } from "@/ui-v2/_legacy/components/match/types";
 
-function makePlayer(id: string, name: string, position = "ADC") {
-  return {
-    id,
-    name,
-    position,
-    condition: 90,
-    fitness: 90,
-    mechanics: 70,
-    laning: 70,
-    teamfighting: 70,
-    macro_play: 70,
-    consistency: 70,
-    shotcalling: 60,
-    champion_pool: 70,
-    discipline: 70,
-    mental_resilience: 70,
-    pace: 70,
-    stamina: 70,
-    strength: 60,
-    agility: 70,
-    passing: 70,
-    shooting: 70,
-    tackling: 40,
-    dribbling: 70,
-    defending: 40,
-    positioning: 70,
-    vision: 70,
-    decisions: 70,
-    composure: 70,
-    aggression: 50,
-    teamwork: 70,
-    leadership: 60,
-    handling: 20,
-    reflexes: 20,
-    aerial: 50,
-    traits: [],
-  };
-}
-
 function makeSnapshot(overrides: Partial<MatchSnapshot> = {}): MatchSnapshot {
   return {
     phase: "FullTime",
@@ -51,21 +12,21 @@ function makeSnapshot(overrides: Partial<MatchSnapshot> = {}): MatchSnapshot {
     possession: "Home",
     ball_zone: "Midfield",
     home_team: {
-      id: "fnc",
-      name: "Fnatic",
+      id: "home-team",
+      name: "Home Team",
       draft_strategy: "Objective control",
-      players: [makePlayer("fnc-adc", "FNC ADC")],
+      players: [],
     },
     away_team: {
-      id: "g2",
-      name: "G2 Esports",
+      id: "away-team",
+      name: "Away Team",
       draft_strategy: "Skirmish",
-      players: [makePlayer("g2-adc", "G2 ADC")],
+      players: [],
     },
     home_bench: [],
     away_bench: [],
-    home_possession_pct: 50,
-    away_possession_pct: 50,
+    home_possession_pct: 55,
+    away_possession_pct: 45,
     events: [],
     home_subs_made: 0,
     away_subs_made: 0,
@@ -82,33 +43,58 @@ function makeSnapshot(overrides: Partial<MatchSnapshot> = {}): MatchSnapshot {
 }
 
 describe("mapRuntimeWinnerToCanonicalScores", () => {
-  it("maps a red runtime win back to the canonical home team when the user controls red", () => {
-    const canonicalSnapshot = makeSnapshot();
-    const snapshotForResult = makeSnapshot({
-      home_team: canonicalSnapshot.away_team,
-      away_team: canonicalSnapshot.home_team,
-      home_bench: canonicalSnapshot.away_bench,
-      away_bench: canonicalSnapshot.home_bench,
+  it("returns existing scores when winnerSide is null", () => {
+    const snapshot = makeSnapshot({ home_score: 0, away_score: 0 });
+    const scores = mapRuntimeWinnerToCanonicalScores({
+      canonicalSnapshot: snapshot,
+      snapshotForResult: snapshot,
+      winnerSide: null,
     });
+
+    expect(scores).toEqual({ home_score: 0, away_score: 0 });
+  });
+
+  it("maps blue winner to the home team in the result snapshot", () => {
+    const canonicalSnapshot = makeSnapshot({ home_score: 0, away_score: 0 });
+    const snapshotForResult = makeSnapshot({ home_score: 0, away_score: 0 });
 
     const scores = mapRuntimeWinnerToCanonicalScores({
       canonicalSnapshot,
       snapshotForResult,
-      winner: "red",
+      winnerSide: "blue",
     });
 
     expect(scores).toEqual({ home_score: 1, away_score: 0 });
   });
 
-  it("preserves canonical fallback scores when runtime has no winner", () => {
-    const canonicalSnapshot = makeSnapshot({ home_score: 2, away_score: 1 });
+  it("maps red winner to the away team in the result snapshot", () => {
+    const canonicalSnapshot = makeSnapshot({ home_score: 0, away_score: 0 });
+    const snapshotForResult = makeSnapshot({ home_score: 0, away_score: 0 });
 
     const scores = mapRuntimeWinnerToCanonicalScores({
       canonicalSnapshot,
-      snapshotForResult: canonicalSnapshot,
-      winner: null,
+      snapshotForResult,
+      winnerSide: "red",
     });
 
-    expect(scores).toEqual({ home_score: 2, away_score: 1 });
+    expect(scores).toEqual({ home_score: 0, away_score: 1 });
+  });
+
+  it("maps winners back to canonical sides when the result snapshot is side-swapped", () => {
+    const canonicalSnapshot = makeSnapshot({ home_score: 0, away_score: 0 });
+    // Side-swapped result snapshot: home_team is the original away team.
+    const snapshotForResult = makeSnapshot({
+      home_team: { id: "away-team", name: "Away Team", draft_strategy: "Skirmish", players: [] },
+      away_team: { id: "home-team", name: "Home Team", draft_strategy: "Objective control", players: [] },
+    });
+
+    const scores = mapRuntimeWinnerToCanonicalScores({
+      canonicalSnapshot,
+      snapshotForResult,
+      winnerSide: "blue",
+    });
+
+    // Blue side in the swapped snapshot is the original away team, so canonical away_score wins.
+    expect(scores).toEqual({ home_score: 0, away_score: 1 });
   });
 });

--- a/src/ui-v2/_legacy/pages/MatchSimulation.resultMapping.ts
+++ b/src/ui-v2/_legacy/pages/MatchSimulation.resultMapping.ts
@@ -1,18 +1,17 @@
 import type { MatchSnapshot } from "@/ui-v2/_legacy/components/match/types";
-import type { TeamId } from "@/ui-v2/_legacy/components/match/lol-prototype/engine/types";
 
 interface MapRuntimeWinnerToCanonicalScoresParams {
   canonicalSnapshot: MatchSnapshot;
   snapshotForResult: MatchSnapshot;
-  winner: TeamId | null;
+  winnerSide: "blue" | "red" | null;
 }
 
 export function mapRuntimeWinnerToCanonicalScores({
   canonicalSnapshot,
   snapshotForResult,
-  winner,
+  winnerSide,
 }: MapRuntimeWinnerToCanonicalScoresParams): Pick<MatchSnapshot, "home_score" | "away_score"> {
-  if (!winner) {
+  if (!winnerSide) {
     return {
       home_score: canonicalSnapshot.home_score ?? 0,
       away_score: canonicalSnapshot.away_score ?? 0,
@@ -20,7 +19,7 @@ export function mapRuntimeWinnerToCanonicalScores({
   }
 
   const winnerTeamId =
-    winner === "blue" ? snapshotForResult.home_team.id : snapshotForResult.away_team.id;
+    winnerSide === "blue" ? snapshotForResult.home_team.id : snapshotForResult.away_team.id;
 
   return {
     home_score: canonicalSnapshot.home_team.id === winnerTeamId ? 1 : 0,

--- a/src/ui-v2/_legacy/pages/MatchSimulation.tsx
+++ b/src/ui-v2/_legacy/pages/MatchSimulation.tsx
@@ -791,6 +791,7 @@ export default function MatchSimulation() {
   const [finalRuntimeState, setFinalRuntimeState] = useState<LolSimV1RuntimeState | null>(null);
   const [draftPayload, setDraftPayload] = useState<ChampionDraftResultPayload | null>(null);
   const [draftResultSimulation, setDraftResultSimulation] = useState<DraftMatchResult | null>(null);
+  const [finalDraftResult, setFinalDraftResult] = useState<DraftMatchResult | null>(null);
   const [championSelections, setChampionSelections] = useState<ChampionSelectionByPlayer | null>(null);
   const [seriesGameIndex, setSeriesGameIndex] = useState(0);
   const [seriesHomeWins, setSeriesHomeWins] = useState(0);
@@ -1164,6 +1165,16 @@ export default function MatchSimulation() {
     return swapSnapshotSides(snapshot);
   }, [managerTeamId, snapshot, swapSnapshotSides, userSelectedSide]);
 
+  const blueTeamId = useMemo(() => {
+    if (!snapshot) return null;
+    if (!managerTeamId) return snapshot.home_team.id;
+
+    const isUserHome = managerTeamId === snapshot.home_team.id;
+    const shouldBeBlue = userSelectedSide === "blue";
+    const notSwapped = (isUserHome && shouldBeBlue) || (!isUserHome && !shouldBeBlue);
+    return notSwapped ? snapshot.home_team.id : snapshot.away_team.id;
+  }, [managerTeamId, snapshot, userSelectedSide]);
+
   const renderSnapshot = activeSnapshot ?? snapshot;
   const renderSnapshotWithTactics = useMemo(() => {
     if (!renderSnapshot || !gameState) return renderSnapshot;
@@ -1304,11 +1315,15 @@ export default function MatchSimulation() {
     }
   }, [hasFinalizedMatch, setGameState]);
 
-  const handleFullTime = useCallback((finalRuntimeState: LolSimV1RuntimeState, meta?: { source: "live" | "skip" }) => {
+  const handleFullTime = useCallback((finalRuntimeState: LolSimV1RuntimeState, meta?: { source: "live" | "skip"; precomputedResult?: DraftMatchResult }) => {
     console.info("[MatchSimulation] handleFullTime");
     const source = meta?.source ?? "live";
     setFinalRuntimeState(finalRuntimeState);
-    const mappedEvents = mapRuntimeEventsToMatchEvents(finalRuntimeState.events);
+    const mappedEvents = mapRuntimeEventsToMatchEvents(
+      finalRuntimeState.events,
+      blueTeamId ?? undefined,
+      snapshot?.home_team.id,
+    );
     setImportantEvents(mappedEvents);
 
     const safeDraftPayload = normalizeDraftPayload(draftPayload, championSelections, renderSnapshotWithTactics ?? null);
@@ -1330,31 +1345,23 @@ export default function MatchSimulation() {
       return;
     }
 
-    // Keep the canonical fixture home/away snapshot intact. `snapshotForResult` can be
-    // side-swapped to render the user's selected LoL side, and storing that swapped
-    // shape as the base snapshot corrupts subsequent home/away series win tracking.
-    const merged = mergeRuntimeEventsIntoSnapshot(snapshot ?? snapshotForResult, finalRuntimeState.events);
-    const canonicalScores = mapRuntimeWinnerToCanonicalScores({
-      canonicalSnapshot: merged,
-      snapshotForResult,
-      winner: finalRuntimeState.winner,
-    });
-    setSnapshot({
-      ...merged,
-      ...canonicalScores,
-    });
-
+    // Determine the single source of truth for the post-match result before any
+    // snapshot/screen/persistence/press updates. Live uses the runtime result;
+    // skip/delegate reuse the deterministic draft simulator result. When a result
+    // was already computed (delegate mode) we pass it through so we never simulate
+    // twice with different seeds.
     const runtimeBasedResult = buildDraftResultFromRuntime({
       runtime: finalRuntimeState,
       snapshot: snapshotForResult,
       championSelections,
     });
 
-    let resultToPersist = runtimeBasedResult;
+    let finalResult: DraftMatchResult = runtimeBasedResult;
 
-    let simulatedForSkip: DraftMatchResult | null = null;
-
-    if (source === "skip" && safeDraftPayload && renderSnapshotWithTactics && gameState) {
+    if (meta?.precomputedResult) {
+      finalResult = meta.precomputedResult;
+      setDraftResultSimulation(meta.precomputedResult);
+    } else if (source === "skip" && safeDraftPayload && renderSnapshotWithTactics && gameState) {
       try {
         const simulated = simulateDraftMatchResult({
           snapshot: renderSnapshotWithTactics,
@@ -1362,9 +1369,8 @@ export default function MatchSimulation() {
           draft: safeDraftPayload,
           seedSalt: `${currentFixture?.id ?? "fixture"}-g${seriesGameIndex + 1}`,
         });
+        finalResult = simulated;
         setDraftResultSimulation(simulated);
-        resultToPersist = simulated;
-        simulatedForSkip = simulated;
       } catch (error) {
         console.error("[MatchSimulation] draftResultFallback:failed", error);
         setDraftResultSimulation(null);
@@ -1372,6 +1378,28 @@ export default function MatchSimulation() {
     } else {
       setDraftResultSimulation(null);
     }
+
+    // Preserve the runtime/simulated result so the press conference can use the
+    // actual blue/red winner in live mode (where draftResultSimulation is null).
+    setFinalDraftResult(finalResult);
+
+    // Keep the canonical fixture home/away snapshot intact. `snapshotForResult` can be
+    // side-swapped to render the user's selected LoL side, and storing that swapped
+    // shape as the base snapshot corrupts subsequent home/away series win tracking.
+    const merged = mergeRuntimeEventsIntoSnapshot(
+      snapshot ?? snapshotForResult,
+      finalRuntimeState.events,
+      blueTeamId ?? undefined,
+    );
+    const canonicalScores = mapRuntimeWinnerToCanonicalScores({
+      canonicalSnapshot: merged,
+      snapshotForResult,
+      winnerSide: finalResult.winnerSide,
+    });
+    setSnapshot({
+      ...merged,
+      ...canonicalScores,
+    });
 
     const targetSeriesWins = getTargetSeriesWins(seriesLength);
     let homeSeriesWins = seriesHomeWins;
@@ -1395,7 +1423,7 @@ export default function MatchSimulation() {
       );
 
       const winnerTeamId =
-        resultToPersist.winnerSide === "blue"
+        finalResult.winnerSide === "blue"
           ? snapshotForResult.home_team.id
           : snapshotForResult.away_team.id;
 
@@ -1479,8 +1507,8 @@ export default function MatchSimulation() {
       const currentSeriesGameIndex = getNextSeriesGameIndex(Array.from(nextSeriesGamesByIndex.values()));
       nextSeriesGamesByIndex.set(currentSeriesGameIndex, {
         gameIndex: currentSeriesGameIndex,
-        result: resultToPersist,
-        winnerSide: resultToPersist.winnerSide,
+        result: finalResult,
+        winnerSide: finalResult.winnerSide,
       });
       const nextSeriesGames = Array.from(nextSeriesGamesByIndex.values()).sort(
         (left, right) => left.gameIndex - right.gameIndex,
@@ -1491,7 +1519,7 @@ export default function MatchSimulation() {
       persistFixtureDraftResult(currentFixture.id, {
         snapshot: snapshotForResult,
         controlledSide: userSelectedSide,
-        result: resultToPersist,
+        result: finalResult,
         seriesGames: nextSeriesGames,
         seriesLength,
         seriesGameIndex: currentSeriesGameIndex,
@@ -1508,27 +1536,25 @@ export default function MatchSimulation() {
       }
     }
 
-    const runtimeForFinalize = simulatedForSkip
-      ? {
-        ...finalRuntimeState,
-        winner: simulatedForSkip.winnerSide,
-        timeSec: simulatedForSkip.durationMinutes * 60,
-        stats: {
-          ...(finalRuntimeState.stats ?? {
-            blue: { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 },
-            red: { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 },
-          }),
-          blue: {
-            ...(finalRuntimeState.stats?.blue ?? { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 }),
-            kills: simulatedForSkip.blueKills,
-          },
-          red: {
-            ...(finalRuntimeState.stats?.red ?? { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 }),
-            kills: simulatedForSkip.redKills,
-          },
+    const runtimeForFinalize = {
+      ...finalRuntimeState,
+      winner: finalResult.winnerSide,
+      timeSec: finalResult.durationMinutes * 60,
+      stats: {
+        ...(finalRuntimeState.stats ?? {
+          blue: { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 },
+          red: { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 },
+        }),
+        blue: {
+          ...(finalRuntimeState.stats?.blue ?? { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 }),
+          kills: finalResult.blueKills,
         },
-      }
-      : finalRuntimeState;
+        red: {
+          ...(finalRuntimeState.stats?.red ?? { kills: 0, towers: 0, dragons: 0, barons: 0, gold: 0 }),
+          kills: finalResult.redKills,
+        },
+      },
+    };
 
     if (seriesComplete) {
       void (async () => {
@@ -1542,6 +1568,7 @@ export default function MatchSimulation() {
 
     setStage("draft_result");
   }, [
+    blueTeamId,
     championSelections,
     currentFixture?.id,
     currentFixture?.away_team_id,
@@ -1617,7 +1644,7 @@ export default function MatchSimulation() {
           speed: PARALLEL_SIM_SPEED,
         };
 
-        handleFullTime(predictiveState, { source: "skip" });
+        handleFullTime(predictiveState, { source: "skip", precomputedResult: simulated });
       } catch (error) {
         console.error("[MatchSimulation] delegateSimulateFromTactics:failed", error);
         setSimulationFeedback(
@@ -1924,6 +1951,7 @@ export default function MatchSimulation() {
           key={stage}
           gameState={gameState}
           snapshot={renderSnapshotWithTactics ?? snapshot}
+          blueTeamId={blueTeamId ?? undefined}
           championSelections={championSelections}
           onSnapshotUpdate={handleSnapshotUpdate}
           onImportantEvent={handleImportantEvent}
@@ -1934,9 +1962,11 @@ export default function MatchSimulation() {
     case "press":
       return (
         <PressConference
-          snapshot={finalRuntimeState ? mergeRuntimeEventsIntoSnapshot(snapshot, finalRuntimeState.events) : snapshot}
+          snapshot={finalRuntimeState ? mergeRuntimeEventsIntoSnapshot(snapshot, finalRuntimeState.events, blueTeamId ?? undefined) : snapshot}
           gameState={gameState}
           userSide={userSide || "Home"}
+          controlledSide={userSelectedSide}
+          winnerSide={finalDraftResult?.winnerSide}
           onFinish={handleFinishMatch}
           onGameUpdate={setGameState}
         />


### PR DESCRIPTION
## Approved issue

Closes #348

- [x] The linked issue has `status:approved`.
- [x] This PR targets `develop` as the repository release branch.
- [x] This PR has exactly one `type:*` label.

## Summary

- Uses the final `DraftMatchResult` as the single source of truth for result screen, snapshot scores, persistence, and PressConference framing.
- Passes explicit press context (controlled side, winner side, user result) instead of relying only on canonical Home/Away score inference.
- Fixes BLUE/RED runtime event mapping when active snapshots are side-swapped and adds regression coverage for intermittent win/loss drift.

## Checks run

Required/stable PR checks are intentionally lightweight and production-build-free:

- [ ] `frontend-install` passed (dependency installation validation) — CI will run.
- [ ] `rust-check` passed (`cargo fmt --check` and `cargo check`) — CI will run.
- [ ] Not applicable locally; docs/templates only.

Manual/experimental full checks:

- [x] Focused press/match tests — 81 passed.
- [x] PressConference focused tests — 19 passed.
- [x] `npm run build:types` — passed.
- [x] `npm run build` — passed.

## Documentation and provenance

- [x] Documentation was updated or no docs change is needed.
- [x] Data provenance was updated or no provenance change is needed.
- [x] No unclear third-party data, generated cache, secret, signing key, or private credential is included.

## Release impact

- [x] Changelog entry added or not needed.
- [x] Version changes are synchronized across `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` when applicable.
