### PR TITLE
feat(transfers): rework AI transfer market — contract expiry, signing policy, strategic recruitment

### DIFF
--- a/src-tauri/crates/olm_core/src/ai_team_agent.rs
+++ b/src-tauri/crates/olm_core/src/ai_team_agent.rs
@@ -1,4 +1,8 @@
+use crate::contract_wage_policy::{
+    AiTransferKind, SigningIntent, ai_signing_policy, ai_team_tier, ai_transfer_cap_try_consume,
+};
 use crate::domain::player::{Player, PlayerTrait};
+use crate::domain::season::TransferWindowStatus;
 use crate::domain::team::Team;
 use crate::game::Game;
 use chrono::{Datelike, NaiveDate};
@@ -104,7 +108,9 @@ pub fn trait_bonus(traits: &[PlayerTrait]) -> f64 {
             | PlayerTrait::ShotCaller
             | PlayerTrait::IceCold
             | PlayerTrait::Visionary => bonus += 0.2,
-            PlayerTrait::TeamPlayer | PlayerTrait::Sentinel | PlayerTrait::Workhorse => bonus += 0.1,
+            PlayerTrait::TeamPlayer | PlayerTrait::Sentinel | PlayerTrait::Workhorse => {
+                bonus += 0.1
+            }
             _ => {}
         }
     }
@@ -250,7 +256,12 @@ pub fn assess_roster(team: &Team, players: &[Player], today: NaiveDate) -> Roste
 
 /// Evaluate which players on a team should get renewal offers.
 /// Sets `player.morale_core.renewal_state` for eligible players.
-pub fn evaluate_renewals(team: &Team, players: &mut [Player], report: &RosterReport, today: NaiveDate) {
+pub fn evaluate_renewals(
+    team: &Team,
+    players: &mut [Player],
+    report: &RosterReport,
+    today: NaiveDate,
+) {
     use crate::domain::player::{ContractRenewalState, RenewalSessionStatus};
 
     let soft_cap_wage = (team.wage_budget as f64 * WAGE_SOFT_CAP_MULTIPLIER) as i64;
@@ -514,9 +525,7 @@ fn select_ai_teams_for_today(game: &Game) -> Vec<String> {
     let ai_teams: Vec<&Team> = game
         .teams
         .iter()
-        .filter(|t| {
-            t.team_kind == crate::domain::team::TeamKind::Main && t.manager_id.is_none()
-        })
+        .filter(|t| t.team_kind == crate::domain::team::TeamKind::Main && t.manager_id.is_none())
         .collect();
 
     if ai_teams.is_empty() {
@@ -581,6 +590,153 @@ pub fn process_ai_team_agents(game: &mut Game) {
 }
 
 // ---------------------------------------------------------------------------
+// Strategic recruitment — high-reputation tier-1 clubs pursue upgrades
+// ---------------------------------------------------------------------------
+
+const STRATEGIC_REPUTATION_THRESHOLD: u32 = 1_100;
+
+/// Evaluate contracted players from other clubs as upgrades for elite teams.
+/// Falls back to high-impact free agents if no club-to-club target is found.
+/// Respects the shared signing policy and the daily AI transfer cap.
+pub fn ai_strategic_recruitment(game: &mut Game, team_id: &str) {
+    let transfer_open = matches!(
+        game.season_context.transfer_window.status,
+        TransferWindowStatus::Open | TransferWindowStatus::DeadlineDay
+    );
+    if !transfer_open {
+        return;
+    }
+
+    let Some(team) = game.teams.iter().find(|t| t.id == team_id).cloned() else {
+        return;
+    };
+    if team.team_kind != crate::domain::team::TeamKind::Main || team.manager_id.is_some() {
+        return;
+    }
+    if team.reputation < STRATEGIC_REPUTATION_THRESHOLD {
+        return;
+    }
+    if ai_team_tier(&team, game) != 1 {
+        return;
+    }
+    if team.transfer_budget <= 0 || team.finance <= 0 {
+        return;
+    }
+
+    let current_date = game.clock.current_date.date_naive();
+    let budget_cap = team.transfer_budget.min(team.finance);
+    let preferred_role = crate::transfers::ai_team_priority_role(game, team_id);
+    let user_team_id = game.manager.team_id.as_deref();
+
+    // Club-to-club upgrade path: target the team's weakest role on another club.
+    let club_candidate = {
+        let candidates: Vec<(String, String, u64)> = game
+            .players
+            .iter()
+            .filter_map(|player| {
+                let seller_id = player.team_id.as_deref()?;
+                if seller_id == team_id {
+                    return None;
+                }
+                // Do not poach the user-managed team without a negotiated offer.
+                if user_team_id == Some(seller_id) {
+                    return None;
+                }
+                let seller_team = game.teams.iter().find(|t| t.id == seller_id)?;
+                if seller_team.team_kind != crate::domain::team::TeamKind::Main {
+                    return None;
+                }
+                if crate::transfers::lol_role_to_string(&player.natural_position) != preferred_role
+                {
+                    return None;
+                }
+                if let Some(date_str) = &player.can_be_transferred_until {
+                    if let Ok(date) = NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
+                        if date >= current_date {
+                            return None;
+                        }
+                    }
+                }
+                let fee =
+                    crate::transfers::suggested_incoming_fee(current_date, player, &team, team_id);
+                if fee == 0 || (fee as i64) > budget_cap {
+                    return None;
+                }
+                let decision = ai_signing_policy(game, &team, player, SigningIntent::Strategic);
+                if !decision.accepted {
+                    return None;
+                }
+                Some((player.id.clone(), seller_id.to_string(), fee))
+            })
+            .collect();
+
+        candidates
+            .into_iter()
+            .map(|(player_id, seller_id, fee)| {
+                let market_value = game
+                    .players
+                    .iter()
+                    .find(|p| p.id == player_id)
+                    .map(|p| p.market_value)
+                    .unwrap_or(0);
+                (player_id, seller_id, fee, market_value)
+            })
+            .max_by_key(|(_, _, _, market_value)| *market_value)
+    };
+
+    if let Some((player_id, seller_id, fee, _)) = club_candidate {
+        if ai_transfer_cap_try_consume(game, team_id, AiTransferKind::ClubToClub) {
+            let _ = crate::transfers::execute_transfer(
+                game, &player_id, team_id, &seller_id, fee, true,
+            );
+        }
+        return;
+    }
+
+    // Free-agent fallback: sign a high-impact free agent for the weak role.
+    let mut fa_candidate: Option<(String, u64, u64)> = None;
+    let mut rejected_candidate: Option<(String, u64)> = None;
+    for p in game
+        .players
+        .iter()
+        .filter(|p| p.team_id.is_none())
+        .filter(|p| crate::transfers::lol_role_to_string(&p.natural_position) == preferred_role)
+    {
+        let fee = (p.market_value as i64).max(25_000) / 5;
+        if fee <= 0 || fee > budget_cap {
+            continue;
+        }
+        let decision = ai_signing_policy(game, &team, p, SigningIntent::Strategic);
+        if decision.accepted {
+            let current_best = fa_candidate.as_ref().map(|(_, _, mv)| *mv).unwrap_or(0);
+            if p.market_value > current_best {
+                fa_candidate = Some((p.id.clone(), fee as u64, p.market_value));
+            }
+        } else if matches!(
+            decision.reason,
+            crate::contract_wage_policy::SigningRejectionReason::ReputationMismatch
+        ) {
+            let current_best = rejected_candidate.as_ref().map(|(_, mv)| *mv).unwrap_or(0);
+            if p.market_value > current_best {
+                rejected_candidate = Some((p.id.clone(), p.market_value));
+            }
+        }
+    }
+
+    if let Some((player_id, fee, _)) = fa_candidate {
+        if ai_transfer_cap_try_consume(game, team_id, AiTransferKind::Strategic) {
+            let _ = crate::transfers::execute_free_agent_signing(game, &player_id, team_id, fee);
+        }
+        return;
+    }
+
+    // Tag a strategic rejection in news if no high-impact fallback was found.
+    if let Some((player_id, _)) = rejected_candidate {
+        crate::turn::news::generate_strategic_rejection_news(game, team_id, &player_id);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Conflict resolution — Team Agent overrides Player Agent
 // ---------------------------------------------------------------------------
 
@@ -609,7 +765,9 @@ pub fn resolve_conflicts(game: &mut Game, previously_transfer_listed: &HashSet<S
     let mut role_depth: HashMap<(String, LolRole), u32> = HashMap::new();
     for p in players {
         if let Some(ref tid) = p.team_id {
-            *role_depth.entry((tid.clone(), p.natural_position)).or_insert(0) += 1;
+            *role_depth
+                .entry((tid.clone(), p.natural_position))
+                .or_insert(0) += 1;
         }
     }
 
@@ -631,7 +789,10 @@ pub fn resolve_conflicts(game: &mut Game, previously_transfer_listed: &HashSet<S
             continue; // expired contract → free agent
         }
 
-        let team = match teams.iter().find(|t| player.team_id.as_deref() == Some(&t.id)) {
+        let team = match teams
+            .iter()
+            .find(|t| player.team_id.as_deref() == Some(&t.id))
+        {
             Some(t) => t,
             None => continue,
         };
@@ -677,10 +838,8 @@ mod tests {
     use super::*;
     use crate::clock::GameClock;
     use crate::domain::manager::Manager;
-    use crate::domain::player::{
-        LolRole, Player, PlayerAttributes, PlayerSeasonStats,
-    };
     use crate::domain::player::RenewalSessionStatus;
+    use crate::domain::player::{LolRole, Player, PlayerAttributes, PlayerSeasonStats};
     use crate::domain::team::Team;
     use chrono::{TimeZone, Utc};
 
@@ -818,32 +977,44 @@ mod tests {
     fn test_retention_score_high_performer() {
         let team = make_team("t1", "Test Team");
         let player = make_player(
-            "p1", "Star", "t1", LolRole::Mid,
-            95,   // lol_ovr
-            8.5,  // avg_rating
-            60_000, // wage
+            "p1",
+            "Star",
+            "t1",
+            LolRole::Mid,
+            95,                 // lol_ovr
+            8.5,                // avg_rating
+            60_000,             // wage
             Some("2027-06-15"), // contract_end
-            "2002-01-01", // age ~24
+            "2002-01-01",       // age ~24
             vec![PlayerTrait::HyperCarry],
         );
         let score = retention_score(&player, &team, test_date());
-        assert!(score > 0.7, "retention_score should be high for star, got {score}");
+        assert!(
+            score > 0.7,
+            "retention_score should be high for star, got {score}"
+        );
     }
 
     #[test]
     fn test_retention_score_low_performer() {
         let team = make_team("t1", "Test Team");
         let player = make_player(
-            "p2", "Bust", "t1", LolRole::Top,
-            55,   // low lol_ovr
-            5.0,  // low avg_rating
-            80_000, // overpaid
+            "p2",
+            "Bust",
+            "t1",
+            LolRole::Top,
+            55,                 // low lol_ovr
+            5.0,                // low avg_rating
+            80_000,             // overpaid
             Some("2026-09-15"), // contract ending soon
-            "1995-01-01", // age ~31
+            "1995-01-01",       // age ~31
             vec![],
         );
         let score = retention_score(&player, &team, test_date());
-        assert!(score < 0.5, "retention_score should be low for bust, got {score}");
+        assert!(
+            score < 0.5,
+            "retention_score should be low for bust, got {score}"
+        );
     }
 
     // Phase 1 — assess_roster
@@ -852,8 +1023,16 @@ mod tests {
     fn test_assess_roster_basic() {
         let team = make_team("t1", "Test Team");
         let player = make_player(
-            "p1", "Star", "t1", LolRole::Mid,
-            90, 8.0, 60_000, Some("2027-06-15"), "2002-01-01", vec![],
+            "p1",
+            "Star",
+            "t1",
+            LolRole::Mid,
+            90,
+            8.0,
+            60_000,
+            Some("2027-06-15"),
+            "2002-01-01",
+            vec![],
         );
         let report = assess_roster(&team, &[player], test_date());
         assert_eq!(*report.role_depth.get(&LolRole::Mid).unwrap(), 1);
@@ -873,8 +1052,30 @@ mod tests {
     fn test_assess_roster_role_gaps_identified() {
         let team = make_team("t1", "Test Team");
         let players = vec![
-            make_player("p1", "Top", "t1", LolRole::Top, 80, 7.0, 50_000, Some("2027-06-15"), "2002-01-01", vec![]),
-            make_player("p2", "Mid", "t1", LolRole::Mid, 85, 7.5, 55_000, Some("2027-06-15"), "2002-01-01", vec![]),
+            make_player(
+                "p1",
+                "Top",
+                "t1",
+                LolRole::Top,
+                80,
+                7.0,
+                50_000,
+                Some("2027-06-15"),
+                "2002-01-01",
+                vec![],
+            ),
+            make_player(
+                "p2",
+                "Mid",
+                "t1",
+                LolRole::Mid,
+                85,
+                7.5,
+                55_000,
+                Some("2027-06-15"),
+                "2002-01-01",
+                vec![],
+            ),
         ];
         let report = assess_roster(&team, &players, test_date());
         assert!(report.role_gaps.contains(&LolRole::Jungle));
@@ -890,15 +1091,18 @@ mod tests {
     fn test_evaluate_renewals_high_performer_gets_offer() {
         let team = make_team("t1", "Test Team");
         let today = test_date();
-        let mut players = vec![
-            make_player(
-                "p1", "Star", "t1", LolRole::Mid,
-                85, 8.0, 50_000,
-                Some("2026-09-15"), // < 6 months
-                "2002-01-01",
-                vec![],
-            ),
-        ];
+        let mut players = vec![make_player(
+            "p1",
+            "Star",
+            "t1",
+            LolRole::Mid,
+            85,
+            8.0,
+            50_000,
+            Some("2026-09-15"), // < 6 months
+            "2002-01-01",
+            vec![],
+        )];
         let report = assess_roster(&team, &players, today);
         evaluate_renewals(&team, &mut players, &report, today);
 
@@ -913,15 +1117,18 @@ mod tests {
     fn test_evaluate_renewals_skip_underperformer() {
         let team = make_team("t1", "Test Team");
         let today = test_date();
-        let mut players = vec![
-            make_player(
-                "p2", "Bust", "t1", LolRole::Top,
-                55, 5.0, 50_000,
-                Some("2026-09-15"),
-                "1995-01-01",
-                vec![],
-            ),
-        ];
+        let mut players = vec![make_player(
+            "p2",
+            "Bust",
+            "t1",
+            LolRole::Top,
+            55,
+            5.0,
+            50_000,
+            Some("2026-09-15"),
+            "1995-01-01",
+            vec![],
+        )];
         let report = assess_roster(&team, &players, today);
         evaluate_renewals(&team, &mut players, &report, today);
 
@@ -936,15 +1143,18 @@ mod tests {
         let mut team = make_team("t1", "Poor Team");
         team.wage_budget = 50_000; // tight budget
         let today = test_date();
-        let mut players = vec![
-            make_player(
-                "p1", "Star", "t1", LolRole::Mid,
-                85, 8.0, 90_000, // already expensive
-                Some("2026-09-15"),
-                "2002-01-01",
-                vec![PlayerTrait::HyperCarry],
-            ),
-        ];
+        let mut players = vec![make_player(
+            "p1",
+            "Star",
+            "t1",
+            LolRole::Mid,
+            85,
+            8.0,
+            90_000, // already expensive
+            Some("2026-09-15"),
+            "2002-01-01",
+            vec![PlayerTrait::HyperCarry],
+        )];
         // Override lol_ovr since assess_roster reads it directly (no Game::new refresh here)
         players[0].lol_ovr = 85;
 
@@ -954,7 +1164,10 @@ mod tests {
         // Soft cap = 50_000 * 1.10 = 55_000, projected = 90_000 * 1.10 = 99_000 > 55_000
         let state = &players[0].morale_core.renewal_state;
         let is_open = matches!(state, Some(s) if s.status == RenewalSessionStatus::Open);
-        assert!(!is_open, "renewal should be skipped when budget is exhausted");
+        assert!(
+            !is_open,
+            "renewal should be skipped when budget is exhausted"
+        );
     }
 
     #[test]
@@ -963,16 +1176,26 @@ mod tests {
         let today = test_date();
         let mut players = vec![
             make_player(
-                "p1", "Star", "t1", LolRole::Mid,
-                85, 8.0, 50_000,
+                "p1",
+                "Star",
+                "t1",
+                LolRole::Mid,
+                85,
+                8.0,
+                50_000,
                 Some("2026-09-15"),
                 "2002-01-01",
                 vec![],
             ),
             // Duplicate same player ID to test deadlock guard
             make_player(
-                "p1", "Star Clone", "t1", LolRole::Mid,
-                85, 8.0, 50_000,
+                "p1",
+                "Star Clone",
+                "t1",
+                LolRole::Mid,
+                85,
+                8.0,
+                50_000,
                 Some("2026-09-15"),
                 "2002-01-01",
                 vec![],
@@ -1005,16 +1228,27 @@ mod tests {
 
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
         let mut team = make_team("ai_team", "AI Team");
         team.team_kind = TeamKind::Main;
         team.manager_id = None; // AI team
 
         let player = make_player(
-            "p1", "Star", "ai_team", LolRole::Mid,
-            85, 8.0, 50_000, Some("2026-09-15"), "2002-01-01", vec![],
+            "p1",
+            "Star",
+            "ai_team",
+            LolRole::Mid,
+            85,
+            8.0,
+            50_000,
+            Some("2026-09-15"),
+            "2002-01-01",
+            vec![],
         );
         let mut game = Game::new(clock, manager, vec![team], vec![player], vec![], vec![]);
         // Game::new refreshes lol_ovr from attributes — override to test high performer logic
@@ -1035,8 +1269,11 @@ mod tests {
 
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
         let mut team = make_team("ai_team", "AI Team");
         team.team_kind = TeamKind::Main;
@@ -1049,17 +1286,20 @@ mod tests {
 
     #[test]
     fn test_process_ai_team_agents_full_integration() {
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
         use crate::domain::player::LolRole;
         use crate::domain::season::TransferWindowStatus;
         use crate::domain::team::TeamKind;
-        use crate::clock::GameClock;
-        use crate::domain::manager::Manager;
         use chrono::{TimeZone, Utc};
 
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
         // AI team with budget + a role gap (no Support)
@@ -1070,12 +1310,67 @@ mod tests {
         team.wage_budget = 500_000;
 
         let base_players = vec![
-            make_player("p1", "Top", "ai_team", LolRole::Top, 80, 7.0, 40_000, Some("2027-06-15"), "2000-01-01", vec![]),
-            make_player("p2", "Jg", "ai_team", LolRole::Jungle, 75, 6.8, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
-            make_player("p3", "Mid", "ai_team", LolRole::Mid, 85, 8.5, 50_000, Some("2026-09-15"), "2002-01-01", vec![]), // high performer, short contract
-            make_player("p4", "Adc", "ai_team", LolRole::Adc, 78, 7.2, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player(
+                "p1",
+                "Top",
+                "ai_team",
+                LolRole::Top,
+                80,
+                7.0,
+                40_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
+            make_player(
+                "p2",
+                "Jg",
+                "ai_team",
+                LolRole::Jungle,
+                75,
+                6.8,
+                45_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
+            make_player(
+                "p3",
+                "Mid",
+                "ai_team",
+                LolRole::Mid,
+                85,
+                8.5,
+                50_000,
+                Some("2026-09-15"),
+                "2002-01-01",
+                vec![],
+            ), // high performer, short contract
+            make_player(
+                "p4",
+                "Adc",
+                "ai_team",
+                LolRole::Adc,
+                78,
+                7.2,
+                45_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
             // Expendable veteran on high wage who should get transfer_listed
-            make_player("p5", "Vet", "ai_team", LolRole::Top, 60, 5.5, 120_000, Some("2028-06-15"), "1995-01-01", vec![]),
+            make_player(
+                "p5",
+                "Vet",
+                "ai_team",
+                LolRole::Top,
+                60,
+                5.5,
+                120_000,
+                Some("2028-06-15"),
+                "1995-01-01",
+                vec![],
+            ),
         ];
 
         let mut game = Game::new(clock, manager, vec![team], base_players, vec![], vec![]);
@@ -1083,8 +1378,16 @@ mod tests {
 
         // Add a free agent Support
         let mut fa = make_player(
-            "fa1", "FreeSupp", "none", LolRole::Support,
-            70, 6.5, 30_000, None, "2001-01-01", vec![],
+            "fa1",
+            "FreeSupp",
+            "none",
+            LolRole::Support,
+            70,
+            6.5,
+            30_000,
+            None,
+            "2001-01-01",
+            vec![],
         );
         fa.market_value = 100_000;
         fa.team_id = None;
@@ -1132,8 +1435,16 @@ mod tests {
     fn test_compute_deadweight_score_high_ovr_low_wage() {
         let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
         let player = make_player(
-            "p1", "Star", "t1", LolRole::Mid,
-            99, 8.0, 50_000, Some("2028-06-15"), "2000-01-01", vec![],
+            "p1",
+            "Star",
+            "t1",
+            LolRole::Mid,
+            99,
+            8.0,
+            50_000,
+            Some("2028-06-15"),
+            "2000-01-01",
+            vec![],
         );
         let score = compute_deadweight_score(&player, today);
         assert!(
@@ -1146,8 +1457,16 @@ mod tests {
     fn test_compute_deadweight_score_low_ovr_high_wage() {
         let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
         let player = make_player(
-            "p2", "Bust", "t1", LolRole::Top,
-            40, 5.0, 200_000, Some("2026-09-15"), "1995-01-01", vec![],
+            "p2",
+            "Bust",
+            "t1",
+            LolRole::Top,
+            40,
+            5.0,
+            200_000,
+            Some("2026-09-15"),
+            "1995-01-01",
+            vec![],
         );
         let score = compute_deadweight_score(&player, today);
         assert!(
@@ -1160,8 +1479,16 @@ mod tests {
     fn test_compute_deadweight_score_no_contract() {
         let today = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
         let player = make_player(
-            "p3", "Expiring", "t1", LolRole::Support,
-            60, 6.0, 80_000, None, "1998-01-01", vec![],
+            "p3",
+            "Expiring",
+            "t1",
+            LolRole::Support,
+            60,
+            6.0,
+            80_000,
+            None,
+            "1998-01-01",
+            vec![],
         );
         let score = compute_deadweight_score(&player, today);
         assert!(
@@ -1197,16 +1524,26 @@ mod tests {
         // Player: age 30 (>28), avg_rating 5.5 (<6.5), contract until 2028 (>12 months)
         let mut players = vec![
             make_player(
-                "p1", "Veteran", "t1", LolRole::Top,
-                65, 5.5, 120_000, // top wage
+                "p1",
+                "Veteran",
+                "t1",
+                LolRole::Top,
+                65,
+                5.5,
+                120_000,            // top wage
                 Some("2028-06-15"), // >12 months
-                "1996-01-01", // age 30
+                "1996-01-01",       // age 30
                 vec![],
             ),
             // Second player, lower wage, so p1 is top 25%
             make_player(
-                "p2", "Youngster", "t1", LolRole::Mid,
-                80, 7.5, 30_000,
+                "p2",
+                "Youngster",
+                "t1",
+                LolRole::Mid,
+                80,
+                7.5,
+                30_000,
                 Some("2027-06-15"),
                 "2002-01-01",
                 vec![],
@@ -1235,15 +1572,18 @@ mod tests {
         let team = make_team("t1", "Test Team");
         let today = test_date();
 
-        let mut players = vec![
-            make_player(
-                "p1", "RecentSigning", "t1", LolRole::Jungle,
-                70, 6.0, 100_000,
-                Some("2028-06-15"),
-                "1995-01-01", // age 31
-                vec![],
-            ),
-        ];
+        let mut players = vec![make_player(
+            "p1",
+            "RecentSigning",
+            "t1",
+            LolRole::Jungle,
+            70,
+            6.0,
+            100_000,
+            Some("2028-06-15"),
+            "1995-01-01", // age 31
+            vec![],
+        )];
         players[0].lol_ovr = 70;
         // Protected from transfer until future date
         players[0].can_be_transferred_until = Some("2026-12-01".to_string());
@@ -1264,18 +1604,21 @@ mod tests {
     fn test_evaluate_purchases_initiates_when_budget_and_gap_exist() {
         // Integration-level: set up a team with budget + role gap + free agent
         // and verify a purchase happens through the transfers module.
+        use crate::clock::GameClock;
+        use crate::domain::manager::Manager;
         use crate::domain::player::LolRole;
         use crate::domain::season::TransferWindowStatus;
         use crate::domain::team::TeamKind;
-        use crate::clock::GameClock;
-        use crate::domain::manager::Manager;
         use chrono::{TimeZone, Utc};
 
         let today = test_date();
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
         let mut team = make_team("t1", "Test Team");
@@ -1286,10 +1629,54 @@ mod tests {
 
         // Team has 4 roles — no Support → gap
         let base_players = vec![
-            make_player("p1", "Top", "t1", LolRole::Top, 80, 7.0, 40_000, Some("2027-06-15"), "2000-01-01", vec![]),
-            make_player("p2", "Jg", "t1", LolRole::Jungle, 75, 6.8, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
-            make_player("p3", "Mid", "t1", LolRole::Mid, 85, 7.5, 50_000, Some("2027-06-15"), "2000-01-01", vec![]),
-            make_player("p4", "Adc", "t1", LolRole::Adc, 78, 7.2, 45_000, Some("2027-06-15"), "2000-01-01", vec![]),
+            make_player(
+                "p1",
+                "Top",
+                "t1",
+                LolRole::Top,
+                80,
+                7.0,
+                40_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
+            make_player(
+                "p2",
+                "Jg",
+                "t1",
+                LolRole::Jungle,
+                75,
+                6.8,
+                45_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
+            make_player(
+                "p3",
+                "Mid",
+                "t1",
+                LolRole::Mid,
+                85,
+                7.5,
+                50_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
+            make_player(
+                "p4",
+                "Adc",
+                "t1",
+                LolRole::Adc,
+                78,
+                7.2,
+                45_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
         ];
 
         let mut game = Game::new(clock, manager, vec![team], base_players, vec![], vec![]);
@@ -1297,9 +1684,16 @@ mod tests {
 
         // Add a free agent Support with low market_value to guarantee purchase
         let mut fa = make_player(
-            "fa1", "FreeSupp", "none", LolRole::Support,
-            70, 6.5, 30_000,
-            None, "2001-01-01", vec![],
+            "fa1",
+            "FreeSupp",
+            "none",
+            LolRole::Support,
+            70,
+            6.5,
+            30_000,
+            None,
+            "2001-01-01",
+            vec![],
         );
         fa.market_value = 100_000;
         fa.team_id = None;
@@ -1320,9 +1714,12 @@ mod tests {
         evaluate_purchases("t1", &mut game, &report);
 
         // After purchase, team should have exactly one Support player
-        let support_count = game.players
+        let support_count = game
+            .players
             .iter()
-            .filter(|p| p.team_id.as_deref() == Some("t1") && p.natural_position == LolRole::Support)
+            .filter(|p| {
+                p.team_id.as_deref() == Some("t1") && p.natural_position == LolRole::Support
+            })
             .count();
         assert_eq!(
             support_count, 1,
@@ -1332,26 +1729,38 @@ mod tests {
 
     #[test]
     fn test_evaluate_purchases_no_budget_no_purchase_attempts() {
-        use crate::domain::season::TransferWindowStatus;
-        use crate::domain::team::TeamKind;
         use crate::clock::GameClock;
         use crate::domain::manager::Manager;
+        use crate::domain::season::TransferWindowStatus;
+        use crate::domain::team::TeamKind;
         use chrono::{TimeZone, Utc};
 
         let today = test_date();
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
         let mut team = make_team("t1", "Broke Team");
         team.team_kind = TeamKind::Main;
         team.transfer_budget = 0; // zero budget
 
-        let players = vec![
-            make_player("p1", "OnlyPlayer", "t1", LolRole::Top, 70, 6.5, 30_000, Some("2027-06-15"), "2000-01-01", vec![]),
-        ];
+        let players = vec![make_player(
+            "p1",
+            "OnlyPlayer",
+            "t1",
+            LolRole::Top,
+            70,
+            6.5,
+            30_000,
+            Some("2027-06-15"),
+            "2000-01-01",
+            vec![],
+        )];
 
         let mut game = Game::new(clock, manager, vec![team], players, vec![], vec![]);
         game.season_context.transfer_window.status = TransferWindowStatus::Open;
@@ -1367,7 +1776,10 @@ mod tests {
         // No panic = function handled zero budget gracefully
         // The game state should be unchanged
         assert_eq!(
-            game.players.iter().filter(|p| p.team_id.as_deref() == Some("t1")).count(),
+            game.players
+                .iter()
+                .filter(|p| p.team_id.as_deref() == Some("t1"))
+                .count(),
             1,
             "no new players should be added with zero budget"
         );
@@ -1382,15 +1794,25 @@ mod tests {
         // should be processed; the duplicate should be skipped.
         let mut players = vec![
             make_player(
-                "p1", "Star", "t1", LolRole::Top,
-                60, 6.0, 120_000,
+                "p1",
+                "Star",
+                "t1",
+                LolRole::Top,
+                60,
+                6.0,
+                120_000,
                 Some("2028-06-15"),
                 "1995-01-01", // age 31, >28
                 vec![],
             ),
             make_player(
-                "p1", "Clone", "t1", LolRole::Top,
-                60, 6.0, 120_000,
+                "p1",
+                "Clone",
+                "t1",
+                LolRole::Top,
+                60,
+                6.0,
+                120_000,
                 Some("2028-06-15"),
                 "1995-01-01",
                 vec![],
@@ -1402,7 +1824,10 @@ mod tests {
         evaluate_sales(&team, &mut players, today);
 
         // First occurrence should be processed
-        assert!(players[0].transfer_listed, "first occurrence should be evaluated");
+        assert!(
+            players[0].transfer_listed,
+            "first occurrence should be evaluated"
+        );
         // Duplicate should be skipped (deadlock guard)
         assert!(!players[1].transfer_listed, "duplicate should be skipped");
     }
@@ -1412,15 +1837,18 @@ mod tests {
         let team = make_team("t1", "Test Team");
         let today = test_date();
 
-        let mut players = vec![
-            make_player(
-                "p1", "InjuredStar", "t1", LolRole::Adc,
-                75, 6.0, 100_000,
-                Some("2028-06-15"),
-                "1995-01-01", // age 31
-                vec![],
-            ),
-        ];
+        let mut players = vec![make_player(
+            "p1",
+            "InjuredStar",
+            "t1",
+            LolRole::Adc,
+            75,
+            6.0,
+            100_000,
+            Some("2028-06-15"),
+            "1995-01-01", // age 31
+            vec![],
+        )];
         players[0].lol_ovr = 75;
         players[0].condition = 30; // injured/poor form
 
@@ -1436,19 +1864,19 @@ mod tests {
     // Phase 4: Conflict resolution (PR4)
     // -----------------------------------------------------------------------
 
-    fn make_full_game_for_conflict(
-        players: Vec<Player>,
-        ai_team_ids: Vec<&str>,
-    ) -> Game {
-        use crate::domain::team::TeamKind;
+    fn make_full_game_for_conflict(players: Vec<Player>, ai_team_ids: Vec<&str>) -> Game {
         use crate::clock::GameClock;
         use crate::domain::manager::Manager;
+        use crate::domain::team::TeamKind;
         use chrono::{TimeZone, Utc};
 
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
         let mut teams: Vec<Team> = ai_team_ids
@@ -1484,10 +1912,16 @@ mod tests {
         // Team Agent should override → reset transfer_listed
         let mut game = make_full_game_for_conflict(
             vec![make_player(
-                "p1", "Star", "ai_default", LolRole::Mid,
-                95, 8.5, 60_000, // high ovr, high rating
+                "p1",
+                "Star",
+                "ai_default",
+                LolRole::Mid,
+                95,
+                8.5,
+                60_000,             // high ovr, high rating
                 Some("2028-06-15"), // long contract
-                "2002-01-01", vec![PlayerTrait::HyperCarry],
+                "2002-01-01",
+                vec![PlayerTrait::HyperCarry],
             )],
             vec!["ai_default"],
         );
@@ -1512,10 +1946,16 @@ mod tests {
     fn test_resolve_conflicts_does_not_clear_human_managed_team_listing() {
         let mut game = make_full_game_for_conflict(
             vec![make_player(
-                "p_human", "HumanStar", "human_team", LolRole::Mid,
-                95, 8.5, 60_000,
+                "p_human",
+                "HumanStar",
+                "human_team",
+                LolRole::Mid,
+                95,
+                8.5,
+                60_000,
                 Some("2028-06-15"),
-                "2002-01-01", vec![PlayerTrait::HyperCarry],
+                "2002-01-01",
+                vec![PlayerTrait::HyperCarry],
             )],
             vec!["human_team"],
         );
@@ -1537,20 +1977,31 @@ mod tests {
     fn test_resolve_conflicts_does_not_clear_preexisting_transfer_listing() {
         let mut game = make_full_game_for_conflict(
             vec![make_player(
-                "p_preexisting", "PreListedStar", "ai_default", LolRole::Mid,
-                95, 8.5, 60_000,
+                "p_preexisting",
+                "PreListedStar",
+                "ai_default",
+                LolRole::Mid,
+                95,
+                8.5,
+                60_000,
                 Some("2028-06-15"),
-                "2002-01-01", vec![PlayerTrait::HyperCarry],
+                "2002-01-01",
+                vec![PlayerTrait::HyperCarry],
             )],
             vec!["ai_default"],
         );
         game.players[0].transfer_listed = true;
         game.players[0].lol_ovr = 95;
 
-        let previously_transfer_listed = std::collections::HashSet::from(["p_preexisting".to_string()]);
+        let previously_transfer_listed =
+            std::collections::HashSet::from(["p_preexisting".to_string()]);
         resolve_conflicts(&mut game, &previously_transfer_listed);
 
-        let player = game.players.iter().find(|p| p.id == "p_preexisting").unwrap();
+        let player = game
+            .players
+            .iter()
+            .find(|p| p.id == "p_preexisting")
+            .unwrap();
         assert!(
             player.transfer_listed,
             "pre-existing or Team-Agent-created listings must remain listed"
@@ -1563,10 +2014,16 @@ mod tests {
         // Team Agent should NOT override → transfer_listed stays true
         let mut game = make_full_game_for_conflict(
             vec![make_player(
-                "p2", "Bust", "ai_default", LolRole::Top,
-                45, 4.0, 100_000, // low ovr, low rating, overpaid
+                "p2",
+                "Bust",
+                "ai_default",
+                LolRole::Top,
+                45,
+                4.0,
+                100_000,            // low ovr, low rating, overpaid
                 Some("2026-09-15"), // short contract
-                "1995-01-01", vec![], // old, no traits
+                "1995-01-01",
+                vec![], // old, no traits
             )],
             vec!["ai_default"],
         );
@@ -1591,10 +2048,16 @@ mod tests {
         let mut game = make_full_game_for_conflict(
             vec![{
                 let mut p = make_player(
-                    "p3", "FreeAgent", "ai_default", LolRole::Jungle,
-                    80, 7.0, 50_000,
+                    "p3",
+                    "FreeAgent",
+                    "ai_default",
+                    LolRole::Jungle,
+                    80,
+                    7.0,
+                    50_000,
                     None, // no contract
-                    "2000-01-01", vec![],
+                    "2000-01-01",
+                    vec![],
                 );
                 p.team_id = Some("ai_default".to_string());
                 p
@@ -1620,10 +2083,16 @@ mod tests {
         // Player with expired contract (end <= today) → free agent, not overridden
         let mut game = make_full_game_for_conflict(
             vec![make_player(
-                "p4", "Expired", "ai_default", LolRole::Support,
-                80, 7.0, 50_000,
+                "p4",
+                "Expired",
+                "ai_default",
+                LolRole::Support,
+                80,
+                7.0,
+                50_000,
                 Some("2025-06-15"), // expired before test date
-                "2000-01-01", vec![],
+                "2000-01-01",
+                vec![],
             )],
             vec!["ai_default"],
         );
@@ -1648,23 +2117,41 @@ mod tests {
         let mut game = make_full_game_for_conflict(
             vec![
                 make_player(
-                    "p5", "OnlySupport", "ai_default", LolRole::Support,
-                    70, 6.5, 40_000,
+                    "p5",
+                    "OnlySupport",
+                    "ai_default",
+                    LolRole::Support,
+                    70,
+                    6.5,
+                    40_000,
                     Some("2028-06-15"), // long contract > 12 months
-                    "2000-01-01", vec![],
+                    "2000-01-01",
+                    vec![],
                 ),
                 // Other roles
                 make_player(
-                    "p6", "Top", "ai_default", LolRole::Top,
-                    75, 7.0, 45_000,
+                    "p6",
+                    "Top",
+                    "ai_default",
+                    LolRole::Top,
+                    75,
+                    7.0,
+                    45_000,
                     Some("2028-06-15"),
-                    "2000-01-01", vec![],
+                    "2000-01-01",
+                    vec![],
                 ),
                 make_player(
-                    "p7", "Jungle", "ai_default", LolRole::Jungle,
-                    75, 7.0, 45_000,
+                    "p7",
+                    "Jungle",
+                    "ai_default",
+                    LolRole::Jungle,
+                    75,
+                    7.0,
+                    45_000,
                     Some("2028-06-15"),
-                    "2000-01-01", vec![],
+                    "2000-01-01",
+                    vec![],
                 ),
             ],
             vec!["ai_default"],
@@ -1700,16 +2187,28 @@ mod tests {
         let mut game = make_full_game_for_conflict(
             vec![
                 make_player(
-                    "p8", "TempOnlySupport", "ai_default", LolRole::Support,
-                    70, 6.5, 40_000,
+                    "p8",
+                    "TempOnlySupport",
+                    "ai_default",
+                    LolRole::Support,
+                    70,
+                    6.5,
+                    40_000,
                     Some("2026-12-01"), // only ~5 months from test date
-                    "2000-01-01", vec![],
+                    "2000-01-01",
+                    vec![],
                 ),
                 make_player(
-                    "p9", "Top", "ai_default", LolRole::Top,
-                    75, 7.0, 45_000,
+                    "p9",
+                    "Top",
+                    "ai_default",
+                    LolRole::Top,
+                    75,
+                    7.0,
+                    45_000,
                     Some("2028-06-15"),
-                    "2000-01-01", vec![],
+                    "2000-01-01",
+                    vec![],
                 ),
             ],
             vec!["ai_default"],
@@ -1750,19 +2249,33 @@ mod tests {
 
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
-        let roles = [LolRole::Top, LolRole::Jungle, LolRole::Mid, LolRole::Adc, LolRole::Support];
+        let roles = [
+            LolRole::Top,
+            LolRole::Jungle,
+            LolRole::Mid,
+            LolRole::Adc,
+            LolRole::Support,
+        ];
         let mut teams = Vec::with_capacity(num_teams);
         let mut players = Vec::with_capacity(num_teams * players_per_team);
 
         for ti in 0..num_teams {
             let tid = format!("ai_team_{ti}");
             let mut team = Team::new(
-                tid.clone(), format!("AI Team {ti}"), format!("AT{ti}"),
-                "DE".to_string(), "Berlin".to_string(), "Arena".to_string(), 10_000,
+                tid.clone(),
+                format!("AI Team {ti}"),
+                format!("AT{ti}"),
+                "DE".to_string(),
+                "Berlin".to_string(),
+                "Arena".to_string(),
+                10_000,
             );
             team.team_kind = TeamKind::Main;
             team.manager_id = None;
@@ -1774,13 +2287,20 @@ mod tests {
                 let role = roles[pi % 5];
                 let pid = format!("p_{tid}_{pi}");
                 let mut p = make_player(
-                    &pid, &format!("Player {tid} {pi}"), &tid, role,
-                    (70 + (pi as u8 * 3) % 25), // varied OVR 70-92
+                    &pid,
+                    &format!("Player {tid} {pi}"),
+                    &tid,
+                    role,
+                    (70 + (pi as u8 * 3) % 25),       // varied OVR 70-92
                     6.5 + (pi as f32 * 0.3).min(2.5), // varied rating 6.5-8.5
-                    40_000 + (pi as u32 * 10_000), // varied wage
-                    Some("2028-06-15"), // standard 2-year contract
+                    40_000 + (pi as u32 * 10_000),    // varied wage
+                    Some("2028-06-15"),               // standard 2-year contract
                     "2000-01-01",
-                    if pi == 0 { vec![PlayerTrait::HyperCarry] } else { vec![] },
+                    if pi == 0 {
+                        vec![PlayerTrait::HyperCarry]
+                    } else {
+                        vec![]
+                    },
                 );
                 p.condition = 80; // healthy
                 p.market_value = 100_000 + (pi as u64 * 50_000);
@@ -1813,31 +2333,41 @@ mod tests {
                 assert!(
                     team.wage_budget >= 0,
                     "Team {} wage_budget went negative on day {}",
-                    team.name, day
+                    team.name,
+                    day
                 );
                 assert!(
                     team.transfer_budget >= 0,
                     "Team {} transfer_budget went negative on day {}",
-                    team.name, day
+                    team.name,
+                    day
                 );
             }
 
             // Invariant I-01: minimum 5 players per team (roster_stability safety net)
             for team in &game.teams {
-                let count = game.players
+                let count = game
+                    .players
                     .iter()
                     .filter(|p| p.team_id.as_deref() == Some(&team.id))
                     .count();
                 assert!(
                     count >= 5,
                     "Team {} has only {count} players on day {} (below minimum)",
-                    team.name, day
+                    team.name,
+                    day
                 );
             }
         }
 
         // Verify at least 25 days elapsed (should be 30 + initial offset)
-        let day_of_year = game.clock.current_date.format("%j").to_string().parse::<u32>().unwrap_or(0);
+        let day_of_year = game
+            .clock
+            .current_date
+            .format("%j")
+            .to_string()
+            .parse::<u32>()
+            .unwrap_or(0);
         // Started June 15 (day 166), after 30 days = day ~196
         assert!(
             day_of_year >= 190,
@@ -1850,16 +2380,19 @@ mod tests {
         // Spec 2.2: Player requests transfer (low satisfaction),
         // Team Agent rejects due to no depth (only player at role), player stays
         // Use a single AI team with 4 players — one Support only
-        use crate::domain::player::LolRole;
-        use crate::domain::team::TeamKind;
         use crate::clock::GameClock;
         use crate::domain::manager::Manager;
+        use crate::domain::player::LolRole;
+        use crate::domain::team::TeamKind;
         use chrono::{TimeZone, Utc};
 
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
         let mut team = make_team("reject_team", "Reject Team");
@@ -1869,26 +2402,48 @@ mod tests {
         team.transfer_budget = 200_000;
 
         // 4 players: Top, Jungle, Mid, Support (only Support — critical depth)
-        let roles = [LolRole::Top, LolRole::Jungle, LolRole::Mid, LolRole::Support];
-        let mut base_players: Vec<Player> = roles.iter().enumerate().map(|(i, &role)| {
-            let pid = format!("p_role_{i}");
-            let mut p = make_player(
-                &pid, &format!("RolePlayer{i}"), "reject_team", role,
-                75, 7.0, 40_000,
-                Some("2028-06-15"), // long contract
-                "2000-01-01", vec![],
-            );
-            p.morale = 60;
-            p.morale_core.manager_trust = 55;
-            p.market_value = 200_000;
-            p
-        }).collect();
+        let roles = [
+            LolRole::Top,
+            LolRole::Jungle,
+            LolRole::Mid,
+            LolRole::Support,
+        ];
+        let mut base_players: Vec<Player> = roles
+            .iter()
+            .enumerate()
+            .map(|(i, &role)| {
+                let pid = format!("p_role_{i}");
+                let mut p = make_player(
+                    &pid,
+                    &format!("RolePlayer{i}"),
+                    "reject_team",
+                    role,
+                    75,
+                    7.0,
+                    40_000,
+                    Some("2028-06-15"), // long contract
+                    "2000-01-01",
+                    vec![],
+                );
+                p.morale = 60;
+                p.morale_core.manager_trust = 55;
+                p.market_value = 200_000;
+                p
+            })
+            .collect();
 
         // Add a 5th player at Top (so only Support has depth 1)
         let mut extra_top = make_player(
-            "p_extra_top", "ExtraTop", "reject_team", LolRole::Top,
-            70, 6.5, 35_000,
-            Some("2028-06-15"), "2000-01-01", vec![],
+            "p_extra_top",
+            "ExtraTop",
+            "reject_team",
+            LolRole::Top,
+            70,
+            6.5,
+            35_000,
+            Some("2028-06-15"),
+            "2000-01-01",
+            vec![],
         );
         extra_top.market_value = 150_000;
         base_players.push(extra_top);
@@ -1896,14 +2451,19 @@ mod tests {
         let mut game = Game::new(clock, manager, vec![team], base_players, vec![], vec![]);
         // Fix lol_ovr
         for p in &mut game.players {
-            if p.lol_ovr == 0 || p.lol_ovr < 30 { p.lol_ovr = 75; }
+            if p.lol_ovr == 0 || p.lol_ovr < 30 {
+                p.lol_ovr = 75;
+            }
         }
 
         // Run the full agent pipeline (Team Agent → Player Agent → resolve_conflicts)
         // The Support player (only one at role) might be unhappy due to setup.
         // We manually ensure the Support player has low morale to trigger Player Agent transfer request.
-        let support = game.players.iter_mut()
-            .find(|p| p.natural_position == LolRole::Support).unwrap();
+        let support = game
+            .players
+            .iter_mut()
+            .find(|p| p.natural_position == LolRole::Support)
+            .unwrap();
         support.morale = 20;
         support.morale_core.manager_trust = 15;
         support.wage = 20_000; // underpaid → triggers transfer request
@@ -1911,15 +2471,19 @@ mod tests {
         // Now run agents. Snapshot after Team Agent so conflict resolution only
         // clears transfer requests that Player Agent created in this cycle.
         crate::ai_team_agent::process_ai_team_agents(&mut game);
-        let previously_transfer_listed: std::collections::HashSet<String> = game.players
+        let previously_transfer_listed: std::collections::HashSet<String> = game
+            .players
             .iter()
             .filter(|p| p.transfer_listed)
             .map(|p| p.id.clone())
             .collect();
         crate::ai_player_agent::process_ai_player_agents(&mut game);
 
-        let support_after_player_agent = game.players.iter()
-            .find(|p| p.natural_position == LolRole::Support).unwrap();
+        let support_after_player_agent = game
+            .players
+            .iter()
+            .find(|p| p.natural_position == LolRole::Support)
+            .unwrap();
         assert!(
             support_after_player_agent.transfer_listed,
             "precondition: Player Agent should request a transfer before conflict resolution"
@@ -1928,8 +2492,11 @@ mod tests {
         crate::ai_team_agent::resolve_conflicts(&mut game, &previously_transfer_listed);
 
         // Support player should NOT be transfer_listed (critical depth overrides)
-        let support_after = game.players.iter()
-            .find(|p| p.natural_position == LolRole::Support).unwrap();
+        let support_after = game
+            .players
+            .iter()
+            .find(|p| p.natural_position == LolRole::Support)
+            .unwrap();
         assert!(
             !support_after.transfer_listed,
             "Support player must stay (critical depth — Team Agent overrides transfer request)"
@@ -1950,7 +2517,8 @@ mod tests {
 
             // I-01: Never below 5 players per team
             for team in &game.teams {
-                let count = game.players
+                let count = game
+                    .players
                     .iter()
                     .filter(|p| p.team_id.as_deref() == Some(&team.id))
                     .count();
@@ -1966,12 +2534,14 @@ mod tests {
                 assert!(
                     team.wage_budget >= 0,
                     "I-02 violated: Team {} wage_budget is {}",
-                    team.name, team.wage_budget
+                    team.name,
+                    team.wage_budget
                 );
                 assert!(
                     team.transfer_budget >= 0,
                     "I-02 violated: Team {} transfer_budget is {}",
-                    team.name, team.transfer_budget
+                    team.name,
+                    team.transfer_budget
                 );
             }
 
@@ -1982,9 +2552,9 @@ mod tests {
 
     #[test]
     fn test_determinism_identical_state_identical_decisions() {
-        use crate::domain::season::TransferWindowStatus;
         use crate::clock::GameClock;
         use crate::domain::manager::Manager;
+        use crate::domain::season::TransferWindowStatus;
         use crate::domain::team::TeamKind;
         use chrono::{TimeZone, Utc};
 
@@ -1992,8 +2562,11 @@ mod tests {
         // Build game manually for precise control
         let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
         let manager = Manager::new(
-            "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-            "1980-01-01".to_string(), "GB".to_string(),
+            "mgr1".to_string(),
+            "Test".to_string(),
+            "Manager".to_string(),
+            "1980-01-01".to_string(),
+            "GB".to_string(),
         );
 
         let mut team = make_team("det_team", "Determinism Team");
@@ -2003,26 +2576,84 @@ mod tests {
         team.transfer_budget = 200_000;
 
         let players = vec![
-            make_player("p1", "Star", "det_team", LolRole::Mid, 90, 8.5, 60_000, Some("2027-06-15"), "2002-01-01", vec![PlayerTrait::HyperCarry]),
-            make_player("p2", "Mediocre", "det_team", LolRole::Top, 70, 6.5, 40_000, Some("2027-06-15"), "2000-01-01", vec![]),
-            make_player("p3", "Vet", "det_team", LolRole::Jungle, 60, 5.5, 120_000, Some("2028-06-15"), "1995-01-01", vec![]),
-            make_player("p4", "Young", "det_team", LolRole::Adc, 80, 7.5, 30_000, Some("2028-06-15"), "2003-01-01", vec![]),
-            make_player("p5", "Supp", "det_team", LolRole::Support, 75, 7.0, 45_000, Some("2027-06-15"), "2001-01-01", vec![]),
+            make_player(
+                "p1",
+                "Star",
+                "det_team",
+                LolRole::Mid,
+                90,
+                8.5,
+                60_000,
+                Some("2027-06-15"),
+                "2002-01-01",
+                vec![PlayerTrait::HyperCarry],
+            ),
+            make_player(
+                "p2",
+                "Mediocre",
+                "det_team",
+                LolRole::Top,
+                70,
+                6.5,
+                40_000,
+                Some("2027-06-15"),
+                "2000-01-01",
+                vec![],
+            ),
+            make_player(
+                "p3",
+                "Vet",
+                "det_team",
+                LolRole::Jungle,
+                60,
+                5.5,
+                120_000,
+                Some("2028-06-15"),
+                "1995-01-01",
+                vec![],
+            ),
+            make_player(
+                "p4",
+                "Young",
+                "det_team",
+                LolRole::Adc,
+                80,
+                7.5,
+                30_000,
+                Some("2028-06-15"),
+                "2003-01-01",
+                vec![],
+            ),
+            make_player(
+                "p5",
+                "Supp",
+                "det_team",
+                LolRole::Support,
+                75,
+                7.0,
+                45_000,
+                Some("2027-06-15"),
+                "2001-01-01",
+                vec![],
+            ),
         ];
 
         // Build game state once, then snapshot
-        fn build_det_game(
-            team: Team, players: Vec<Player>,
-        ) -> Game {
+        fn build_det_game(team: Team, players: Vec<Player>) -> Game {
             let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 6, 15, 12, 0, 0).unwrap());
             let manager = Manager::new(
-                "mgr1".to_string(), "Test".to_string(), "Manager".to_string(),
-                "1980-01-01".to_string(), "GB".to_string(),
+                "mgr1".to_string(),
+                "Test".to_string(),
+                "Manager".to_string(),
+                "1980-01-01".to_string(),
+                "GB".to_string(),
             );
             let mut g = Game::new(clock, manager, vec![team], players, vec![], vec![]);
             g.season_context.transfer_window.status = TransferWindowStatus::Open;
             for p in &mut g.players {
-                if p.lol_ovr == 0 || p.lol_ovr < 30 { p.lol_ovr = 70; }
+                if p.lol_ovr == 0 || p.lol_ovr < 30 {
+                    p.lol_ovr = 70;
+                }
             }
             g
         }
@@ -2037,14 +2668,25 @@ mod tests {
         game1.players[4].lol_ovr = 75;
 
         // Snapshot player state
-        let snapshot1: Vec<(String, bool, Option<String>)> = game1.players
+        let snapshot1: Vec<(String, bool, Option<String>)> = game1
+            .players
             .iter()
-            .map(|p| (p.id.clone(), p.transfer_listed, p.morale_core.renewal_state.as_ref().map(|s| format!("{:?}", s.status))))
+            .map(|p| {
+                (
+                    p.id.clone(),
+                    p.transfer_listed,
+                    p.morale_core
+                        .renewal_state
+                        .as_ref()
+                        .map(|s| format!("{:?}", s.status)),
+                )
+            })
             .collect();
 
         // ... run agents
         crate::ai_team_agent::process_ai_team_agents(&mut game1);
-        let previously_transfer_listed1: std::collections::HashSet<String> = game1.players
+        let previously_transfer_listed1: std::collections::HashSet<String> = game1
+            .players
             .iter()
             .filter(|p| p.transfer_listed)
             .map(|p| p.id.clone())
@@ -2052,9 +2694,19 @@ mod tests {
         crate::ai_player_agent::process_ai_player_agents(&mut game1);
         crate::ai_team_agent::resolve_conflicts(&mut game1, &previously_transfer_listed1);
 
-        let result1: Vec<(String, bool, Option<String>)> = game1.players
+        let result1: Vec<(String, bool, Option<String>)> = game1
+            .players
             .iter()
-            .map(|p| (p.id.clone(), p.transfer_listed, p.morale_core.renewal_state.as_ref().map(|s| format!("{:?}", s.status))))
+            .map(|p| {
+                (
+                    p.id.clone(),
+                    p.transfer_listed,
+                    p.morale_core
+                        .renewal_state
+                        .as_ref()
+                        .map(|s| format!("{:?}", s.status)),
+                )
+            })
             .collect();
 
         // Run 2 — identical setup
@@ -2066,7 +2718,8 @@ mod tests {
         game2.players[4].lol_ovr = 75;
 
         crate::ai_team_agent::process_ai_team_agents(&mut game2);
-        let previously_transfer_listed2: std::collections::HashSet<String> = game2.players
+        let previously_transfer_listed2: std::collections::HashSet<String> = game2
+            .players
             .iter()
             .filter(|p| p.transfer_listed)
             .map(|p| p.id.clone())
@@ -2074,9 +2727,19 @@ mod tests {
         crate::ai_player_agent::process_ai_player_agents(&mut game2);
         crate::ai_team_agent::resolve_conflicts(&mut game2, &previously_transfer_listed2);
 
-        let result2: Vec<(String, bool, Option<String>)> = game2.players
+        let result2: Vec<(String, bool, Option<String>)> = game2
+            .players
             .iter()
-            .map(|p| (p.id.clone(), p.transfer_listed, p.morale_core.renewal_state.as_ref().map(|s| format!("{:?}", s.status))))
+            .map(|p| {
+                (
+                    p.id.clone(),
+                    p.transfer_listed,
+                    p.morale_core
+                        .renewal_state
+                        .as_ref()
+                        .map(|s| format!("{:?}", s.status)),
+                )
+            })
             .collect();
 
         // Compare — must be identical

--- a/src-tauri/crates/olm_core/src/contract_wage_policy.rs
+++ b/src-tauri/crates/olm_core/src/contract_wage_policy.rs
@@ -1,11 +1,20 @@
-use crate::contracts::RenewalFinancialProjection;
+use crate::contracts::{RenewalFinancialProjection, expected_contract_years, expected_wage};
+use crate::domain::league::League;
+use crate::domain::player::Player;
+use crate::domain::team::Team;
 use crate::finances::calc_cash_runway_weeks;
 use crate::game::Game;
-use crate::domain::team::Team;
+use serde::{Deserialize, Serialize};
 
 const WAGE_SOFT_CAP_PCT: i64 = 110;
 const LEGACY_OVER_BUDGET_GRACE_PCT: i64 = 3;
 const LEGACY_OVER_BUDGET_GRACE_MIN: i64 = 25_000;
+
+const MAX_AI_TRANSFERS_PER_DAY: u8 = 2;
+const MAX_AI_EMERGENCY_TRANSFERS_PER_DAY: u8 = 1;
+
+const HIGH_REPUTATION_THRESHOLD: u32 = 1_100;
+const MIN_STRATEGIC_ATTRACTIVENESS: i32 = 35;
 
 fn annual_team_wage_bill(game: &Game, team_id: &str) -> i64 {
     let player_wages: i64 = game
@@ -114,3 +123,193 @@ pub fn project_renewal_financial_impact(
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SigningIntent {
+    Emergency,
+    Strategic,
+    Casual,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SigningRejectionReason {
+    None,
+    WageBudgetExceeded,
+    ReputationMismatch,
+    DailyCapReached,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SigningDecision {
+    pub accepted: bool,
+    pub annual_wage: u32,
+    pub contract_years: u8,
+    pub reason: SigningRejectionReason,
+}
+
+impl SigningDecision {
+    fn accepted(annual_wage: u32, contract_years: u8) -> Self {
+        Self {
+            accepted: true,
+            annual_wage,
+            contract_years,
+            reason: SigningRejectionReason::None,
+        }
+    }
+
+    fn rejected(reason: SigningRejectionReason, annual_wage: u32, contract_years: u8) -> Self {
+        Self {
+            accepted: false,
+            annual_wage,
+            contract_years,
+            reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AiTransferKind {
+    Strategic,
+    FreeAgent,
+    ClubToClub,
+    Emergency,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AiTransferCapState {
+    pub strategic_count: u8,
+    pub emergency_count: u8,
+}
+
+/// Resolve a team's competition tier (1..=3).
+/// Prefers `team.competition_id -> game.leagues[].tier`, falling back to
+/// reputation bands when no matching league exists.
+pub fn ai_team_tier(team: &Team, game: &Game) -> u8 {
+    tier_from_competition_id(team, &game.leagues)
+        .unwrap_or_else(|| tier_from_reputation(team.reputation))
+}
+
+fn tier_from_competition_id(team: &Team, leagues: &[League]) -> Option<u8> {
+    let competition_id = team.competition_id.as_deref()?;
+    leagues
+        .iter()
+        .find(|league| league.competition_id.as_deref() == Some(competition_id))
+        .map(|league| league.tier.max(1).min(3))
+}
+
+fn tier_from_reputation(reputation: u32) -> u8 {
+    if reputation >= 1_300 {
+        1
+    } else if reputation >= 1_100 {
+        1
+    } else if reputation >= 800 {
+        2
+    } else {
+        3
+    }
+}
+
+/// Compute a free-agent attractiveness score used by the strategic gating
+/// path. Mirrors the spirit of `transfers::incoming_interest_score` but uses
+/// stable player attributes so the result is deterministic per player.
+pub fn player_attractiveness_score(player: &Player) -> i32 {
+    let mut score = 8;
+
+    if player.market_value >= 1_000_000 {
+        score += 20;
+    } else if player.market_value >= 500_000 {
+        score += 10;
+    }
+
+    if player.lol_ovr >= 80 {
+        score += 15;
+    } else if player.lol_ovr >= 70 {
+        score += 8;
+    }
+
+    score
+}
+
+/// Reputation/tier fit gate for AI signings.
+/// Emergency intent always passes. Strategic intent at high-reputation tier-1
+/// clubs rejects low-impact free agents unless roster validity is at stake.
+pub fn reputation_fit_ok(team: &Team, player: &Player, intent: SigningIntent, game: &Game) -> bool {
+    if matches!(intent, SigningIntent::Emergency | SigningIntent::Casual) {
+        return true;
+    }
+
+    let is_elite_context =
+        team.reputation >= HIGH_REPUTATION_THRESHOLD && ai_team_tier(team, game) == 1;
+    if !is_elite_context {
+        return true;
+    }
+
+    player_attractiveness_score(player) >= MIN_STRATEGIC_ATTRACTIVENESS
+}
+
+/// Shared AI signing policy: computes wage/term and enforces budget + fit gates.
+pub fn ai_signing_policy(
+    game: &Game,
+    team: &Team,
+    player: &Player,
+    intent: SigningIntent,
+) -> SigningDecision {
+    let current_date = game.clock.current_date.date_naive();
+    let annual_wage = expected_wage(player, team, current_date);
+    let contract_years = expected_contract_years(player, current_date) as u8;
+
+    if !reputation_fit_ok(team, player, intent, game) {
+        return SigningDecision::rejected(
+            SigningRejectionReason::ReputationMismatch,
+            annual_wage,
+            contract_years,
+        );
+    }
+
+    if !renewal_wage_policy_allows(game, team, 0, annual_wage) {
+        return SigningDecision::rejected(
+            SigningRejectionReason::WageBudgetExceeded,
+            annual_wage,
+            contract_years,
+        );
+    }
+
+    SigningDecision::accepted(annual_wage, contract_years)
+}
+
+/// Attempt to consume one slot from the per-team daily transfer cap.
+/// Returns `true` if the slot was available.
+pub fn ai_transfer_cap_try_consume(game: &mut Game, team_id: &str, kind: AiTransferKind) -> bool {
+    let state = game
+        .ai_transfer_cap_counts
+        .entry(team_id.to_string())
+        .or_default();
+
+    let allowed = match kind {
+        AiTransferKind::Emergency => state.emergency_count < MAX_AI_EMERGENCY_TRANSFERS_PER_DAY,
+        _ => state.strategic_count < MAX_AI_TRANSFERS_PER_DAY,
+    };
+
+    if !allowed {
+        return false;
+    }
+
+    match kind {
+        AiTransferKind::Emergency => state.emergency_count += 1,
+        _ => state.strategic_count += 1,
+    }
+
+    true
+}
+
+/// Reset per-team transfer counters when the in-game date advances.
+pub fn ai_transfer_cap_reset_if_new_day(game: &mut Game) {
+    let current_date = game.clock.current_date.format("%Y-%m-%d").to_string();
+    if game.ai_transfer_cap_last_reset_date.as_deref() == Some(&current_date) {
+        return;
+    }
+    game.ai_transfer_cap_counts.clear();
+    game.ai_transfer_cap_last_reset_date = Some(current_date);
+}

--- a/src-tauri/crates/olm_core/src/contracts.rs
+++ b/src-tauri/crates/olm_core/src/contracts.rs
@@ -3,13 +3,15 @@ use crate::contract_wage_policy::{
     renewal_wage_policy_allows, renewal_wage_policy_error_message,
 };
 use crate::delegated_renewals::delegate_renewals as delegate_renewals_service;
+use crate::domain::message::{InboxMessage, MessageCategory, MessagePriority};
+use crate::domain::negotiation::{NegotiationFeedback, NegotiationMood};
+use crate::domain::player::{
+    ContractRenewalState, Player, RenewalSessionOutcome, RenewalSessionStatus,
+};
+use crate::domain::team::Team;
 use crate::game::Game;
 use crate::roster_stability::{RosterStabilityReason, repair_team};
 use chrono::{Datelike, Months, NaiveDate};
-use crate::domain::message::{InboxMessage, MessageCategory, MessagePriority};
-use crate::domain::negotiation::{NegotiationFeedback, NegotiationMood};
-use crate::domain::player::{ContractRenewalState, Player, RenewalSessionOutcome, RenewalSessionStatus};
-use crate::domain::team::Team;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -481,7 +483,7 @@ pub fn process_contract_expiries(game: &mut Game) {
             let player = &mut game.players[player_index];
             player.team_id = None;
             player.contract_end = None;
-            player.wage = 0;
+            player.wage = expected_wage(player, team, current_date);
             player.transfer_listed = false;
             player.loan_listed = false;
             player.transfer_offers.clear();
@@ -510,7 +512,13 @@ pub fn process_contract_expiries(game: &mut Game) {
 }
 
 pub(crate) fn expected_wage(player: &Player, team: &Team, current_date: NaiveDate) -> u32 {
-    let mut wage = player.wage as f32;
+    let apply_minimum_floor = should_apply_minimum_expected_wage_floor(player, current_date);
+    let starting_wage = if apply_minimum_floor {
+        player.wage.max(minimum_expected_wage_floor(player))
+    } else {
+        player.wage
+    };
+    let mut wage = starting_wage as f32;
     let age = player_age_on(current_date, &player.date_of_birth);
     let remaining_days = remaining_contract_days(player, current_date);
 
@@ -537,7 +545,21 @@ pub(crate) fn expected_wage(player: &Player, team: &Team, current_date: NaiveDat
     }
 
     let rounded = round_up_to_nearest_thousand(wage.ceil() as u32);
-    rounded.max(player.wage)
+    let expected = rounded.max(player.wage);
+    if apply_minimum_floor {
+        expected.max(minimum_expected_wage_floor(player))
+    } else {
+        expected
+    }
+}
+
+fn should_apply_minimum_expected_wage_floor(player: &Player, current_date: NaiveDate) -> bool {
+    player.wage == 0 || player.team_id.is_none() || remaining_contract_days(player, current_date) == 0
+}
+
+fn minimum_expected_wage_floor(player: &Player) -> u32 {
+    let market_value_floor = (player.market_value / 20).min(u64::from(u32::MAX)) as u32;
+    round_up_to_nearest_thousand(market_value_floor.max(25_000))
 }
 
 fn importance_wage_multiplier(player: &Player) -> f32 {
@@ -820,4 +842,3 @@ fn contract_expired_message(
         vec![("player", player_name), ("team", team_name)],
     )
 }
-

--- a/src-tauri/crates/olm_core/src/db/save_manager.rs
+++ b/src-tauri/crates/olm_core/src/db/save_manager.rs
@@ -64,8 +64,7 @@ impl SaveManager {
 
     /// Read only the format version from an .olsave file (first 4 bytes).
     fn read_olsave_version(path: &Path) -> Result<u32, String> {
-        let mut file =
-            fs::File::open(path).map_err(|e| format!("Failed to open: {}", e))?;
+        let mut file = fs::File::open(path).map_err(|e| format!("Failed to open: {}", e))?;
         let mut buf = [0u8; 4];
         file.read_exact(&mut buf)
             .map_err(|e| format!("Failed to read version: {}", e))?;
@@ -88,17 +87,19 @@ impl SaveManager {
         let tmp_path = path.with_extension("olsave.tmp");
 
         // Serialize to JSON, then gzip
-        use flate2::write::GzEncoder;
         use flate2::Compression;
+        use flate2::write::GzEncoder;
         use std::io::Write;
 
         let json = serde_json::to_string(game)
             .map_err(|e| format!("Failed to JSON-serialize game: {e}"))?;
 
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(json.as_bytes())
+        encoder
+            .write_all(json.as_bytes())
             .map_err(|e| format!("Failed to gzip game: {e}"))?;
-        let compressed = encoder.finish()
+        let compressed = encoder
+            .finish()
             .map_err(|e| format!("Failed to finalize gzip: {e}"))?;
 
         let mut file = fs::File::create(&tmp_path)
@@ -116,24 +117,21 @@ impl SaveManager {
             .map_err(|e| format!("Failed to flush: {}", e))?;
 
         // Atomic rename: tmp → target
-        fs::rename(&tmp_path, path)
-            .map_err(|e| format!("Failed to rename temp file: {}", e))?;
+        fs::rename(&tmp_path, path).map_err(|e| format!("Failed to rename temp file: {}", e))?;
 
         Ok(())
     }
 
     /// Read a Game from a .olsave file.
     fn read_olsave(path: &Path) -> Result<Game, String> {
-        let file_size = fs::metadata(path)
-            .map(|m| m.len())
-            .unwrap_or(0);
-        let bytes = fs::read(path)
-            .unwrap_or_default();
+        let file_size = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        let bytes = fs::read(path).unwrap_or_default();
 
         if bytes.len() < 4 {
             return Err(format!(
                 "Save file too small: {} bytes (path={:?})",
-                bytes.len(), path
+                bytes.len(),
+                path
             ));
         }
 
@@ -142,7 +140,11 @@ impl SaveManager {
         let version = u32::from_le_bytes(version_bytes);
 
         // Dump first bytes for debugging
-        let hex_preview: Vec<String> = bytes.iter().take(32).map(|b| format!("{:02x}", b)).collect();
+        let hex_preview: Vec<String> = bytes
+            .iter()
+            .take(32)
+            .map(|b| format!("{:02x}", b))
+            .collect();
         let hex_str = hex_preview.join(" ");
 
         if version != FORMAT_VERSION {
@@ -159,11 +161,11 @@ impl SaveManager {
 
             let mut decoder = GzDecoder::new(&bytes[4..]);
             let mut json_str = String::new();
-            decoder.read_to_string(&mut json_str)
+            decoder
+                .read_to_string(&mut json_str)
                 .map_err(|e| format!("Failed to decompress save: {e}"))?;
 
-            serde_json::from_str(&json_str)
-                .map_err(|e| format!("Failed to parse JSON save: {e}"))
+            serde_json::from_str(&json_str).map_err(|e| format!("Failed to parse JSON save: {e}"))
         })() {
             Ok(g) => g,
             Err(e) => {
@@ -183,8 +185,12 @@ impl SaveManager {
         // Self-test: verify JSON roundtrip before writing to disk
         let json = serde_json::to_string(game)
             .map_err(|e| format!("[serde-test] JSON serialize failed: {e}"))?;
-        let back: Game = serde_json::from_str(&json)
-            .map_err(|e| format!("[serde-test] JSON deserialize failed ({}B JSON): {e}", json.len()))?;
+        let back: Game = serde_json::from_str(&json).map_err(|e| {
+            format!(
+                "[serde-test] JSON deserialize failed ({}B JSON): {e}",
+                json.len()
+            )
+        })?;
         if back.clock.current_date != game.clock.current_date {
             return Err("[serde-test] roundtrip mismatch: clock.current_date differs".into());
         }
@@ -252,10 +258,7 @@ impl SaveManager {
             .clone();
 
         let save_path = self.save_path(save_id);
-        info!(
-            "[save_manager] load_game: loading from {:?}",
-            save_path
-        );
+        info!("[save_manager] load_game: loading from {:?}", save_path);
 
         let mut game = Self::read_olsave(&save_path)?;
 
@@ -367,14 +370,16 @@ impl SaveManager {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::TimeZone;
-    use crate::domain::league::{Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry};
+    use crate::clock::GameClock;
+    use crate::domain::league::{
+        Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry,
+    };
     use crate::domain::manager::Manager;
     use crate::domain::player::{Player, PlayerAttributes};
     use crate::domain::staff::{Staff, StaffAttributes, StaffRole};
     use crate::domain::team::Team;
-    use crate::clock::GameClock;
     use crate::game::BoardObjective;
+    use chrono::TimeZone;
 
     fn sample_game() -> Game {
         let start = Utc.with_ymd_and_hms(2026, 7, 1, 0, 0, 0).unwrap();
@@ -457,6 +462,8 @@ mod tests {
             stats_state: Default::default(),
             competition_configs: std::collections::HashMap::new(),
             transfer_history: Default::default(),
+            ai_transfer_cap_counts: Default::default(),
+            ai_transfer_cap_last_reset_date: None,
         }
     }
 
@@ -781,7 +788,11 @@ mod tests {
 
         let result = SaveManager::read_olsave(&path);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Unsupported save format version"));
+        assert!(
+            result
+                .unwrap_err()
+                .contains("Unsupported save format version")
+        );
     }
 
     #[test]
@@ -796,13 +807,11 @@ mod tests {
         let path = saves_dir.join("corrupt.olsave");
         let mut f = fs::File::create(&path).unwrap();
         f.write_all(&1u32.to_le_bytes()).unwrap();
-        f.write_all(b"garbage data that is not valid bincode").unwrap();
+        f.write_all(b"garbage data that is not valid bincode")
+            .unwrap();
         drop(f);
 
         let result = SaveManager::read_olsave(&path);
         assert!(result.is_err());
     }
 }
-
-
-

--- a/src-tauri/crates/olm_core/src/domain/transfer_history.rs
+++ b/src-tauri/crates/olm_core/src/domain/transfer_history.rs
@@ -61,6 +61,9 @@ pub struct TransferHistoryEntry {
     pub negotiation_rounds: u8,
     #[serde(default)]
     pub included_players: Vec<IncludedPlayerEntry>,
+    /// Optional signing intent/reason used for news tagging.
+    #[serde(default)]
+    pub intent: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/crates/olm_core/src/game.rs
+++ b/src-tauri/crates/olm_core/src/game.rs
@@ -1,5 +1,6 @@
 use crate::champions::{ChampionMasteryEntry, ChampionPatchState};
 use crate::clock::GameClock;
+use crate::contract_wage_policy::AiTransferCapState;
 use crate::domain::league::League;
 use crate::domain::manager::Manager;
 use crate::domain::message::InboxMessage;
@@ -136,6 +137,13 @@ pub struct Game {
     pub competition_configs: HashMap<String, CompetitionManifest>,
     #[serde(default)]
     pub transfer_history: TransferHistory,
+    /// Per-team daily counters for AI-initiated transfers (strategic/FA/club-to-club
+    /// share one bucket; emergency repairs have a separate bucket).
+    #[serde(default)]
+    pub ai_transfer_cap_counts: HashMap<String, AiTransferCapState>,
+    /// Last in-game date for which `ai_transfer_cap_counts` was reset.
+    #[serde(default)]
+    pub ai_transfer_cap_last_reset_date: Option<String>,
 }
 
 /// Lenient deserializer for `competition_configs`.
@@ -193,6 +201,8 @@ impl Game {
             stats_state: StatsState::default(),
             competition_configs: HashMap::new(),
             transfer_history: TransferHistory::default(),
+            ai_transfer_cap_counts: HashMap::new(),
+            ai_transfer_cap_last_reset_date: None,
         };
         crate::identity_upgrade::upgrade_game_football_identities(&mut game);
         crate::season_context::refresh_game_context(&mut game);
@@ -205,7 +215,11 @@ impl Game {
     pub fn active_league(&self) -> Option<&League> {
         self.user_competition_id
             .as_ref()
-            .and_then(|cid| self.leagues.iter().find(|l| l.competition_id.as_deref() == Some(cid)))
+            .and_then(|cid| {
+                self.leagues
+                    .iter()
+                    .find(|l| l.competition_id.as_deref() == Some(cid))
+            })
             .or_else(|| self.leagues.first())
     }
 
@@ -213,7 +227,11 @@ impl Game {
     pub fn active_league_mut(&mut self) -> Option<&mut League> {
         let cid = self.user_competition_id.clone();
         if let Some(ref cid) = cid {
-            if let Some(pos) = self.leagues.iter().position(|l| l.competition_id.as_deref() == Some(cid)) {
+            if let Some(pos) = self
+                .leagues
+                .iter()
+                .position(|l| l.competition_id.as_deref() == Some(cid))
+            {
                 return self.leagues.get_mut(pos);
             }
         }
@@ -231,8 +249,11 @@ impl Game {
     pub fn active_league_index(&self) -> usize {
         self.user_competition_id
             .as_ref()
-            .and_then(|cid| self.leagues.iter().position(|l| l.competition_id.as_deref() == Some(cid)))
+            .and_then(|cid| {
+                self.leagues
+                    .iter()
+                    .position(|l| l.competition_id.as_deref() == Some(cid))
+            })
             .unwrap_or(0)
     }
 }
-

--- a/src-tauri/crates/olm_core/src/roster_stability.rs
+++ b/src-tauri/crates/olm_core/src/roster_stability.rs
@@ -1,8 +1,12 @@
+use crate::contract_wage_policy::{
+    AiTransferKind, SigningIntent, ai_signing_policy, ai_transfer_cap_try_consume,
+};
 use crate::domain::player::{Player, PlayerAttributes};
 use crate::domain::season::TransferWindowStatus;
 use crate::domain::stats::LolRole;
 use crate::domain::team::TeamKind;
 use crate::game::Game;
+use crate::transfers::record_transfer;
 use chrono::{Datelike, NaiveDate};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
@@ -34,6 +38,7 @@ pub enum RosterStabilityReason {
     PreMatch,
     BackgroundSimulation,
     LoadMigration,
+    Emergency,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -296,7 +301,7 @@ fn fill_missing_roles(
             .copied()
             .unwrap_or_else(|| first_uncovered_extra_role(game, team_id));
 
-        if let Some(player_id) = assign_free_agent(game, team_id, role) {
+        if let Some(player_id) = assign_free_agent(game, team_id, role, reason) {
             actions.push(RepairAction::AssignedFreeAgent { player_id, role });
         } else {
             let player_id = available_generated_player_id(game, team_id, reason, role)
@@ -309,7 +314,12 @@ fn fill_missing_roles(
     Ok(())
 }
 
-fn assign_free_agent(game: &mut Game, team_id: &str, role: LolRole) -> Option<String> {
+fn assign_free_agent(
+    game: &mut Game,
+    team_id: &str,
+    role: LolRole,
+    reason: RosterStabilityReason,
+) -> Option<String> {
     let current_date = current_date(game);
     let index = game
         .players
@@ -322,11 +332,76 @@ fn assign_free_agent(game: &mut Game, team_id: &str, role: LolRole) -> Option<St
         })
         .min_by(|(_, left), (_, right)| left.id.cmp(&right.id))
         .map(|(index, _)| index)?;
-    let contract_end = renewed_contract_end(game);
+
+    let team = game
+        .teams
+        .iter()
+        .find(|team| team.id == team_id)
+        .expect("repair team must exist")
+        .clone();
+
+    let intent = repair_signing_intent(reason);
+    let decision = ai_signing_policy(game, &team, &game.players[index], intent);
+    if !decision.accepted {
+        return None;
+    }
+
+    let cap_kind = if is_emergency_repair(reason) {
+        AiTransferKind::Emergency
+    } else {
+        AiTransferKind::Strategic
+    };
+    if !ai_transfer_cap_try_consume(game, team_id, cap_kind) {
+        return None;
+    }
+
+    let contract_end = contract_end_for_years(game, decision.contract_years);
     let player = &mut game.players[index];
+    let player_id = player.id.clone();
     player.team_id = Some(team_id.to_string());
     player.contract_end = Some(contract_end);
-    Some(player.id.clone())
+    player.wage = decision.annual_wage;
+
+    let intent = if is_emergency_repair(reason) {
+        Some("emergency")
+    } else {
+        None
+    };
+    record_transfer(
+        game,
+        &player_id,
+        "",
+        team_id,
+        0,
+        decision.annual_wage,
+        decision.contract_years,
+        false,
+        false,
+        false,
+        None,
+        0,
+        &[],
+        intent,
+    );
+
+    Some(player_id)
+}
+
+fn is_emergency_repair(reason: RosterStabilityReason) -> bool {
+    matches!(
+        reason,
+        RosterStabilityReason::Emergency
+            | RosterStabilityReason::ContractExpired
+            | RosterStabilityReason::TransferOut
+    )
+}
+
+fn repair_signing_intent(reason: RosterStabilityReason) -> SigningIntent {
+    if is_emergency_repair(reason) {
+        SigningIntent::Emergency
+    } else {
+        SigningIntent::Strategic
+    }
 }
 
 fn actions_require_transfer_window_exception(actions: &[RepairAction]) -> bool {
@@ -562,6 +637,15 @@ fn renewed_contract_end(game: &Game) -> String {
     format!("{}-{}", current.year() + 1, RENEWED_CONTRACT_END_MONTH_DAY)
 }
 
+fn contract_end_for_years(game: &Game, contract_years: u8) -> String {
+    let current = current_date(game);
+    format!(
+        "{}-{}",
+        current.year() + i32::from(contract_years.max(1)),
+        RENEWED_CONTRACT_END_MONTH_DAY
+    )
+}
+
 fn current_date(game: &Game) -> NaiveDate {
     game.clock.get_date().date_naive()
 }
@@ -588,6 +672,7 @@ fn reason_slug(reason: RosterStabilityReason) -> &'static str {
         RosterStabilityReason::PreMatch => "prematch",
         RosterStabilityReason::BackgroundSimulation => "background-simulation",
         RosterStabilityReason::LoadMigration => "load-migration",
+        RosterStabilityReason::Emergency => "emergency",
     }
 }
 

--- a/src-tauri/crates/olm_core/src/transfers.rs
+++ b/src-tauri/crates/olm_core/src/transfers.rs
@@ -1,17 +1,23 @@
-use crate::finances::{calc_annual_wages, record_transaction, BudgetImpact, FinanceTransactionInput};
-use crate::game::Game;
-use crate::roster_stability::{RosterStabilityReason, repair_team};
-use chrono::{Datelike, NaiveDate};
+use crate::contract_wage_policy::{
+    AiTransferKind, SigningIntent, ai_signing_policy, ai_transfer_cap_try_consume,
+};
+use crate::contracts::{expected_contract_years, expected_wage};
 use crate::domain::negotiation::{NegotiationFeedback, NegotiationMood};
 use crate::domain::player::{PlayerOfferItem, TransferOfferStatus, WageNegotiationStatus};
 use crate::domain::season::TransferWindowStatus;
 use crate::domain::stats::LolRole;
 use crate::domain::team::{FinancialTransactionKind, TeamKind};
 use crate::domain::transfer_history::{IncludedPlayerEntry, TransferHistoryEntry};
+use crate::finances::{
+    BudgetImpact, FinanceTransactionInput, calc_annual_wages, record_transaction,
+};
+use crate::game::Game;
+use crate::roster_stability::{RosterStabilityReason, repair_team};
+use chrono::{Datelike, NaiveDate};
 use rand_08::Rng;
 use serde::{Deserialize, Serialize};
-use std::collections::hash_map::DefaultHasher;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 
@@ -22,15 +28,19 @@ fn ai_random_contract_years() -> u8 {
 
 fn next_split_end_date(game: &Game) -> String {
     let current_date = game.clock.current_date.date_naive();
-    let league_name = game.leagues.first().and_then(|l| {
-        if l.name.contains("Winter") {
-            Some("Winter")
-        } else if l.name.contains("Spring") {
-            Some("Spring")
-        } else {
-            Some("Summer")
-        }
-    }).unwrap_or("Winter");
+    let league_name = game
+        .leagues
+        .first()
+        .and_then(|l| {
+            if l.name.contains("Winter") {
+                Some("Winter")
+            } else if l.name.contains("Spring") {
+                Some("Spring")
+            } else {
+                Some("Summer")
+            }
+        })
+        .unwrap_or("Winter");
 
     let next_split = match league_name {
         "Winter" => (current_date.year(), 3, 28),
@@ -181,7 +191,9 @@ fn calculate_player_offer_value(
         0.60
     };
 
-    let potential_gap = player.potential_base.saturating_sub(player.attributes.overall());
+    let potential_gap = player
+        .potential_base
+        .saturating_sub(player.attributes.overall());
     let potential_multiplier: f64 = if potential_gap >= 15 {
         1.20
     } else if potential_gap >= 10 {
@@ -248,7 +260,10 @@ fn player_move_openness_score(
     score
 }
 
-fn apply_blocked_move_consequences(player: &mut crate::domain::player::Player, openness_score: i32) {
+fn apply_blocked_move_consequences(
+    player: &mut crate::domain::player::Player,
+    openness_score: i32,
+) {
     if openness_score < 40 {
         return;
     }
@@ -295,7 +310,7 @@ fn incoming_interest_score(current_date: NaiveDate, player: &crate::domain::play
     score
 }
 
-fn suggested_incoming_fee(
+pub(crate) fn suggested_incoming_fee(
     current_date: NaiveDate,
     player: &crate::domain::player::Player,
     buyer_team: &crate::domain::team::Team,
@@ -343,7 +358,10 @@ fn suggested_incoming_fee(
     ((player.market_value as f64) * multiplier).round() as u64
 }
 
-fn has_open_incoming_offer_from_club(player: &crate::domain::player::Player, club_id: &str) -> bool {
+fn has_open_incoming_offer_from_club(
+    player: &crate::domain::player::Player,
+    club_id: &str,
+) -> bool {
     player
         .transfer_offers
         .iter()
@@ -501,28 +519,30 @@ fn upsert_transfer_offer(
     }
 
     let offer_id = Uuid::new_v4().to_string();
-    player.transfer_offers.push(crate::domain::player::TransferOffer {
-        id: offer_id.clone(),
-        from_team_id: from_team_id.to_string(),
-        destination_team_id: destination_team_id.map(str::to_string),
-        fee,
-        wage_offered: 0,
-        last_manager_fee,
-        negotiation_round,
-        suggested_counter_fee,
-        players_included: vec![],
-        status,
-        date: date.to_string(),
-        wage_negotiation_status: crate::domain::player::WageNegotiationStatus::NotStarted,
-        contract_years_offered: 0,
-        suggested_counter_wage: None,
-        suggested_counter_years: None,
-        wage_negotiation_round: 0,
-    });
+    player
+        .transfer_offers
+        .push(crate::domain::player::TransferOffer {
+            id: offer_id.clone(),
+            from_team_id: from_team_id.to_string(),
+            destination_team_id: destination_team_id.map(str::to_string),
+            fee,
+            wage_offered: 0,
+            last_manager_fee,
+            negotiation_round,
+            suggested_counter_fee,
+            players_included: vec![],
+            status,
+            date: date.to_string(),
+            wage_negotiation_status: crate::domain::player::WageNegotiationStatus::NotStarted,
+            contract_years_offered: 0,
+            suggested_counter_wage: None,
+            suggested_counter_years: None,
+            wage_negotiation_round: 0,
+        });
     offer_id
 }
 
-fn transfer_window_is_open(game: &Game) -> bool {
+pub(crate) fn transfer_window_is_open(game: &Game) -> bool {
     matches!(
         game.season_context.transfer_window.status,
         TransferWindowStatus::Open | TransferWindowStatus::DeadlineDay
@@ -747,24 +767,26 @@ pub fn generate_incoming_transfer_offers(game: &mut Game) {
 
         let offer_id = Uuid::new_v4().to_string();
 
-        player.transfer_offers.push(crate::domain::player::TransferOffer {
-            id: offer_id.clone(),
-            from_team_id: buyer_id.clone(),
-            destination_team_id: None,
-            fee: chosen_fee,
-            wage_offered: 0,
-            last_manager_fee: None,
-            negotiation_round: 1,
-            suggested_counter_fee: None,
-            players_included: vec![],
-            status: TransferOfferStatus::Pending,
-            date: today.clone(),
-            wage_negotiation_status: crate::domain::player::WageNegotiationStatus::NotStarted,
-            contract_years_offered: 0,
-            suggested_counter_wage: None,
-            suggested_counter_years: None,
-            wage_negotiation_round: 0,
-        });
+        player
+            .transfer_offers
+            .push(crate::domain::player::TransferOffer {
+                id: offer_id.clone(),
+                from_team_id: buyer_id.clone(),
+                destination_team_id: None,
+                fee: chosen_fee,
+                wage_offered: 0,
+                last_manager_fee: None,
+                negotiation_round: 1,
+                suggested_counter_fee: None,
+                players_included: vec![],
+                status: TransferOfferStatus::Pending,
+                date: today.clone(),
+                wage_negotiation_status: crate::domain::player::WageNegotiationStatus::NotStarted,
+                contract_years_offered: 0,
+                suggested_counter_wage: None,
+                suggested_counter_years: None,
+                wage_negotiation_round: 0,
+            });
 
         let player_name = player.match_name.clone();
         let buyer_name = buyer_team.name.clone();
@@ -876,6 +898,21 @@ fn simulate_ai_free_agent_signings(game: &mut Game, user_team_id: &str) {
             continue;
         };
 
+        let Some(player) = game.players.iter().find(|p| p.id == player_id) else {
+            continue;
+        };
+        let Some(team) = game.teams.iter().find(|t| t.id == team_id) else {
+            continue;
+        };
+        let decision = ai_signing_policy(game, &team, player, SigningIntent::Strategic);
+        if !decision.accepted {
+            continue;
+        }
+
+        if !ai_transfer_cap_try_consume(game, &team_id, AiTransferKind::FreeAgent) {
+            continue;
+        }
+
         if execute_free_agent_signing(game, &player_id, &team_id, fee).is_ok() {
             completed = completed.saturating_add(1);
         }
@@ -885,7 +922,7 @@ fn simulate_ai_free_agent_signings(game: &mut Game, user_team_id: &str) {
 /// Public wrapper for the Team Agent to purchase a free agent for a specific
 /// role. Returns `true` if a signing was executed.
 pub fn ai_agent_purchase(game: &mut Game, team_id: &str, role: &str) -> bool {
-    let Some(team) = game.teams.iter().find(|t| t.id == team_id) else {
+    let Some(team) = game.teams.iter().find(|t| t.id == team_id).cloned() else {
         return false;
     };
     let budget_cap = team.transfer_budget.min(team.finance);
@@ -909,6 +946,18 @@ pub fn ai_agent_purchase(game: &mut Game, team_id: &str, role: &str) -> bool {
         .max_by_key(|(_, fee, _)| *fee);
 
     if let Some((player_id, fee, _market_value)) = candidate {
+        let Some(player) = game.players.iter().find(|p| p.id == player_id) else {
+            return false;
+        };
+        let decision = ai_signing_policy(game, &team, player, SigningIntent::Casual);
+        if !decision.accepted {
+            return false;
+        }
+
+        if !ai_transfer_cap_try_consume(game, team_id, AiTransferKind::FreeAgent) {
+            return false;
+        }
+
         execute_free_agent_signing(game, &player_id, team_id, fee).is_ok()
     } else {
         false
@@ -932,7 +981,7 @@ fn simulate_ai_club_to_club_transfers(game: &mut Game, user_team_id: &str) {
             break;
         }
 
-        let Some(buyer_team) = game.teams.iter().find(|team| team.id == buyer_id) else {
+        let Some(buyer_team) = game.teams.iter().find(|team| team.id == buyer_id).cloned() else {
             continue;
         };
         let budget_cap = buyer_team.transfer_budget.min(buyer_team.finance);
@@ -968,7 +1017,7 @@ fn simulate_ai_club_to_club_transfers(game: &mut Game, user_team_id: &str) {
                     return None;
                 }
 
-                let fee = suggested_incoming_fee(current_date, player, buyer_team, &buyer_id);
+                let fee = suggested_incoming_fee(current_date, player, &buyer_team, &buyer_id);
                 if fee == 0 || (fee as i64) > budget_cap {
                     return None;
                 }
@@ -1012,7 +1061,7 @@ fn simulate_ai_club_to_club_transfers(game: &mut Game, user_team_id: &str) {
                     return None;
                 }
 
-                let fee = suggested_incoming_fee(current_date, player, buyer_team, &buyer_id);
+                let fee = suggested_incoming_fee(current_date, player, &buyer_team, &buyer_id);
                 if fee == 0 || (fee as i64) > budget_cap {
                     return None;
                 }
@@ -1038,13 +1087,25 @@ fn simulate_ai_club_to_club_transfers(game: &mut Game, user_team_id: &str) {
             continue;
         };
 
+        let Some(player) = game.players.iter().find(|p| p.id == player_id) else {
+            continue;
+        };
+        let decision = ai_signing_policy(game, &buyer_team, player, SigningIntent::Strategic);
+        if !decision.accepted {
+            continue;
+        }
+
+        if !ai_transfer_cap_try_consume(game, &buyer_id, AiTransferKind::ClubToClub) {
+            continue;
+        }
+
         if execute_transfer(game, &player_id, &buyer_id, &seller_id, fee, true).is_ok() {
             completed = completed.saturating_add(1);
         }
     }
 }
 
-fn ai_team_priority_role(game: &Game, team_id: &str) -> &'static str {
+pub(crate) fn ai_team_priority_role(game: &Game, team_id: &str) -> &'static str {
     let mut role_counts = [0_usize; 5];
 
     for player in &game.players {
@@ -1233,8 +1294,14 @@ pub fn make_transfer_bid(
                 .find(|p| p.id == pid.as_str() && p.team_id.as_deref() == Some(&user_team_id))
                 .ok_or_else(|| format!("Included player {} not found or not yours", pid))?;
 
-            if p.transfer_offers.iter().any(|o| o.status == TransferOfferStatus::Pending) {
-                return Err(format!("Player {} already has a pending transfer offer", pid));
+            if p.transfer_offers
+                .iter()
+                .any(|o| o.status == TransferOfferStatus::Pending)
+            {
+                return Err(format!(
+                    "Player {} already has a pending transfer offer",
+                    pid
+                ));
             }
 
             let days = contract_days_remaining(current_date, p.contract_end.as_deref())
@@ -1474,7 +1541,7 @@ pub fn make_transfer_bid(
     ))
 }
 
-fn execute_free_agent_signing(
+pub(crate) fn execute_free_agent_signing(
     game: &mut Game,
     player_id: &str,
     to_team_id: &str,
@@ -1490,21 +1557,31 @@ fn execute_free_agent_signing_with_payer(
     payer_team_id: &str,
     fee: u64,
 ) -> Result<(), String> {
+    let current_date = game.clock.current_date.date_naive();
+    let annual_wage;
+    let contract_years;
+
     if let Some(player) = game
         .players
         .iter_mut()
         .find(|player| player.id == player_id)
     {
+        let to_team = game
+            .teams
+            .iter()
+            .find(|team| team.id == to_team_id)
+            .ok_or("Destination team not found")?;
+        annual_wage = expected_wage(player, to_team, current_date);
+        contract_years = expected_contract_years(player, current_date) as u8;
+
         player.team_id = Some(to_team_id.to_string());
         player.transfer_listed = false;
         player.loan_listed = false;
         player
             .transfer_offers
             .retain(|offer| offer.status == TransferOfferStatus::Accepted);
-        if player.contract_end.is_none() {
-            let renewal_year = game.clock.current_date.year() + 2;
-            player.contract_end = Some(format!("{}-11-30", renewal_year));
-        }
+        player.contract_end = Some(contract_end_for_years(current_date, contract_years));
+        player.wage = annual_wage;
     } else {
         return Err("Player not found".to_string());
     }
@@ -1523,7 +1600,8 @@ fn execute_free_agent_signing_with_payer(
                 source_id: Some(player_id.to_string()),
                 correlation_id: Some(format!("transfer:{payer_team_id}:{player_id}:free-agent")),
             },
-        ).ok();
+        )
+        .ok();
     }
 
     let players_snapshot = game.players.clone();
@@ -1542,14 +1620,15 @@ fn execute_free_agent_signing_with_payer(
         "",
         to_team_id,
         0,
-        0,
-        1,
+        annual_wage,
+        contract_years,
         is_user_involved,
         is_user_buying,
         false,
         None,
         0,
         &[],
+        None,
     );
 
     Ok(())
@@ -1666,8 +1745,14 @@ pub fn counter_offer(
                 .find(|p| p.id == pid.as_str() && p.team_id.as_deref() == Some(&user_team_id))
                 .ok_or_else(|| format!("Included player {} not found or not yours", pid))?;
 
-            if p.transfer_offers.iter().any(|o| o.status == TransferOfferStatus::Pending) {
-                return Err(format!("Player {} already has a pending transfer offer", pid));
+            if p.transfer_offers
+                .iter()
+                .any(|o| o.status == TransferOfferStatus::Pending)
+            {
+                return Err(format!(
+                    "Player {} already has a pending transfer offer",
+                    pid
+                ));
             }
 
             let days = contract_days_remaining(current_date, p.contract_end.as_deref())
@@ -1715,9 +1800,9 @@ pub fn counter_offer(
         <= adjusted_ceiling
             .saturating_add(goodwill_margin)
             .min(budget_cap);
-    let counter_window =
-        ((adjusted_ceiling as f64) * if round >= 3 && stalled { 1.03 } else { 1.08 }).round()
-            as u64;
+    let counter_window = ((adjusted_ceiling as f64)
+        * if round >= 3 && stalled { 1.03 } else { 1.08 })
+    .round() as u64;
     let date = game.clock.current_date.format("%Y-%m-%d").to_string();
 
     if let Some(p) = game.players.iter_mut().find(|p| p.id == player_id)
@@ -1726,6 +1811,7 @@ pub fn counter_offer(
         if accepted {
             o.fee = requested_fee;
             o.status = TransferOfferStatus::Accepted;
+            o.destination_team_id = Some(o.from_team_id.clone());
             o.last_manager_fee = Some(requested_fee);
             o.negotiation_round = round;
             o.suggested_counter_fee = None;
@@ -1862,7 +1948,10 @@ fn calculate_wage_acceptance_score(
         score += 25;
     } else if let Some(team_id) = &player.team_id {
         if game.teams.iter().any(|t| t.id.as_str() == team_id.as_str()) {
-            let player_team = game.teams.iter().find(|t| t.id.as_str() == team_id.as_str());
+            let player_team = game
+                .teams
+                .iter()
+                .find(|t| t.id.as_str() == team_id.as_str());
             let is_academy = player_team
                 .map(|t| t.team_kind == TeamKind::Academy)
                 .unwrap_or(false);
@@ -1905,18 +1994,18 @@ fn calculate_wage_acceptance_score(
             } else if days_left <= 90 {
                 score += 10; // Contract expiring this season
             } else if days_left <= 180 {
-                score += 5;  // One year or less remaining
+                score += 5; // One year or less remaining
             }
         }
     }
 
     // Contract duration: longer commitments demand higher wages
     if contract_years == 1 {
-        score += 12;  // Short deal, willing to accept less
+        score += 12; // Short deal, willing to accept less
     } else if contract_years == 2 {
-        score += 8;  // Moderate commitment
+        score += 8; // Moderate commitment
     } else if contract_years == 3 {
-        score -= 3;  // Longer commitment, wants better pay
+        score -= 3; // Longer commitment, wants better pay
     } else if contract_years >= 4 {
         score -= 6; // Long-term lock-in, demands premium wages
     }
@@ -2017,6 +2106,17 @@ pub fn negotiate_player_wage(
         .destination_team_id
         .clone()
         .ok_or("No destination team")?;
+    let destination_is_user_academy = game
+        .teams
+        .iter()
+        .find(|team| team.id == destination_team_id)
+        .and_then(|team| team.parent_team_id.as_deref())
+        == Some(user_team_id.as_str());
+    let payer_team_id = if destination_team_id == user_team_id || destination_is_user_academy {
+        user_team_id.clone()
+    } else {
+        destination_team_id.clone()
+    };
 
     let offer_fee = offer.fee;
 
@@ -2043,7 +2143,7 @@ pub fn negotiate_player_wage(
             game,
             player_id,
             &destination_team_id,
-            &user_team_id,
+            &payer_team_id,
             player_team_id.as_deref(),
             offer_fee,
             annual_wage,
@@ -2068,13 +2168,8 @@ pub fn negotiate_player_wage(
         });
     }
 
-    let score = calculate_wage_acceptance_score(
-        current_date,
-        player,
-        annual_wage,
-        contract_years,
-        game,
-    );
+    let score =
+        calculate_wage_acceptance_score(current_date, player, annual_wage, contract_years, game);
 
     let previous_wage = if annual_wage > player.wage {
         Some(player.wage)
@@ -2088,8 +2183,8 @@ pub fn negotiate_player_wage(
             .map(|suggested| annual_wage <= suggested.saturating_add(50_000))
             .unwrap_or(false);
     // Stalled: offer barely above current wage (< 5% increase)
-    let stalled = previous_wage.is_some()
-        && annual_wage <= (player.wage as f64 * 1.05).round() as u32;
+    let stalled =
+        previous_wage.is_some() && annual_wage <= (player.wage as f64 * 1.05).round() as u32;
 
     let (tension, patience) = wage_negotiation_metrics(round, stalled, respected_signal);
 
@@ -2117,7 +2212,7 @@ pub fn negotiate_player_wage(
             game,
             player_id,
             &destination_team_id,
-            &user_team_id,
+            &payer_team_id,
             player_team_id.as_deref(),
             offer_fee,
             annual_wage,
@@ -2126,9 +2221,15 @@ pub fn negotiate_player_wage(
         )?;
 
         let (headline, detail) = if can_afford {
-            ("transfers.wageFeedbackAcceptedHeadline", "transfers.wageFeedbackAcceptedDetail")
+            (
+                "transfers.wageFeedbackAcceptedHeadline",
+                "transfers.wageFeedbackAcceptedDetail",
+            )
         } else {
-            ("transfers.wageFeedbackAcceptedOverBudgetHeadline", "transfers.wageFeedbackAcceptedOverBudgetDetail")
+            (
+                "transfers.wageFeedbackAcceptedOverBudgetHeadline",
+                "transfers.wageFeedbackAcceptedOverBudgetDetail",
+            )
         };
 
         return Ok(WageNegotiationOutcome {
@@ -2297,6 +2398,30 @@ fn complete_transfer_with_wage(
         .find(|p| p.id == player_id)
         .cloned()
         .ok_or("Player not found")?;
+    let from_id = from_team_id.unwrap_or("");
+    let from_team_name = game
+        .teams
+        .iter()
+        .find(|team| team.id == from_id)
+        .map(|team| team.name.clone())
+        .unwrap_or_else(|| from_id.to_string());
+    let to_team_name = game
+        .teams
+        .iter()
+        .find(|team| team.id == to_team_id)
+        .map(|team| team.name.clone())
+        .unwrap_or_else(|| to_team_id.to_string());
+    let academy_owner_id = game
+        .teams
+        .iter()
+        .find(|team| team.id == from_id && team.team_kind == TeamKind::Academy)
+        .and_then(|team| team.parent_team_id.clone());
+    let selling_team_is_academy = game
+        .teams
+        .iter()
+        .find(|team| team.id == from_id)
+        .map(|team| team.team_kind == TeamKind::Academy)
+        .unwrap_or(false);
 
     let current_date = game.clock.current_date.date_naive();
     let renewal_year = current_date.year() + contract_years as i32;
@@ -2324,16 +2449,23 @@ fn complete_transfer_with_wage(
                 affects_season_totals: false,
                 source: "transfer".to_string(),
                 source_id: Some(player_id.to_string()),
-                correlation_id: Some(format!("transfer:{payer_team_id}:{player_id}:{date}:purchase")),
+                correlation_id: Some(format!(
+                    "transfer:{payer_team_id}:{player_id}:{date}:purchase"
+                )),
             },
-        ).ok();
+        )
+        .ok();
     }
 
-    if let Some(from_id) = from_team_id {
+    if !from_id.is_empty() {
         if let Some(t) = game.teams.iter_mut().find(|t| t.id == from_id) {
             if let Some(pos) = t.active_lineup_ids.iter().position(|id| id == player_id) {
                 t.active_lineup_ids.remove(pos);
             }
+        }
+
+        let credit_target_id = academy_owner_id.as_deref().unwrap_or(from_id);
+        if let Some(t) = game.teams.iter_mut().find(|t| t.id == credit_target_id) {
             record_transaction(
                 t,
                 FinanceTransactionInput {
@@ -2347,10 +2479,17 @@ fn complete_transfer_with_wage(
                     affects_season_totals: false,
                     source: "transfer".to_string(),
                     source_id: Some(player_id.to_string()),
-                    correlation_id: Some(format!("transfer:{from_id}:{player_id}:{date}:sale")),
+                    correlation_id: Some(format!(
+                        "transfer:{credit_target_id}:{player_id}:{date}:sale"
+                    )),
                 },
-            ).ok();
+            )
+            .ok();
         }
+    }
+
+    if selling_team_is_academy {
+        ensure_academy_roster_continuity(game, from_id, &player_snapshot);
     }
 
     if let Some(t) = game.teams.iter_mut().find(|t| t.id == to_team_id) {
@@ -2368,14 +2507,7 @@ fn complete_transfer_with_wage(
     if let Some(ref offer) = offer {
         let seller_team = from_team_id.unwrap_or("");
         for item in &offer.players_included {
-            execute_transfer(
-                game,
-                &item.player_id,
-                seller_team,
-                payer_team_id,
-                0,
-                false,
-            )?;
+            execute_transfer(game, &item.player_id, seller_team, payer_team_id, 0, false)?;
         }
     }
 
@@ -2384,9 +2516,28 @@ fn complete_transfer_with_wage(
     game.messages.push(msg);
 
     let user_team_id = game.manager.team_id.clone().unwrap_or_default();
-    let from_id = from_team_id.unwrap_or("");
     let is_user_involved = from_id == user_team_id || to_team_id == user_team_id;
     let is_user_buying = to_team_id == user_team_id;
+
+    if should_generate_major_transfer_news(&player_snapshot, fee) {
+        let article_id = format!(
+            "transfer_news_{}_{}_{}_{}",
+            player_id, from_id, to_team_id, date
+        );
+        if !game.news.iter().any(|article| article.id == article_id) {
+            game.news.push(crate::news::major_transfer_article(
+                &article_id,
+                player_id,
+                &player_snapshot.match_name,
+                from_id,
+                &from_team_name,
+                to_team_id,
+                &to_team_name,
+                fee,
+                date,
+            ));
+        }
+    }
     let (initial_fee, neg_rounds, included_ids) = if let Some(ref o) = offer {
         (
             if o.fee > 0 && o.fee != fee {
@@ -2395,7 +2546,10 @@ fn complete_transfer_with_wage(
                 None
             },
             o.negotiation_round,
-            o.players_included.iter().map(|p| p.player_id.clone()).collect::<Vec<_>>(),
+            o.players_included
+                .iter()
+                .map(|p| p.player_id.clone())
+                .collect::<Vec<_>>(),
         )
     } else {
         (None, 1, Vec::new())
@@ -2415,6 +2569,7 @@ fn complete_transfer_with_wage(
         initial_fee,
         neg_rounds,
         &included_ids,
+        None,
     );
 
     Ok(())
@@ -2438,6 +2593,7 @@ pub fn record_transfer(
     initial_offer_fee: Option<u64>,
     negotiation_rounds: u8,
     included_player_ids: &[String],
+    intent: Option<&str>,
 ) {
     let player = match game.players.iter().find(|p| p.id == player_id) {
         Some(p) => p,
@@ -2498,6 +2654,7 @@ pub fn record_transfer(
         initial_offer_fee,
         negotiation_rounds,
         included_players,
+        intent: intent.map(str::to_string),
     };
 
     game.transfer_history.entries.insert(0, entry);
@@ -2537,7 +2694,10 @@ fn clear_player_from_active_lineup(team: &mut crate::domain::team::Team, player_
     }
 }
 
-fn reconcile_lol_active_lineup(team: &mut crate::domain::team::Team, players: &[crate::domain::player::Player]) {
+fn reconcile_lol_active_lineup(
+    team: &mut crate::domain::team::Team,
+    players: &[crate::domain::player::Player],
+) {
     const ROLES: [LolRole; 5] = [
         LolRole::Top,
         LolRole::Jungle,
@@ -2599,7 +2759,10 @@ fn current_team_player_by_id<'a>(
         .find(|player| player.id == player_id && player.team_id.as_deref() == Some(team_id))
 }
 
-fn remaining_contract_salary(player: &crate::domain::player::Player, current_date: NaiveDate) -> i64 {
+fn remaining_contract_salary(
+    player: &crate::domain::player::Player,
+    current_date: NaiveDate,
+) -> i64 {
     let days_remaining =
         contract_days_remaining(current_date, player.contract_end.as_deref()).unwrap_or(0);
 
@@ -2733,7 +2896,8 @@ pub fn release_player_contract(game: &mut Game, player_id: &str) -> Result<i64, 
                 source_id: Some(player_id.to_string()),
                 correlation_id: Some(format!("release:{owning_team_id}:{player_id}:{today}")),
             },
-        ).map_err(|err| format!("Failed to record release penalty: {err:?}"))?;
+        )
+        .map_err(|err| format!("Failed to record release penalty: {err:?}"))?;
     }
     remove_player_from_team_references(team, player_id);
 
@@ -2913,7 +3077,7 @@ fn build_transfer_feedback(
 }
 
 /// Transfer a player between teams, adjusting finances.
-fn execute_transfer(
+pub(crate) fn execute_transfer(
     game: &mut Game,
     player_id: &str,
     to_team_id: &str,
@@ -2922,7 +3086,16 @@ fn execute_transfer(
     record_history: bool,
 ) -> Result<(), String> {
     let contract_years = ai_random_contract_years();
-    execute_transfer_with_payer(game, player_id, to_team_id, from_team_id, fee, to_team_id, record_history, contract_years)
+    execute_transfer_with_payer(
+        game,
+        player_id,
+        to_team_id,
+        from_team_id,
+        fee,
+        to_team_id,
+        record_history,
+        contract_years,
+    )
 }
 
 fn execute_transfer_with_payer(
@@ -2975,6 +3148,14 @@ fn execute_transfer_with_payer(
         .unwrap_or_default();
 
     let next_split_date = next_split_end_date(game);
+    let current_date = game.clock.current_date.date_naive();
+    let contract_years = transfer_contract_years.max(1);
+    let annual_wage = game
+        .teams
+        .iter()
+        .find(|team| team.id == to_team_id)
+        .map(|to_team| expected_wage(&player_snapshot, to_team, current_date))
+        .unwrap_or(player_snapshot.wage);
 
     // Move player
     if let Some(p) = game.players.iter_mut().find(|p| p.id == player_id) {
@@ -2982,10 +3163,8 @@ fn execute_transfer_with_payer(
         p.transfer_listed = false;
         p.loan_listed = false;
         p.can_be_transferred_until = Some(next_split_date);
-        let current_date = game.clock.current_date.date_naive();
-        if let Some(new_date) = current_date.checked_add_months(chrono::Months::new(transfer_contract_years as u32 * 12)) {
-            p.contract_end = Some(format!("{}-11-30", new_date.year()));
-        }
+        p.contract_end = Some(contract_end_for_years(current_date, contract_years));
+        p.wage = annual_wage;
     }
 
     if !departing_starter_ids.is_empty() {
@@ -3011,9 +3190,12 @@ fn execute_transfer_with_payer(
                 affects_season_totals: false,
                 source: "transfer".to_string(),
                 source_id: Some(player_id.to_string()),
-                correlation_id: Some(format!("transfer:{payer_team_id}:{player_id}:{today}:purchase")),
+                correlation_id: Some(format!(
+                    "transfer:{payer_team_id}:{player_id}:{today}:purchase"
+                )),
             },
-        ).ok();
+        )
+        .ok();
     }
 
     let players_snapshot = game.players.clone();
@@ -3044,9 +3226,12 @@ fn execute_transfer_with_payer(
                 affects_season_totals: false,
                 source: "transfer".to_string(),
                 source_id: Some(player_id.to_string()),
-                correlation_id: Some(format!("transfer:{credit_target_id}:{player_id}:{today}:sale")),
+                correlation_id: Some(format!(
+                    "transfer:{credit_target_id}:{player_id}:{today}:sale"
+                )),
             },
-        ).ok();
+        )
+        .ok();
     }
 
     if selling_team_is_academy {
@@ -3095,16 +3280,30 @@ fn execute_transfer_with_payer(
             from_team_id,
             to_team_id,
             fee,
-            player_snapshot.wage,
-            0,
+            annual_wage,
+            contract_years,
             is_user_involved,
             is_user_buying,
             false,
             None,
             0,
             &[],
+            None,
         );
     }
 
     Ok(())
+}
+
+fn contract_end_for_years(current_date: NaiveDate, contract_years: u8) -> String {
+    if let Some(new_date) =
+        current_date.checked_add_months(chrono::Months::new(contract_years.max(1) as u32 * 12))
+    {
+        return format!("{}-11-30", new_date.year());
+    }
+
+    format!(
+        "{}-11-30",
+        current_date.year() + i32::from(contract_years.max(1))
+    )
 }

--- a/src-tauri/crates/olm_core/src/turn/mod.rs
+++ b/src-tauri/crates/olm_core/src/turn/mod.rs
@@ -1,10 +1,17 @@
-mod news;
+pub(crate) mod news;
 mod post_match;
 mod round_summary;
 
 use crate::board_objectives;
 use crate::champions;
+use crate::contract_wage_policy::ai_transfer_cap_reset_if_new_day;
+use crate::domain::league::{Fixture, FixtureStatus, League, MatchResult, MatchType};
+use crate::domain::message::{InboxMessage, MessageCategory, MessageContext, MessagePriority};
+use crate::domain::player::{LolRole as DomainLolRole, Player};
+use crate::domain::stats::StatsState;
+use crate::domain::team::{Team, TeamKind, TeamSeasonRecord};
 use crate::end_of_season;
+use crate::engine::LolRole as EngineLolRole;
 use crate::game::Game;
 use crate::player_events;
 use crate::potential;
@@ -14,12 +21,6 @@ use crate::scouting;
 use crate::training;
 use crate::transfers;
 use chrono::Datelike;
-use crate::domain::league::{Fixture, FixtureStatus, League, MatchResult, MatchType};
-use crate::domain::message::{InboxMessage, MessageCategory, MessageContext, MessagePriority};
-use crate::domain::player::{LolRole as DomainLolRole, Player};
-use crate::domain::stats::StatsState;
-use crate::domain::team::{Team, TeamKind, TeamSeasonRecord};
-use crate::engine::LolRole as EngineLolRole;
 use log::{debug, info};
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
@@ -52,10 +53,28 @@ fn snapshot_transfer_listed_player_ids(game: &Game) -> HashSet<String> {
         .collect()
 }
 
+/// Run strategic recruitment for every AI main team before the generic
+/// transfer simulation paths execute. Eligibility (reputation/tier/budget)
+/// is evaluated inside `ai_team_agent::ai_strategic_recruitment`.
+fn run_ai_strategic_recruitment(game: &mut Game) {
+    let team_ids: Vec<String> = game
+        .teams
+        .iter()
+        .filter(|team| team.team_kind == TeamKind::Main && team.manager_id.is_none())
+        .map(|team| team.id.clone())
+        .collect();
+
+    for team_id in team_ids {
+        crate::ai_team_agent::ai_strategic_recruitment(game, &team_id);
+    }
+}
+
 pub fn process_day_with_capture<F>(game: &mut Game, on_capture: &mut F)
 where
     F: FnMut(StatsState),
 {
+    ai_transfer_cap_reset_if_new_day(game);
+
     let today = game.clock.current_date.format("%Y-%m-%d").to_string();
 
     let has_match_today = game.active_league().is_some_and(|league| {
@@ -90,6 +109,7 @@ where
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    run_ai_strategic_recruitment(game);
     let previously_transfer_listed = snapshot_transfer_listed_player_ids(game);
     crate::ai_player_agent::process_ai_player_agents(game);
     crate::ai_team_agent::resolve_conflicts(game, &previously_transfer_listed);
@@ -116,6 +136,7 @@ where
 /// generates matchday news, pre-match messages, and advances the clock by one day.
 pub fn finish_live_match_day(game: &mut Game) {
     let today = game.clock.current_date.format("%Y-%m-%d").to_string();
+    ai_transfer_cap_reset_if_new_day(game);
     info!("[turn] finish_live_match_day: {}", today);
     generate_matchday_news(game, &today);
     maybe_schedule_playoffs(game);
@@ -134,6 +155,7 @@ pub fn finish_live_match_day(game: &mut Game) {
     scouting::process_scouting(game);
     transfers::generate_incoming_transfer_offers(game);
     crate::ai_team_agent::process_ai_team_agents(game);
+    run_ai_strategic_recruitment(game);
     let previously_transfer_listed = snapshot_transfer_listed_player_ids(game);
     crate::ai_player_agent::process_ai_player_agents(game);
     crate::ai_team_agent::resolve_conflicts(game, &previously_transfer_listed);
@@ -158,18 +180,32 @@ pub fn finish_live_match_day(game: &mut Game) {
 // Domain → Engine type conversion
 // ---------------------------------------------------------------------------
 
-fn build_engine_team_from(teams: &[Team], players: &[Player], team_id: &str) -> crate::engine::TeamData {
+fn build_engine_team_from(
+    teams: &[Team],
+    players: &[Player],
+    team_id: &str,
+) -> crate::engine::TeamData {
     let team = teams.iter().find(|t| t.id == team_id);
 
     let (name, draft_strategy) = match team {
         Some(t) => (
             t.name.clone(),
             match t.draft_strategy {
-                crate::domain::team::DraftStrategy::Aggressive => crate::engine::DraftStrategy::Aggressive,
-                crate::domain::team::DraftStrategy::Passive => crate::engine::DraftStrategy::Passive,
-                crate::domain::team::DraftStrategy::Scaling => crate::engine::DraftStrategy::Scaling,
-                crate::domain::team::DraftStrategy::CounterPick => crate::engine::DraftStrategy::CounterPick,
-                crate::domain::team::DraftStrategy::PriorityBans => crate::engine::DraftStrategy::PriorityBans,
+                crate::domain::team::DraftStrategy::Aggressive => {
+                    crate::engine::DraftStrategy::Aggressive
+                }
+                crate::domain::team::DraftStrategy::Passive => {
+                    crate::engine::DraftStrategy::Passive
+                }
+                crate::domain::team::DraftStrategy::Scaling => {
+                    crate::engine::DraftStrategy::Scaling
+                }
+                crate::domain::team::DraftStrategy::CounterPick => {
+                    crate::engine::DraftStrategy::CounterPick
+                }
+                crate::domain::team::DraftStrategy::PriorityBans => {
+                    crate::engine::DraftStrategy::PriorityBans
+                }
                 _ => crate::engine::DraftStrategy::Balanced,
             },
         ),
@@ -628,7 +664,6 @@ fn simulate_background_league(
             *home_wins,
             *away_wins,
         ));
-
     }
 
     for (home_team_id, away_team_id, home_wins, away_wins) in &completed_fixtures {
@@ -1304,9 +1339,7 @@ where
             team_id,
             crate::roster_stability::RosterStabilityReason::PreMatch,
         ) {
-            info!(
-                "[turn] pre-match repair failed for team {team_id}: {e}"
-            );
+            info!("[turn] pre-match repair failed for team {team_id}: {e}");
         }
     }
 
@@ -1526,9 +1559,9 @@ fn simulate_series(
 mod tests {
     use super::*;
     use crate::clock::GameClock;
-    use chrono::{TimeZone, Utc};
     use crate::domain::player::{Player, PlayerAttributes};
     use crate::domain::stats::LolRole;
+    use chrono::{TimeZone, Utc};
 
     fn make_player(id: &str, team_id: &str, overall: u8) -> Player {
         let attrs = PlayerAttributes {
@@ -1628,7 +1661,13 @@ mod tests {
         let season = 2025;
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(&mut game.teams, &mut game.players, league, &today_str, season);
+        simulate_background_league(
+            &mut game.teams,
+            &mut game.players,
+            league,
+            &today_str,
+            season,
+        );
 
         // The fixture should now be Completed with a result
         let fixture = &league.fixtures[0];
@@ -1646,7 +1685,13 @@ mod tests {
         let season = 2025;
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(&mut game.teams, &mut game.players, league, &today_str, season);
+        simulate_background_league(
+            &mut game.teams,
+            &mut game.players,
+            league,
+            &today_str,
+            season,
+        );
 
         // Both teams should have played=1
         let home_entry = league
@@ -1677,13 +1722,7 @@ mod tests {
         let season = 2025;
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(
-            &mut game.teams,
-            &game.players,
-            league,
-            &today_str,
-            season,
-        );
+        simulate_background_league(&mut game.teams, &game.players, league, &today_str, season);
 
         // Both teams should have form entries (W or L)
         let team1 = game.teams.iter().find(|t| t.id == "team1").unwrap();
@@ -1710,13 +1749,7 @@ mod tests {
             .collect();
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(
-            &mut game.teams,
-            &game.players,
-            league,
-            &today_str,
-            season,
-        );
+        simulate_background_league(&mut game.teams, &game.players, league, &today_str, season);
 
         // Player stats should be unchanged
         for (id, before_stats) in &before {
@@ -1740,13 +1773,7 @@ mod tests {
         let before_news = game.news.len();
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(
-            &mut game.teams,
-            &game.players,
-            league,
-            &today_str,
-            season,
-        );
+        simulate_background_league(&mut game.teams, &game.players, league, &today_str, season);
 
         // No messages or news should be generated
         assert_eq!(game.messages.len(), before_msgs);
@@ -1781,13 +1808,7 @@ mod tests {
         }
 
         let league = game.leagues.first_mut().unwrap();
-        simulate_background_league(
-            &mut game.teams,
-            &game.players,
-            league,
-            "2025-06-15",
-            season,
-        );
+        simulate_background_league(&mut game.teams, &game.players, league, "2025-06-15", season);
 
         // Fixture should still be Scheduled
         let fixture = &game.leagues[0].fixtures[0];

--- a/src-tauri/crates/olm_core/src/turn/news.rs
+++ b/src-tauri/crates/olm_core/src/turn/news.rs
@@ -1,8 +1,8 @@
+use crate::domain::league::{Fixture, FixtureStatus, League, StandingEntry};
 use crate::game::Game;
 use crate::messages;
 use crate::news;
 use chrono::Datelike;
-use crate::domain::league::{Fixture, FixtureStatus, League, StandingEntry};
 use std::collections::HashMap;
 
 fn completed_fixtures_for_day<'a>(league: &'a League, today: &str) -> Vec<&'a Fixture> {
@@ -423,27 +423,73 @@ pub(super) fn generate_ai_transfer_news(game: &mut Game) {
         params.insert("team".to_string(), team_name);
         params.insert("years".to_string(), entry.contract_years.to_string());
         params.insert("wage".to_string(), entry.annual_wage.to_string());
+        if let Some(ref intent) = entry.intent {
+            params.insert("intent".to_string(), intent.clone());
+        }
 
-        let article =
-            crate::domain::news::NewsArticle::new(
-                article_id,
-                String::new(),
-                String::new(),
-                String::new(),
-                date,
-                crate::domain::news::NewsCategory::TransferRumour,
-            )
-            .with_i18n(
-                "be.news.freeAgentSigned.headline",
-                "be.news.freeAgentSigned.body",
-                "be.source.leagueChronicle",
-                params,
-            )
-            .with_teams(vec![entry.to_team_id.clone()])
-            .with_players(vec![entry.player_id.clone()]);
+        let article = crate::domain::news::NewsArticle::new(
+            article_id,
+            String::new(),
+            String::new(),
+            String::new(),
+            date,
+            crate::domain::news::NewsCategory::TransferRumour,
+        )
+        .with_i18n(
+            "be.news.freeAgentSigned.headline",
+            "be.news.freeAgentSigned.body",
+            "be.source.leagueChronicle",
+            params,
+        )
+        .with_teams(vec![entry.to_team_id.clone()])
+        .with_players(vec![entry.player_id.clone()]);
 
         game.news.push(article);
     }
+}
+
+/// Generate a news article when an elite team strategically passes on a free agent
+/// because their impact does not meet the club's recruitment threshold.
+pub(crate) fn generate_strategic_rejection_news(game: &mut Game, team_id: &str, player_id: &str) {
+    let article_id = format!(
+        "ai_strategic_rejected_{}_{}",
+        team_id,
+        game.clock.current_date.format("%Y-%m-%d")
+    );
+    if game.news.iter().any(|n| n.id == article_id) {
+        return;
+    }
+
+    let player_name = player_match_name_or_id(game, player_id);
+    let team_name = team_name(game, team_id);
+    let date = game.clock.current_date.to_rfc3339();
+
+    let mut params = HashMap::new();
+    params.insert("player".to_string(), player_name.clone());
+    params.insert("team".to_string(), team_name.clone());
+    params.insert("intent".to_string(), "strategic".to_string());
+    params.insert("outcome".to_string(), "rejected".to_string());
+
+    let article = crate::domain::news::NewsArticle::new(
+        article_id,
+        format!("{team_name} pass on {player_name}"),
+        format!(
+            "{team_name} ended their strategic review of {player_name} without making an offer."
+        ),
+        "League Chronicle".to_string(),
+        date,
+        crate::domain::news::NewsCategory::TransferRumour,
+    )
+    .with_i18n(
+        "be.news.strategicRejection.headline",
+        "be.news.strategicRejection.body",
+        "be.source.leagueChronicle",
+        params,
+    )
+    .with_teams(vec![team_id.to_string()])
+    .with_players(vec![player_id.to_string()]);
+
+    game.news.push(article);
 }
 
 #[cfg(test)]
@@ -453,19 +499,19 @@ mod tests {
         generate_pre_match_messages, generate_weekly_digest_news,
     };
     use crate::clock::GameClock;
-    use crate::game::Game;
-    use chrono::{TimeZone, Utc};
     use crate::domain::league::{
-        Fixture, MatchType, FixtureStatus, League, MatchResult, StandingEntry,
+        Fixture, FixtureStatus, League, MatchResult, MatchType, StandingEntry,
     };
     use crate::domain::manager::Manager;
     use crate::domain::message::{MessageCategory, MessagePriority};
     use crate::domain::news::NewsCategory;
     use crate::domain::player::{LolRole, Player, PlayerAttributes};
     use crate::domain::team::Team;
+    use crate::domain::transfer_history::TransferHistoryEntry;
     use crate::engine::{KillDetail, MatchReport, MatchReportEndReason, Side, TeamStats};
-        use crate::domain::transfer_history::TransferHistoryEntry;
-        use std::collections::HashMap;
+    use crate::game::Game;
+    use chrono::{TimeZone, Utc};
+    use std::collections::HashMap;
 
     fn make_team(id: &str, name: &str) -> Team {
         Team::new(
@@ -1064,6 +1110,7 @@ mod tests {
         from_team_id: &str,
         to_team_id: &str,
         is_user_involved: bool,
+        intent: Option<&str>,
     ) -> TransferHistoryEntry {
         TransferHistoryEntry {
             id: id.to_string(),
@@ -1086,15 +1133,16 @@ mod tests {
             initial_offer_fee: None,
             negotiation_rounds: 0,
             included_players: vec![],
+            intent: intent.map(str::to_string),
         }
     }
 
     #[test]
     fn generate_ai_transfer_news_creates_article_for_ai_free_agent_signing() {
         let mut game = make_game("2025-08-12", FixtureStatus::Completed);
-        game.transfer_history.entries.push(make_transfer_entry(
-            "th1", "p1", "", "team2", false,
-        ));
+        game.transfer_history
+            .entries
+            .push(make_transfer_entry("th1", "p1", "", "team2", false, None));
         // Add a player and team for name resolution
         game.players.push(make_player("p1", "Alice", "team2"));
         game.teams.push(make_team("team2", "Beta FC"));
@@ -1119,16 +1167,16 @@ mod tests {
         );
         assert_eq!(article.team_ids, vec!["team2".to_string()]);
         assert_eq!(article.player_ids, vec!["p1".to_string()]);
-        assert_eq!(article.i18n_params.get("player"), Some(&"Alice".to_string()));
+        assert_eq!(
+            article.i18n_params.get("player"),
+            Some(&"Alice".to_string())
+        );
         assert_eq!(
             article.i18n_params.get("team"),
             Some(&"Beta FC".to_string())
         );
         assert_eq!(article.i18n_params.get("years"), Some(&"2".to_string()));
-        assert_eq!(
-            article.i18n_params.get("wage"),
-            Some(&"50000".to_string())
-        );
+        assert_eq!(article.i18n_params.get("wage"), Some(&"50000".to_string()));
     }
 
     #[test]
@@ -1136,7 +1184,7 @@ mod tests {
         let mut game = make_game("2025-08-12", FixtureStatus::Completed);
         game.transfer_history
             .entries
-            .push(make_transfer_entry("th1", "p1", "", "team1", true));
+            .push(make_transfer_entry("th1", "p1", "", "team1", true, None));
 
         game.players.push(make_player("p1", "Alice", "team1"));
 
@@ -1149,7 +1197,7 @@ mod tests {
     fn generate_ai_transfer_news_skips_club_to_club_transfer() {
         let mut game = make_game("2025-08-12", FixtureStatus::Completed);
         game.transfer_history.entries.push(make_transfer_entry(
-            "th1", "p1", "team3", "team2", false,
+            "th1", "p1", "team3", "team2", false, None,
         ));
 
         game.players.push(make_player("p1", "Alice", "team2"));
@@ -1162,9 +1210,9 @@ mod tests {
     #[test]
     fn generate_ai_transfer_news_deduplicates_on_repeat_call() {
         let mut game = make_game("2025-08-12", FixtureStatus::Completed);
-        game.transfer_history.entries.push(make_transfer_entry(
-            "th1", "p1", "", "team2", false,
-        ));
+        game.transfer_history
+            .entries
+            .push(make_transfer_entry("th1", "p1", "", "team2", false, None));
         game.players.push(make_player("p1", "Alice", "team2"));
         game.teams.push(make_team("team2", "Beta FC"));
 
@@ -1177,15 +1225,15 @@ mod tests {
     #[test]
     fn generate_ai_transfer_news_handles_multiple_signings() {
         let mut game = make_game("2025-08-12", FixtureStatus::Completed);
-        game.transfer_history.entries.push(make_transfer_entry(
-            "th1", "p1", "", "team2", false,
-        ));
-        game.transfer_history.entries.push(make_transfer_entry(
-            "th2", "p2", "", "team3", false,
-        ));
-        game.transfer_history.entries.push(make_transfer_entry(
-            "th3", "p3", "", "team2", false,
-        ));
+        game.transfer_history
+            .entries
+            .push(make_transfer_entry("th1", "p1", "", "team2", false, None));
+        game.transfer_history
+            .entries
+            .push(make_transfer_entry("th2", "p2", "", "team3", false, None));
+        game.transfer_history
+            .entries
+            .push(make_transfer_entry("th3", "p3", "", "team2", false, None));
         game.players.push(make_player("p1", "Alice", "team2"));
         game.players.push(make_player("p2", "Bob", "team3"));
         game.players.push(make_player("p3", "Carol", "team2"));
@@ -1201,6 +1249,3 @@ mod tests {
         assert!(ids.iter().any(|id| id.starts_with("ai_fa_signed_p3_")));
     }
 }
-
-
-

--- a/src-tauri/crates/olm_core/tests/ai_signing_policy_tests.rs
+++ b/src-tauri/crates/olm_core/tests/ai_signing_policy_tests.rs
@@ -1,0 +1,332 @@
+use chrono::{TimeZone, Utc};
+use olm_core::clock::GameClock;
+use olm_core::contract_wage_policy::{
+    AiTransferKind, SigningIntent, ai_signing_policy, ai_team_tier,
+    ai_transfer_cap_reset_if_new_day, ai_transfer_cap_try_consume, reputation_fit_ok,
+};
+use olm_core::domain::league::{
+    Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry,
+};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::game::Game;
+
+fn attrs() -> PlayerAttributes {
+    PlayerAttributes {
+        mental_resilience: 60,
+        champion_pool: 60,
+        laning: 60,
+        mechanics: 60,
+        macro_play: 60,
+        consistency: 60,
+        discipline: 60,
+        teamfighting: 60,
+        shotcalling: 60,
+    }
+}
+
+fn player(
+    id: &str,
+    team_id: Option<&str>,
+    role: LolRole,
+    lol_ovr: u8,
+    market_value: u64,
+) -> Player {
+    let mut player = Player::new(
+        id.to_string(),
+        id.to_string(),
+        format!("{id} Test"),
+        "2000-01-01".to_string(),
+        "Spain".to_string(),
+        role,
+        attrs(),
+    );
+    player.team_id = team_id.map(str::to_string);
+    player.wage = 50_000;
+    player.lol_ovr = lol_ovr;
+    player.market_value = market_value;
+    player
+}
+
+fn team(id: &str, reputation: u32) -> Team {
+    let mut team = Team::new(
+        id.to_string(),
+        format!("{id} Esports"),
+        id.chars().take(3).collect::<String>().to_uppercase(),
+        "Spain".to_string(),
+        "Madrid".to_string(),
+        "Arena".to_string(),
+        10_000,
+    );
+    team.reputation = reputation;
+    team.wage_budget = 500_000;
+    team.transfer_budget = 500_000;
+    team.finance = 500_000;
+    team
+}
+
+fn league_with_team(team_id: &str, tier: u8, competition_id: &str) -> League {
+    League {
+        id: "league-1".to_string(),
+        name: "League One".to_string(),
+        season: 2026,
+        fixtures: vec![Fixture {
+            id: "fixture-1".to_string(),
+            matchday: 1,
+            date: "2026-08-02".to_string(),
+            home_team_id: team_id.to_string(),
+            away_team_id: "other-ai".to_string(),
+            match_type: MatchType::League,
+            best_of: 1,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        }],
+        standings: vec![StandingEntry::new(team_id.to_string())],
+        competition_id: Some(competition_id.to_string()),
+        logo: None,
+        league_kind: LeagueKind::Main,
+        split_index: 0,
+        tier,
+        active: true,
+    }
+}
+
+fn game_with_team_and_player(team_reputation: u32, player: Player, league_tier: u8) -> Game {
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "manager-1".to_string(),
+        "Jane".to_string(),
+        "Doe".to_string(),
+        "1980-01-01".to_string(),
+        "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut home_team = team("ai-team", team_reputation);
+    home_team.competition_id = Some("competition-1".to_string());
+
+    let player_id = player.id.clone();
+    let player_ovr = player.lol_ovr;
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![home_team, team("other-ai", 500)],
+        vec![player],
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("ai-team", league_tier, "competition-1")];
+    game.user_competition_id = Some("competition-1".to_string());
+    if let Some(p) = game.players.iter_mut().find(|p| p.id == player_id) {
+        p.lol_ovr = player_ovr;
+    }
+    game
+}
+
+#[test]
+fn team_tier_uses_competition_id_when_available() {
+    let player = player("fa1", None, LolRole::Mid, 80, 1_000_000);
+    let game = game_with_team_and_player(1_200, player, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    assert_eq!(ai_team_tier(team, &game), 1);
+}
+
+#[test]
+fn team_tier_falls_back_to_reputation_bands() {
+    let player = player("fa1", None, LolRole::Mid, 80, 1_000_000);
+    let mut game = game_with_team_and_player(1_200, player, 1);
+    game.leagues.clear();
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    assert_eq!(ai_team_tier(team, &game), 1);
+}
+
+#[test]
+fn team_tier_reputation_fallback_maps_low_reputation_to_tier_three() {
+    let player = player("fa1", None, LolRole::Mid, 80, 1_000_000);
+    let mut game = game_with_team_and_player(500, player, 1);
+    game.leagues.clear();
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    assert_eq!(ai_team_tier(team, &game), 3);
+}
+
+#[test]
+fn emergency_intent_ignores_reputation_fit() {
+    let low_impact = player("fa1", None, LolRole::Support, 60, 100_000);
+    let game = game_with_team_and_player(1_200, low_impact, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    assert!(reputation_fit_ok(
+        team,
+        player_ref,
+        SigningIntent::Emergency,
+        &game
+    ));
+}
+
+#[test]
+fn strategic_intent_blocks_low_impact_at_tier_one_high_reputation() {
+    let low_impact = player("fa1", None, LolRole::Support, 60, 100_000);
+    let game = game_with_team_and_player(1_200, low_impact, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    assert!(!reputation_fit_ok(
+        team,
+        player_ref,
+        SigningIntent::Strategic,
+        &game
+    ));
+}
+
+#[test]
+fn strategic_intent_allows_high_impact_at_tier_one_high_reputation() {
+    let high_impact = player("fa1", None, LolRole::Mid, 85, 2_000_000);
+    let game = game_with_team_and_player(1_200, high_impact, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    assert!(reputation_fit_ok(
+        team,
+        player_ref,
+        SigningIntent::Strategic,
+        &game
+    ));
+}
+
+#[test]
+fn casual_intent_allows_low_impact_at_tier_one() {
+    let low_impact = player("fa1", None, LolRole::Support, 60, 100_000);
+    let game = game_with_team_and_player(1_200, low_impact, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    assert!(reputation_fit_ok(
+        team,
+        player_ref,
+        SigningIntent::Casual,
+        &game
+    ));
+}
+
+#[test]
+fn signing_policy_accepts_when_budget_and_fit_ok() {
+    let fa = player("fa1", None, LolRole::Mid, 80, 1_000_000);
+    let game = game_with_team_and_player(1_100, fa, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    let decision = ai_signing_policy(&game, team, player_ref, SigningIntent::Casual);
+    assert!(decision.accepted);
+    assert!(decision.annual_wage > 0);
+    assert!(decision.contract_years >= 1 && decision.contract_years <= 5);
+}
+
+#[test]
+fn signing_policy_rejects_when_wage_budget_exceeded() {
+    let mut fa = player("fa1", None, LolRole::Mid, 95, 5_000_000);
+    fa.wage = 2_000_000;
+    let mut game = game_with_team_and_player(1_100, fa, 1);
+    game.teams
+        .iter_mut()
+        .find(|t| t.id == "ai-team")
+        .unwrap()
+        .wage_budget = 100_000;
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    let decision = ai_signing_policy(&game, team, player_ref, SigningIntent::Casual);
+    assert!(!decision.accepted);
+}
+
+#[test]
+fn signing_policy_rejects_strategic_low_impact_at_tier_one() {
+    let low_impact = player("fa1", None, LolRole::Support, 60, 100_000);
+    let game = game_with_team_and_player(1_200, low_impact, 1);
+    let team = game.teams.iter().find(|t| t.id == "ai-team").unwrap();
+    let player_ref = game.players.iter().find(|p| p.id == "fa1").unwrap();
+    let decision = ai_signing_policy(&game, team, player_ref, SigningIntent::Strategic);
+    assert!(!decision.accepted);
+}
+
+#[test]
+fn transfer_cap_allows_up_to_two_strategic_signings_per_day() {
+    let mut game =
+        game_with_team_and_player(1_100, player("fa1", None, LolRole::Mid, 80, 1_000_000), 1);
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+    assert!(!ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+}
+
+#[test]
+fn emergency_cap_is_independent_from_strategic_cap() {
+    let mut game =
+        game_with_team_and_player(1_100, player("fa1", None, LolRole::Mid, 80, 1_000_000), 1);
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::Emergency
+    ));
+    assert!(!ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::Emergency
+    ));
+}
+
+#[test]
+fn transfer_cap_resets_on_new_day() {
+    let mut game =
+        game_with_team_and_player(1_100, player("fa1", None, LolRole::Mid, 80, 1_000_000), 1);
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+
+    game.clock.current_date = Utc.with_ymd_and_hms(2026, 8, 2, 12, 0, 0).unwrap();
+    ai_transfer_cap_reset_if_new_day(&mut game);
+
+    assert!(ai_transfer_cap_try_consume(
+        &mut game,
+        "ai-team",
+        AiTransferKind::FreeAgent
+    ));
+}
+
+#[test]
+fn transfer_cap_state_tracks_counts_per_team() {
+    let mut game =
+        game_with_team_and_player(1_100, player("fa1", None, LolRole::Mid, 80, 1_000_000), 1);
+    ai_transfer_cap_try_consume(&mut game, "ai-team", AiTransferKind::FreeAgent);
+    let state = game
+        .ai_transfer_cap_counts
+        .get("ai-team")
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(state.strategic_count, 1);
+    assert_eq!(state.emergency_count, 0);
+}

--- a/src-tauri/crates/olm_core/tests/contracts_tests.rs
+++ b/src-tauri/crates/olm_core/tests/contracts_tests.rs
@@ -1,14 +1,16 @@
 use chrono::{TimeZone, Utc};
-use olm_core::domain::manager::Manager;
-use olm_core::domain::player::{ContractRenewalState, Player, PlayerAttributes, RenewalSessionStatus};
-use olm_core::domain::staff::{Staff, StaffAttributes, StaffRole};
-use olm_core::domain::stats::LolRole;
-use olm_core::domain::team::Team;
 use olm_core::clock::GameClock;
 use olm_core::contracts::{
     DelegatedRenewalOptions, DelegatedRenewalResultStatus, RenewalDecision, RenewalOffer,
-    delegate_renewals, evaluate_renewal_offer, propose_renewal,
+    delegate_renewals, evaluate_renewal_offer, process_contract_expiries, propose_renewal,
 };
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{
+    ContractRenewalState, Player, PlayerAttributes, RenewalSessionStatus,
+};
+use olm_core::domain::staff::{Staff, StaffAttributes, StaffRole};
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
 use olm_core::game::Game;
 
 fn default_attrs() -> PlayerAttributes {
@@ -436,26 +438,69 @@ fn renewal_is_blocked_when_offer_pushes_healthy_club_far_over_soft_cap() {
 }
 
 #[test]
-fn renewal_allows_small_increase_for_legacy_over_budget_saves() {
+fn expired_contract_preserves_non_zero_wage() {
     let mut game = make_game();
-    game.teams[0].wage_budget = 50_000;
-    game.players[0].wage = 48_000;
-    game.players
-        .push(make_player_with("player-2", 40_000, "2027-06-30"));
+    game.players[0].wage = 1_500_000;
+    game.players[0].contract_end = Some("2026-07-31".to_string());
 
-    let outcome = propose_renewal(
-        &mut game,
-        "player-1",
-        RenewalOffer {
-            annual_wage: 70_000,
-            contract_years: 2,
-        },
-    );
+    process_contract_expiries(&mut game);
 
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "player-1")
+        .unwrap();
+    assert!(player.team_id.is_none());
+    assert!(player.contract_end.is_none());
     assert!(
-        outcome.is_ok(),
-        "legacy saves should allow manageable wage increases without policy lock"
+        player.wage > 0,
+        "expired player should retain non-zero wage, got {}",
+        player.wage
     );
+}
+
+#[test]
+fn expired_contract_wage_reflects_expected_wage_multipliers() {
+    let mut game = make_game();
+    game.players[0].wage = 100_000;
+    game.players[0].market_value = 2_000_000;
+    game.players[0].morale = 40;
+    game.players[0].date_of_birth = "2002-01-01".to_string();
+    game.players[0].contract_end = Some("2026-07-31".to_string());
+    game.teams[0].reputation = 30;
+
+    process_contract_expiries(&mut game);
+
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "player-1")
+        .unwrap();
+    // 100_000 * 1.05 (age <= 27) * 1.10 (morale <= 50) * 1.18 (market_value >= 2M)
+    // * 1.05 (reputation < 40) * 1.10 (remaining_days <= 180) = 158_000 after rounding.
+    assert_eq!(player.wage, 158_000);
+}
+
+#[test]
+fn expired_contract_wage_floor_is_previous_wage() {
+    let mut game = make_game();
+    game.players[0].wage = 1_500_000;
+    game.players[0].market_value = 100_000;
+    game.players[0].morale = 80;
+    game.players[0].date_of_birth = "1990-01-01".to_string();
+    game.players[0].contract_end = Some("2026-07-31".to_string());
+    game.teams[0].reputation = 50;
+
+    process_contract_expiries(&mut game);
+
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "player-1")
+        .unwrap();
+    // Multipliers would push computed wage below the previous wage, so the max()
+    // floor preserves the original asking baseline.
+    assert_eq!(player.wage, 1_500_000);
 }
 
 #[test]

--- a/src-tauri/crates/olm_core/tests/roster_stability_tests.rs
+++ b/src-tauri/crates/olm_core/tests/roster_stability_tests.rs
@@ -12,6 +12,7 @@ use olm_core::game::Game;
 use olm_core::roster_stability::{
     RepairAction, RosterStabilityReason, evaluate_team, repair_league, repair_team,
 };
+use olm_core::transfers::get_transfer_history;
 
 fn attrs() -> PlayerAttributes {
     PlayerAttributes {
@@ -192,6 +193,7 @@ fn missing_role_prefers_role_fit_free_agent() {
     ];
     players[5].market_value = 100_000;
     let mut game = game_with(players, vec!["top", "jungle", "mid", "adc", "adc2"]);
+    game.teams[0].wage_budget = 1_000_000;
 
     let report = repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
         .expect("free support should repair role gap");
@@ -782,22 +784,22 @@ fn load_migration_repairs_ai_team_with_four_players_and_stale_lineup() {
     );
 
     // Before repair: not match eligible, stale lineup
-    let before =
-        evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
-            .expect("team should evaluate before repair");
+    let before = evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+        .expect("team should evaluate before repair");
     assert!(!before.match_eligible);
-    assert!(before
-        .stale_lineup_ids
-        .contains(&"stale-player-id".to_string()));
+    assert!(
+        before
+            .stale_lineup_ids
+            .contains(&"stale-player-id".to_string())
+    );
 
     // WHEN repair_league runs with LoadMigration reason
     let reports = repair_league(&mut game, RosterStabilityReason::LoadMigration)
         .expect("load migration should repair the league");
 
     // THEN the team is match eligible (5 players, valid lineup)
-    let after =
-        evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
-            .expect("team should evaluate after repair");
+    let after = evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+        .expect("team should evaluate after repair");
     assert!(after.match_eligible);
     assert_eq!(after.eligible_player_count, 5);
     assert!(after.stale_lineup_ids.is_empty());
@@ -863,30 +865,15 @@ fn load_migration_does_not_generate_emergency_players_for_user_team() {
             player("mid", Some("user-team"), LolRole::Mid, Some("2028-06-30")),
             player("adc", Some("user-team"), LolRole::Adc, Some("2028-06-30")),
             // AI team players — only 4, missing support
-            player(
-                "a-top",
-                Some("ai-team"),
-                LolRole::Top,
-                Some("2028-06-30"),
-            ),
+            player("a-top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
             player(
                 "a-jungle",
                 Some("ai-team"),
                 LolRole::Jungle,
                 Some("2028-06-30"),
             ),
-            player(
-                "a-mid",
-                Some("ai-team"),
-                LolRole::Mid,
-                Some("2028-06-30"),
-            ),
-            player(
-                "a-adc",
-                Some("ai-team"),
-                LolRole::Adc,
-                Some("2028-06-30"),
-            ),
+            player("a-mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+            player("a-adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
         ],
         vec![],
         vec![],
@@ -898,9 +885,8 @@ fn load_migration_does_not_generate_emergency_players_for_user_team() {
     game.user_competition_id = Some("competition-1".to_string());
 
     // Verify user team is ineligible before (no repair expected for user teams)
-    let user_before =
-        evaluate_team(&game, "user-team", RosterStabilityReason::LoadMigration)
-            .expect("user team should evaluate");
+    let user_before = evaluate_team(&game, "user-team", RosterStabilityReason::LoadMigration)
+        .expect("user team should evaluate");
     assert!(!user_before.match_eligible);
 
     // WHEN repair_league runs with LoadMigration
@@ -908,9 +894,8 @@ fn load_migration_does_not_generate_emergency_players_for_user_team() {
         .expect("load migration should succeed");
 
     // THEN the AI team is repaired and match eligible
-    let ai_after =
-        evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
-            .expect("ai-team should evaluate");
+    let ai_after = evaluate_team(&game, "ai-team", RosterStabilityReason::LoadMigration)
+        .expect("ai-team should evaluate");
     assert!(
         ai_after.match_eligible,
         "AI team should be eligible after load migration"
@@ -960,30 +945,15 @@ fn pre_match_repair_fixes_invalid_ai_opponent() {
             player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
             player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
             // opponent (other-ai) is missing support
-            player(
-                "o-top",
-                Some("other-ai"),
-                LolRole::Top,
-                Some("2028-06-30"),
-            ),
+            player("o-top", Some("other-ai"), LolRole::Top, Some("2028-06-30")),
             player(
                 "o-jungle",
                 Some("other-ai"),
                 LolRole::Jungle,
                 Some("2028-06-30"),
             ),
-            player(
-                "o-mid",
-                Some("other-ai"),
-                LolRole::Mid,
-                Some("2028-06-30"),
-            ),
-            player(
-                "o-adc",
-                Some("other-ai"),
-                LolRole::Adc,
-                Some("2028-06-30"),
-            ),
+            player("o-mid", Some("other-ai"), LolRole::Mid, Some("2028-06-30")),
+            player("o-adc", Some("other-ai"), LolRole::Adc, Some("2028-06-30")),
         ],
         vec!["top", "jungle", "mid", "adc", "adc"], // ai-team has adc-duplicate lineup
     );
@@ -1004,9 +974,8 @@ fn pre_match_repair_fixes_invalid_ai_opponent() {
     });
 
     // Before: other-ai is not match eligible (missing support)
-    let other_before =
-        evaluate_team(&game, "other-ai", RosterStabilityReason::PreMatch)
-            .expect("other-ai should evaluate");
+    let other_before = evaluate_team(&game, "other-ai", RosterStabilityReason::PreMatch)
+        .expect("other-ai should evaluate");
     assert!(!other_before.match_eligible);
 
     // WHEN pre-match repair runs on the opponent
@@ -1014,9 +983,8 @@ fn pre_match_repair_fixes_invalid_ai_opponent() {
         .expect("pre-match repair should fix opponent roster");
 
     // THEN the opponent is match eligible
-    let other_after =
-        evaluate_team(&game, "other-ai", RosterStabilityReason::PreMatch)
-            .expect("other-ai should evaluate after repair");
+    let other_after = evaluate_team(&game, "other-ai", RosterStabilityReason::PreMatch)
+        .expect("other-ai should evaluate after repair");
     assert!(
         other_after.match_eligible,
         "opponent should be eligible after pre-match repair"
@@ -1125,30 +1093,15 @@ fn background_simulation_repair_fixes_all_ai_teams() {
             player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
             player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
             // other-ai is missing support
-            player(
-                "o-top",
-                Some("other-ai"),
-                LolRole::Top,
-                Some("2028-06-30"),
-            ),
+            player("o-top", Some("other-ai"), LolRole::Top, Some("2028-06-30")),
             player(
                 "o-jungle",
                 Some("other-ai"),
                 LolRole::Jungle,
                 Some("2028-06-30"),
             ),
-            player(
-                "o-mid",
-                Some("other-ai"),
-                LolRole::Mid,
-                Some("2028-06-30"),
-            ),
-            player(
-                "o-adc",
-                Some("other-ai"),
-                LolRole::Adc,
-                Some("2028-06-30"),
-            ),
+            player("o-mid", Some("other-ai"), LolRole::Mid, Some("2028-06-30")),
+            player("o-adc", Some("other-ai"), LolRole::Adc, Some("2028-06-30")),
         ],
         vec!["top", "jungle", "mid", "adc"],
     );
@@ -1158,24 +1111,32 @@ fn background_simulation_repair_fixes_all_ai_teams() {
         .push(StandingEntry::new("other-ai".to_string()));
 
     // Verify both teams are ineligible before repair
-    let ai_before =
-        evaluate_team(&game, "ai-team", RosterStabilityReason::BackgroundSimulation)
-            .expect("ai-team should evaluate");
+    let ai_before = evaluate_team(
+        &game,
+        "ai-team",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("ai-team should evaluate");
     assert!(!ai_before.match_eligible);
-    let other_before =
-        evaluate_team(&game, "other-ai", RosterStabilityReason::BackgroundSimulation)
-            .expect("other-ai should evaluate");
+    let other_before = evaluate_team(
+        &game,
+        "other-ai",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("other-ai should evaluate");
     assert!(!other_before.match_eligible);
 
     // WHEN repair_league runs with BackgroundSimulation reason
-    let reports =
-        repair_league(&mut game, RosterStabilityReason::BackgroundSimulation)
-            .expect("background simulation repair should succeed");
+    let reports = repair_league(&mut game, RosterStabilityReason::BackgroundSimulation)
+        .expect("background simulation repair should succeed");
 
     // THEN all AI teams are match eligible
-    let ai_after =
-        evaluate_team(&game, "ai-team", RosterStabilityReason::BackgroundSimulation)
-            .expect("ai-team should evaluate after repair");
+    let ai_after = evaluate_team(
+        &game,
+        "ai-team",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("ai-team should evaluate after repair");
     assert!(
         ai_after.match_eligible,
         "ai-team should be eligible after background simulation repair"
@@ -1185,9 +1146,12 @@ fn background_simulation_repair_fixes_all_ai_teams() {
         "ai-team should have 5 eligible players"
     );
 
-    let other_after =
-        evaluate_team(&game, "other-ai", RosterStabilityReason::BackgroundSimulation)
-            .expect("other-ai should evaluate after repair");
+    let other_after = evaluate_team(
+        &game,
+        "other-ai",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("other-ai should evaluate after repair");
     assert!(
         other_after.match_eligible,
         "other-ai should be eligible after background simulation repair"
@@ -1205,5 +1169,205 @@ fn background_simulation_repair_fixes_all_ai_teams() {
     assert!(
         reports.iter().any(|r| r.team_id == "other-ai"),
         "other-ai should have a repair report"
+    );
+}
+
+#[test]
+fn repair_assigns_free_agent_with_non_zero_wage_and_term() {
+    let mut players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "jungle",
+            Some("ai-team"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("adc2", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("free-support", None, LolRole::Support, Some("2028-06-30")),
+    ];
+    players[5].wage = 100_000;
+    players[5].market_value = 2_000_000;
+    players[5].morale = 40;
+    players[5].date_of_birth = "2002-01-01".to_string();
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc", "adc2"]);
+    game.teams[0].reputation = 30;
+    game.teams[0].wage_budget = 1_000_000;
+
+    repair_team(&mut game, "ai-team", RosterStabilityReason::PreMatch)
+        .expect("free support should repair role gap");
+
+    let assigned = game
+        .players
+        .iter()
+        .find(|player| player.id == "free-support")
+        .unwrap();
+    assert_eq!(assigned.team_id.as_deref(), Some("ai-team"));
+    // 100_000 * 1.05 (age <= 27) * 1.10 (morale <= 50) * 1.18 (market_value >= 2M)
+    // * 1.05 (reputation < 40) = 144_000 after rounding.
+    assert_eq!(assigned.wage, 144_000);
+    assert!(assigned.contract_end.is_some());
+}
+
+#[test]
+fn repair_assigns_free_agent_with_history_terms_matching_player_state() {
+    let mut players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "jungle",
+            Some("ai-team"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("adc2", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+        player("free-support", None, LolRole::Support, Some("2028-06-30")),
+    ];
+    players[5].wage = 120_000;
+    players[5].market_value = 600_000;
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc", "adc2"]);
+    game.teams[0].wage_budget = 1_000_000;
+
+    repair_team(&mut game, "ai-team", RosterStabilityReason::ContractExpired)
+        .expect("free support should repair role gap");
+
+    let assigned = game
+        .players
+        .iter()
+        .find(|player| player.id == "free-support")
+        .unwrap();
+    let entry = get_transfer_history(&game)
+        .into_iter()
+        .find(|entry| entry.player_id == "free-support")
+        .expect("repair signing should be recorded in transfer history");
+    assert_eq!(
+        assigned.wage, entry.annual_wage,
+        "player wage and history annual_wage must match"
+    );
+    assert!(
+        entry.contract_years > 0,
+        "history contract_years should be realistic, got {}",
+        entry.contract_years
+    );
+    assert!(
+        assigned
+            .contract_end
+            .as_ref()
+            .is_some_and(|contract_end| contract_end
+                .starts_with(&(2026 + i32::from(entry.contract_years)).to_string())),
+        "player contract_end must match history contract_years"
+    );
+}
+
+fn elite_game_with_low_impact_free_agent(reason: RosterStabilityReason) -> (Game, String) {
+    let mut players = vec![
+        player("top", Some("ai-team"), LolRole::Top, Some("2028-06-30")),
+        player(
+            "jungle",
+            Some("ai-team"),
+            LolRole::Jungle,
+            Some("2028-06-30"),
+        ),
+        player("mid", Some("ai-team"), LolRole::Mid, Some("2028-06-30")),
+        player("adc", Some("ai-team"), LolRole::Adc, Some("2028-06-30")),
+    ];
+    let mut free_agent = player("free-support", None, LolRole::Support, Some("2028-06-30"));
+    free_agent.wage = 30_000;
+    free_agent.market_value = 100_000;
+    free_agent.lol_ovr = 60;
+    players.push(free_agent);
+
+    let mut game = game_with(players, vec!["top", "jungle", "mid", "adc"]);
+    game.teams[0].reputation = 1_200;
+    game.teams[0].competition_id = Some("competition-1".to_string());
+    game.teams[0].wage_budget = 500_000;
+    game.leagues = vec![League {
+        id: "league-1".to_string(),
+        name: "League One".to_string(),
+        season: 2026,
+        fixtures: vec![Fixture {
+            id: "fixture-1".to_string(),
+            matchday: 1,
+            date: "2026-08-02".to_string(),
+            home_team_id: "ai-team".to_string(),
+            away_team_id: "other-ai".to_string(),
+            match_type: MatchType::League,
+            best_of: 1,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        }],
+        standings: vec![StandingEntry::new("ai-team".to_string())],
+        competition_id: Some("competition-1".to_string()),
+        logo: None,
+        league_kind: LeagueKind::Main,
+        split_index: 0,
+        tier: 1,
+        active: true,
+    }];
+
+    if let RosterStabilityReason::Emergency = reason {
+        // ensure the generated player ID namespace is free so we can tell
+        // whether the free agent was actually assigned vs. a generated fallback
+        game.players
+            .retain(|p| !p.id.starts_with("emergency-ai-team"));
+    }
+
+    (game, "free-support".to_string())
+}
+
+#[test]
+fn emergency_repair_allows_low_impact_free_agent_at_tier_one() {
+    let (mut game, fa_id) = elite_game_with_low_impact_free_agent(RosterStabilityReason::Emergency);
+
+    repair_team(&mut game, "ai-team", RosterStabilityReason::Emergency)
+        .expect("emergency repair should succeed");
+
+    let assigned = game.players.iter().find(|p| p.id == fa_id).unwrap();
+    assert_eq!(assigned.team_id.as_deref(), Some("ai-team"));
+    assert!(assigned.wage > 0);
+    assert!(assigned.contract_end.is_some());
+
+    let entry = get_transfer_history(&game)
+        .into_iter()
+        .find(|entry| entry.player_id == fa_id)
+        .expect("emergency repair signing should appear in history");
+    assert_eq!(entry.annual_wage, assigned.wage);
+    assert!(entry.contract_years > 0);
+    assert!(
+        assigned
+            .contract_end
+            .as_ref()
+            .is_some_and(|contract_end| contract_end
+                .starts_with(&(2026 + i32::from(entry.contract_years)).to_string())),
+        "player contract_end must match history contract_years"
+    );
+}
+
+#[test]
+fn non_emergency_repair_rejects_low_impact_free_agent_at_tier_one() {
+    let (mut game, fa_id) =
+        elite_game_with_low_impact_free_agent(RosterStabilityReason::BackgroundSimulation);
+
+    repair_team(
+        &mut game,
+        "ai-team",
+        RosterStabilityReason::BackgroundSimulation,
+    )
+    .expect("repair should fall back to generated replacement");
+
+    let free_agent = game.players.iter().find(|p| p.id == fa_id).unwrap();
+    assert_ne!(
+        free_agent.team_id.as_deref(),
+        Some("ai-team"),
+        "low-impact free agent should be rejected by non-emergency repair"
+    );
+
+    assert!(
+        game.players.iter().any(|p| {
+            p.team_id.as_deref() == Some("ai-team") && p.natural_position == LolRole::Support
+        }),
+        "a replacement support should still be on the team"
     );
 }

--- a/src-tauri/crates/olm_core/tests/transfers_tests.rs
+++ b/src-tauri/crates/olm_core/tests/transfers_tests.rs
@@ -12,8 +12,9 @@ use olm_core::domain::stats::LolRole;
 use olm_core::domain::team::{FinancialTransactionKind, Team, TeamKind};
 use olm_core::game::Game;
 use olm_core::transfers::{
-    counter_offer, generate_incoming_transfer_offers, make_transfer_bid, release_player_contract,
-    respond_to_offer, TransferDestination, TransferNegotiationDecision,
+    TransferDestination, TransferNegotiationDecision, ai_agent_purchase, counter_offer,
+    generate_incoming_transfer_offers, get_transfer_history, make_transfer_bid,
+    negotiate_player_wage, release_player_contract, respond_to_offer,
 };
 
 fn default_attrs() -> PlayerAttributes {
@@ -158,6 +159,24 @@ fn make_game_with_player(
     game
 }
 
+fn complete_accepted_transfer(game: &mut Game, player_id: &str) {
+    let offer_id = game
+        .players
+        .iter()
+        .find(|player| player.id == player_id)
+        .and_then(|player| {
+            player
+                .transfer_offers
+                .iter()
+                .find(|offer| offer.status == TransferOfferStatus::Accepted)
+                .map(|offer| offer.id.clone())
+        })
+        .expect("accepted offer should exist");
+
+    negotiate_player_wage(game, player_id, &offer_id, 200_000, 3)
+        .expect("accepted transfer should complete after wage agreement");
+}
+
 #[test]
 fn incoming_transfer_offers_do_not_arrive_when_window_is_closed() {
     let mut player = make_user_player("player-window-closed");
@@ -199,6 +218,23 @@ fn transfer_bid_is_rejected_when_window_is_closed() {
 }
 
 #[test]
+fn over_budget_transfer_bid_is_rejected() {
+    let player = make_player("player-over-budget");
+    let mut game = make_game_with_player(player, vec![], 5_000_000, 500_000);
+
+    let error = make_transfer_bid(
+        &mut game,
+        "player-over-budget",
+        750_000,
+        TransferDestination::Main,
+        &[],
+    )
+    .expect_err("bid above transfer budget should be rejected");
+
+    assert_eq!(error, "Transfer budget too low");
+}
+
+#[test]
 fn expiring_contract_lowers_resistance_to_sale() {
     let mut player = make_player("player-expiring");
     player.contract_end = Some("2026-08-31".to_string());
@@ -215,6 +251,7 @@ fn expiring_contract_lowers_resistance_to_sale() {
     .expect("bid should be evaluated");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-expiring");
     assert_eq!(
         game.players
             .iter()
@@ -265,6 +302,7 @@ fn accepted_transfer_bid_can_assign_player_to_academy_and_charge_parent_club() {
     .expect("academy destination bid should be evaluated");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-academy-destination");
     let player = game
         .players
         .iter()
@@ -363,6 +401,7 @@ fn repeated_bid_advances_transfer_negotiation_round() {
         second_result.decision,
         TransferNegotiationDecision::Accepted
     );
+    complete_accepted_transfer(&mut game, "player-repeat-bid");
     assert_eq!(second_result.feedback.round, 2);
     assert_eq!(
         game.players
@@ -379,8 +418,8 @@ fn stale_outgoing_transfer_negotiation_is_withdrawn_before_new_bid() {
     player.morale = 35;
     player.stats.appearances = 1;
     player.transfer_offers.push(TransferOffer {
-        id: "offer-counter-accept".to_string(),
-        from_team_id: "team-2".to_string(),
+        id: "offer-stale".to_string(),
+        from_team_id: "team-1".to_string(),
         destination_team_id: None,
         fee: 1_000_000,
         wage_offered: 0,
@@ -389,7 +428,7 @@ fn stale_outgoing_transfer_negotiation_is_withdrawn_before_new_bid() {
         suggested_counter_fee: None,
         players_included: vec![],
         status: TransferOfferStatus::Pending,
-        date: "2026-08-01".to_string(),
+        date: "2026-07-01".to_string(),
         wage_negotiation_status: WageNegotiationStatus::NotStarted,
         contract_years_offered: 0,
         suggested_counter_wage: None,
@@ -430,22 +469,58 @@ fn stale_outgoing_transfer_negotiation_is_withdrawn_before_new_bid() {
 }
 
 #[test]
-fn low_transfer_budget_cannot_behave_unrealistically() {
-    let mut player = make_player("player-budget");
-    player.transfer_listed = true;
+fn club_to_club_transfer_records_non_zero_wage_and_realistic_term() {
+    let mut player = make_user_player("player-c2c-terms");
+    player.wage = 100_000;
+    player.contract_end = Some("2028-06-30".to_string());
+    player
+        .transfer_offers
+        .push(make_pending_incoming_offer("offer-c2c-terms", 950_000));
 
-    let mut game = make_game_with_player(player, vec![], 5_000_000, 400_000);
+    let mut game = make_game_with_player(player, vec![], 5_000_000, 2_000_000);
+    game.teams[1].finance = 6_000_000;
+    game.teams[1].transfer_budget = 3_000_000;
 
-    let error = make_transfer_bid(
-        &mut game,
-        "player-budget",
-        900_000,
-        TransferDestination::Main,
-        &[],
-    )
-    .expect_err("bid should be blocked by transfer budget");
+    respond_to_offer(&mut game, "player-c2c-terms", "offer-c2c-terms", true)
+        .expect("accepting a pending offer should execute transfer");
 
-    assert_eq!(error, "Transfer budget too low");
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "player-c2c-terms")
+        .unwrap();
+    assert_eq!(player.team_id.as_deref(), Some("team-2"));
+    assert!(
+        player.wage > 0,
+        "transferred player wage should be non-zero"
+    );
+
+    let entry = get_transfer_history(&game)
+        .into_iter()
+        .find(|entry| entry.player_id == "player-c2c-terms")
+        .expect("history should contain the transfer");
+    assert!(
+        entry.annual_wage > 0,
+        "history annual_wage should be non-zero, got {}",
+        entry.annual_wage
+    );
+    assert!(
+        (1..=5).contains(&entry.contract_years),
+        "history contract_years should be realistic, got {}",
+        entry.contract_years
+    );
+    assert_eq!(
+        player.wage, entry.annual_wage,
+        "player wage must match history annual_wage"
+    );
+    assert!(
+        player
+            .contract_end
+            .as_ref()
+            .is_some_and(|contract_end| contract_end
+                .starts_with(&(2026 + i32::from(entry.contract_years)).to_string())),
+        "player contract_end must match history contract_years"
+    );
 }
 
 #[test]
@@ -485,7 +560,7 @@ fn does_not_duplicate_pending_incoming_offer_from_same_club() {
     player.contract_end = Some("2026-09-01".to_string());
     player.transfer_offers.push(TransferOffer {
         id: "offer-stale".to_string(),
-        from_team_id: "team-1".to_string(),
+        from_team_id: "team-2".to_string(),
         destination_team_id: None,
         fee: 900_000,
         wage_offered: 0,
@@ -494,7 +569,7 @@ fn does_not_duplicate_pending_incoming_offer_from_same_club() {
         suggested_counter_fee: None,
         players_included: vec![],
         status: TransferOfferStatus::Pending,
-        date: "2026-07-15".to_string(),
+        date: "2026-07-25".to_string(),
         wage_negotiation_status: WageNegotiationStatus::NotStarted,
         contract_years_offered: 0,
         suggested_counter_wage: None,
@@ -515,7 +590,7 @@ fn does_not_duplicate_pending_incoming_offer_from_same_club() {
         .unwrap();
 
     assert_eq!(player.transfer_offers.len(), 1);
-    assert_eq!(player.transfer_offers[0].id, "offer-existing");
+    assert_eq!(player.transfer_offers[0].id, "offer-stale");
     assert!(game.messages.is_empty());
 }
 
@@ -740,6 +815,7 @@ fn reasonable_counter_offer_is_accepted_and_executes_transfer() {
     .expect("counter offer should be evaluated");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-counter-accept");
     let player = game
         .players
         .iter()
@@ -981,6 +1057,7 @@ fn accepted_major_transfer_generates_news_article() {
     .expect("major transfer bid should succeed");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-news-major");
     let article = game
         .news
         .iter()
@@ -1012,6 +1089,7 @@ fn smaller_completed_transfer_does_not_generate_news_article() {
     .expect("small transfer bid should succeed");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-news-small");
     assert!(game.news.is_empty());
 }
 
@@ -1044,6 +1122,7 @@ fn completed_transfer_news_is_not_duplicated_when_article_already_exists() {
     .expect("major transfer bid should succeed");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-news-dup");
     assert_eq!(
         game.news
             .iter()
@@ -1069,6 +1148,7 @@ fn academy_sale_replenishes_roster_and_role_coverage() {
     .expect("academy transfer bid should succeed");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-academy-sale");
     assert_eq!(
         game.players
             .iter()
@@ -1148,6 +1228,7 @@ fn academy_sale_routes_fee_to_parent_club_owner() {
     .expect("academy transfer should succeed");
 
     assert_eq!(result.decision, TransferNegotiationDecision::Accepted);
+    complete_accepted_transfer(&mut game, "player-academy-owner");
     let academy_finance_after = game
         .teams
         .iter()
@@ -1395,10 +1476,13 @@ fn release_player_contract_sets_was_released_flag() {
 
     let mut game = make_game_with_player(player, vec![], 10_000_000, 5_000_000);
 
-    let penalty = release_player_contract(&mut game, "release-test-1")
-        .expect("release should succeed");
+    let penalty =
+        release_player_contract(&mut game, "release-test-1").expect("release should succeed");
 
-    assert!(penalty > 0, "release penalty should be > 0 for non-zero wage");
+    assert!(
+        penalty > 0,
+        "release penalty should be > 0 for non-zero wage"
+    );
 
     let released = game
         .players
@@ -1406,13 +1490,25 @@ fn release_player_contract_sets_was_released_flag() {
         .find(|p| p.id == "release-test-1")
         .expect("released player should still be in game");
 
-    assert!(released.was_released, "was_released should be true after release");
-    assert!(released.team_id.is_none(), "team_id should be None after release");
-    assert!(released.contract_end.is_none(), "contract_end should be None after release");
+    assert!(
+        released.was_released,
+        "was_released should be true after release"
+    );
+    assert!(
+        released.team_id.is_none(),
+        "team_id should be None after release"
+    );
+    assert!(
+        released.contract_end.is_none(),
+        "contract_end should be None after release"
+    );
     assert_eq!(released.wage, 0, "wage should be 0 after release");
     assert!(!released.transfer_listed, "should not be transfer listed");
     assert!(!released.loan_listed, "should not be loan listed");
-    assert!(released.transfer_offers.is_empty(), "transfer offers should be cleared");
+    assert!(
+        released.transfer_offers.is_empty(),
+        "transfer offers should be cleared"
+    );
 }
 
 #[test]
@@ -1541,4 +1637,301 @@ fn release_academy_player_without_contract_end_succeeds() {
 
     assert!(released.was_released);
     assert!(released.team_id.is_none());
+}
+
+fn make_ai_team(id: &str) -> Team {
+    let mut team = Team::new(
+        id.to_string(),
+        format!("{} FC", id),
+        id.chars().take(3).collect::<String>().to_uppercase(),
+        "England".to_string(),
+        "London".to_string(),
+        "Arena".to_string(),
+        50_000,
+    );
+    team.finance = 10_000_000;
+    team.transfer_budget = 5_000_000;
+    team.reputation = 50;
+    team
+}
+
+fn make_free_agent(id: &str, role: LolRole) -> Player {
+    let mut player = Player::new(
+        id.to_string(),
+        format!("{}. Free", id),
+        format!("{} Free", id),
+        "2000-01-01".to_string(),
+        "England".to_string(),
+        role,
+        default_attrs(),
+    );
+    player.team_id = None;
+    player.contract_end = None;
+    player.market_value = 500_000;
+    player.wage = 100_000;
+    player.morale = 70;
+    player
+}
+
+fn make_game_with_free_agent(free_agent: Player) -> Game {
+    make_game_with_free_agents(vec![free_agent])
+}
+
+fn make_game_with_free_agents(free_agents: Vec<Player>) -> Game {
+    let clock = GameClock::new(Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap());
+    let mut manager = Manager::new(
+        "manager-1".to_string(),
+        "Jane".to_string(),
+        "Doe".to_string(),
+        "1980-01-01".to_string(),
+        "England".to_string(),
+    );
+    manager.hire("team-user".to_string());
+
+    let mut team = make_ai_team("team-ai");
+    team.wage_budget = 1_000_000;
+
+    let mut game = Game::new(clock, manager, vec![team], free_agents, vec![], vec![]);
+    game.season_context.transfer_window.status = TransferWindowStatus::Open;
+    game
+}
+
+#[test]
+fn ai_free_agent_signing_records_non_zero_wage_and_term() {
+    let free_agent = make_free_agent("fa-wage-term", LolRole::Adc);
+    let mut game = make_game_with_free_agent(free_agent);
+
+    let signed = ai_agent_purchase(&mut game, "team-ai", "ADC");
+    assert!(signed, "AI should sign the free agent");
+
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "fa-wage-term")
+        .unwrap();
+    assert_eq!(player.team_id.as_deref(), Some("team-ai"));
+    assert!(player.wage > 0, "player wage should be non-zero");
+
+    let history = get_transfer_history(&game);
+    let entry = history
+        .iter()
+        .find(|entry| entry.player_id == "fa-wage-term")
+        .expect("history should contain the free-agent signing");
+    assert!(
+        entry.annual_wage > 0,
+        "history annual_wage should be non-zero, got {}",
+        entry.annual_wage
+    );
+    assert!(
+        (1..=5).contains(&entry.contract_years),
+        "history contract_years should be realistic, got {}",
+        entry.contract_years
+    );
+    assert_eq!(
+        player.wage, entry.annual_wage,
+        "player wage must match history annual_wage"
+    );
+    assert!(
+        player
+            .contract_end
+            .as_ref()
+            .is_some_and(|contract_end| contract_end
+                .starts_with(&(2026 + i32::from(entry.contract_years)).to_string())),
+        "player contract_end must match history contract_years"
+    );
+}
+
+#[test]
+fn ai_free_agent_signing_applies_non_zero_wage_floor_for_new_player() {
+    let mut free_agent = Player::new(
+        "fa-zero-wage".to_string(),
+        "Zero Wage".to_string(),
+        "Zero Wage".to_string(),
+        "2000-01-01".to_string(),
+        "England".to_string(),
+        LolRole::Adc,
+        default_attrs(),
+    );
+    free_agent.team_id = None;
+    free_agent.contract_end = None;
+    free_agent.market_value = 500_000;
+    free_agent.morale = 70;
+
+    let mut game = make_game_with_free_agent(free_agent);
+
+    assert!(ai_agent_purchase(&mut game, "team-ai", "ADC"));
+
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "fa-zero-wage")
+        .unwrap();
+    let entry = get_transfer_history(&game)
+        .into_iter()
+        .find(|entry| entry.player_id == "fa-zero-wage")
+        .unwrap();
+
+    assert!(player.wage > 0, "signed player wage should be non-zero");
+    assert!(
+        entry.annual_wage > 0,
+        "history annual_wage should be non-zero"
+    );
+    assert_eq!(player.wage, entry.annual_wage);
+}
+
+#[test]
+fn ai_free_agent_signing_matches_player_state_to_history() {
+    let free_agent = make_free_agent("fa-state-match", LolRole::Top);
+    let mut game = make_game_with_free_agent(free_agent);
+
+    ai_agent_purchase(&mut game, "team-ai", "TOP");
+
+    let player = game
+        .players
+        .iter()
+        .find(|player| player.id == "fa-state-match")
+        .unwrap();
+    let entry = get_transfer_history(&game)
+        .into_iter()
+        .find(|entry| entry.player_id == "fa-state-match")
+        .unwrap();
+    assert_eq!(player.wage, entry.annual_wage);
+    assert!(entry.contract_years > 0);
+    assert!(
+        player
+            .contract_end
+            .as_ref()
+            .is_some_and(|contract_end| contract_end
+                .starts_with(&(2026 + i32::from(entry.contract_years)).to_string())),
+        "player contract_end must match history contract_years"
+    );
+}
+
+#[test]
+fn ai_agent_purchase_respects_daily_cap() {
+    let free_agents = vec![
+        make_free_agent("fa-cap-1", LolRole::Top),
+        make_free_agent("fa-cap-2", LolRole::Top),
+        make_free_agent("fa-cap-3", LolRole::Top),
+    ];
+    let mut game = make_game_with_free_agents(free_agents);
+
+    assert!(ai_agent_purchase(&mut game, "team-ai", "TOP"));
+    assert!(ai_agent_purchase(&mut game, "team-ai", "TOP"));
+    assert!(
+        !ai_agent_purchase(&mut game, "team-ai", "TOP"),
+        "third same-day purchase should be blocked by daily cap"
+    );
+}
+
+#[test]
+fn rejected_ai_agent_purchase_does_not_consume_daily_cap() {
+    let mut low_impact = make_free_agent("fa-low-impact-cap", LolRole::Top);
+    low_impact.lol_ovr = 60;
+    low_impact.market_value = 100_000;
+    let mut game = make_game_with_free_agent(low_impact);
+
+    game.teams[0].wage_budget = 10_000;
+
+    assert!(
+        !ai_agent_purchase(&mut game, "team-ai", "TOP"),
+        "free agent should be rejected by signing policy"
+    );
+
+    game.teams[0].wage_budget = 10_000_000;
+
+    let mut strong_one = make_free_agent("fa-cap-valid-1", LolRole::Top);
+    strong_one.lol_ovr = 95;
+    strong_one.market_value = 2_000_000;
+    let mut strong_two = make_free_agent("fa-cap-valid-2", LolRole::Top);
+    strong_two.lol_ovr = 94;
+    strong_two.market_value = 1_900_000;
+    game.players.push(strong_one);
+    game.players.push(strong_two);
+
+    assert!(ai_agent_purchase(&mut game, "team-ai", "TOP"));
+    assert!(
+        ai_agent_purchase(&mut game, "team-ai", "TOP"),
+        "two valid signings should remain available after the rejected attempt"
+    );
+}
+
+#[test]
+fn ai_free_agent_signing_respects_reputation_gate_for_tier_one() {
+    let mut free_agent = make_free_agent("fa-low-impact", LolRole::Top);
+    free_agent.lol_ovr = 60;
+    free_agent.market_value = 100_000;
+    let mut game = make_game_with_free_agent(free_agent);
+
+    let mut team = game.teams.remove(0);
+    team.reputation = 1_200;
+    team.competition_id = Some("comp-1".to_string());
+    team.wage_budget = 1_000_000;
+    game.teams.push(team);
+
+    game.leagues.push(olm_core::domain::league::League {
+        id: "league-1".to_string(),
+        name: "League One".to_string(),
+        season: 2026,
+        competition_id: Some("comp-1".to_string()),
+        logo: None,
+        league_kind: olm_core::domain::league::LeagueKind::Main,
+        fixtures: vec![],
+        standings: vec![olm_core::domain::league::StandingEntry::new(
+            "team-ai".to_string(),
+        )],
+        split_index: 0,
+        tier: 1,
+        active: true,
+    });
+
+    // Seed a recent incoming offer on a dummy user-team player so that
+    // generate_incoming_transfer_offers takes the early return path that
+    // invokes simulate_ai_free_agent_signings.
+    let user_player_id = "user-player".to_string();
+    game.players.push({
+        let mut p = Player::new(
+            user_player_id.clone(),
+            "User Player".to_string(),
+            "User Player".to_string(),
+            "2000-01-01".to_string(),
+            "England".to_string(),
+            LolRole::Mid,
+            default_attrs(),
+        );
+        p.team_id = Some("team-user".to_string());
+        p.contract_end = Some("2028-06-30".to_string());
+        p.transfer_offers.push(TransferOffer {
+            id: "offer-1".to_string(),
+            from_team_id: "team-ai".to_string(),
+            destination_team_id: Some("team-user".to_string()),
+            fee: 1_000_000,
+            wage_offered: 100_000,
+            last_manager_fee: None,
+            negotiation_round: 1,
+            suggested_counter_fee: None,
+            players_included: vec![],
+            status: TransferOfferStatus::Pending,
+            date: game.clock.current_date.format("%Y-%m-%d").to_string(),
+            wage_negotiation_status: WageNegotiationStatus::Pending,
+            contract_years_offered: 2,
+            suggested_counter_wage: None,
+            suggested_counter_years: None,
+            wage_negotiation_round: 1,
+        });
+        p
+    });
+
+    generate_incoming_transfer_offers(&mut game);
+
+    let signed = game
+        .players
+        .iter()
+        .find(|p| p.id == "fa-low-impact")
+        .unwrap();
+    assert_ne!(
+        signed.team_id.as_deref(),
+        Some("team-ai"),
+        "tier-1 high-reputation team should reject low-impact free agent"
+    );
 }

--- a/src-tauri/crates/olm_core/tests/turn_strategic_recruitment_tests.rs
+++ b/src-tauri/crates/olm_core/tests/turn_strategic_recruitment_tests.rs
@@ -1,0 +1,494 @@
+use chrono::{TimeZone, Utc};
+use olm_core::ai_team_agent::ai_strategic_recruitment;
+use olm_core::clock::GameClock;
+use olm_core::domain::league::{
+    Fixture, FixtureStatus, League, LeagueKind, MatchType, StandingEntry,
+};
+use olm_core::domain::manager::Manager;
+use olm_core::domain::player::{Player, PlayerAttributes};
+use olm_core::domain::season::TransferWindowStatus;
+use olm_core::domain::stats::LolRole;
+use olm_core::domain::team::Team;
+use olm_core::game::Game;
+use olm_core::turn;
+use std::collections::HashMap;
+
+fn attrs() -> PlayerAttributes {
+    PlayerAttributes {
+        mental_resilience: 60,
+        champion_pool: 60,
+        laning: 60,
+        mechanics: 60,
+        macro_play: 60,
+        consistency: 60,
+        discipline: 60,
+        teamfighting: 60,
+        shotcalling: 60,
+    }
+}
+
+fn player(
+    id: &str,
+    team_id: Option<&str>,
+    role: LolRole,
+    lol_ovr: u8,
+    market_value: u64,
+) -> Player {
+    let mut player = Player::new(
+        id.to_string(),
+        id.to_string(),
+        format!("{id} Test"),
+        "2000-01-01".to_string(),
+        "Spain".to_string(),
+        role,
+        attrs(),
+    );
+    player.team_id = team_id.map(str::to_string);
+    player.wage = 50_000;
+    player.lol_ovr = lol_ovr;
+    player.market_value = market_value;
+    player.contract_end = Some("2028-06-30".to_string());
+    player
+}
+
+fn free_agent(id: &str, role: LolRole, lol_ovr: u8, market_value: u64) -> Player {
+    player(id, None, role, lol_ovr, market_value)
+}
+
+fn team(id: &str, reputation: u32) -> Team {
+    let mut team = Team::new(
+        id.to_string(),
+        format!("{id} Esports"),
+        id.chars().take(3).collect::<String>().to_uppercase(),
+        "Spain".to_string(),
+        "Madrid".to_string(),
+        "Arena".to_string(),
+        10_000,
+    );
+    team.reputation = reputation;
+    team.wage_budget = 2_000_000;
+    team.transfer_budget = 2_000_000;
+    team.finance = 5_000_000;
+    team
+}
+
+fn league_with_team(team_id: &str, tier: u8, competition_id: &str) -> League {
+    League {
+        id: "league-1".to_string(),
+        name: "League One".to_string(),
+        season: 2026,
+        fixtures: vec![Fixture {
+            id: "fixture-1".to_string(),
+            matchday: 1,
+            date: "2026-08-02".to_string(),
+            home_team_id: team_id.to_string(),
+            away_team_id: "other-ai".to_string(),
+            match_type: MatchType::League,
+            best_of: 1,
+            status: FixtureStatus::Scheduled,
+            result: None,
+        }],
+        standings: vec![StandingEntry::new(team_id.to_string())],
+        competition_id: Some(competition_id.to_string()),
+        logo: None,
+        league_kind: LeagueKind::Main,
+        split_index: 0,
+        tier,
+        active: true,
+    }
+}
+
+fn make_strategic_game(
+    buyer_reputation: u32,
+    league_tier: u8,
+    seller_players: Vec<Player>,
+    free_agents: Vec<Player>,
+) -> Game {
+    let date = Utc.with_ymd_and_hms(2026, 8, 1, 12, 0, 0).unwrap();
+    let clock = GameClock::new(date);
+    let mut manager = Manager::new(
+        "manager-1".to_string(),
+        "Jane".to_string(),
+        "Doe".to_string(),
+        "1980-01-01".to_string(),
+        "Spain".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut buyer = team("buyer", buyer_reputation);
+    buyer.competition_id = Some("competition-1".to_string());
+
+    let seller = team("seller", 800);
+    let other = team("other-ai", 500);
+
+    // Capture custom values before Game::new refreshes them.
+    let snapshot: Vec<(String, u8, u64)> = seller_players
+        .iter()
+        .chain(free_agents.iter())
+        .map(|p| (p.id.clone(), p.lol_ovr, p.market_value))
+        .collect();
+
+    let mut players = vec![];
+    players.extend(seller_players);
+    players.extend(free_agents);
+    // Give buyer a minimal roster so it has a preferred role
+    players.push(player(
+        "buyer-top",
+        Some("buyer"),
+        LolRole::Top,
+        75,
+        300_000,
+    ));
+    players.push(player(
+        "buyer-jungle",
+        Some("buyer"),
+        LolRole::Jungle,
+        75,
+        300_000,
+    ));
+    players.push(player(
+        "buyer-mid",
+        Some("buyer"),
+        LolRole::Mid,
+        75,
+        300_000,
+    ));
+    players.push(player(
+        "buyer-adc",
+        Some("buyer"),
+        LolRole::Adc,
+        75,
+        300_000,
+    ));
+    // Support gap intentionally left so preferred role becomes SUPPORT
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![buyer, seller, other],
+        players,
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league_with_team("buyer", league_tier, "competition-1")];
+    game.user_competition_id = Some("competition-1".to_string());
+    game.season_context.transfer_window.status = TransferWindowStatus::Open;
+
+    // Restore custom lol_ovr/market_value after Game::new refresh.
+    for (id, ovr, mv) in snapshot {
+        if let Some(p) = game.players.iter_mut().find(|p| p.id == id) {
+            p.lol_ovr = ovr;
+            p.market_value = mv;
+        }
+    }
+    game
+}
+
+#[test]
+fn strategic_recruitment_rejects_low_impact_free_agent_at_tier_one() {
+    let free_agents = vec![free_agent("fa-low", LolRole::Support, 60, 100_000)];
+    let mut game = make_strategic_game(1_200, 1, vec![], free_agents);
+
+    ai_strategic_recruitment(&mut game, "buyer");
+
+    let fa = game.players.iter().find(|p| p.id == "fa-low").unwrap();
+    assert_eq!(
+        fa.team_id, None,
+        "low-impact FA should be rejected by strategic recruitment"
+    );
+    assert!(
+        game.transfer_history.entries.is_empty(),
+        "no history should be recorded for rejected signing"
+    );
+}
+
+#[test]
+fn strategic_recruitment_completes_club_to_club_upgrade_with_non_zero_terms() {
+    // Seller has a high-impact Support player (matches buyer's preferred role gap)
+    let seller_players = vec![player(
+        "star-support",
+        Some("seller"),
+        LolRole::Support,
+        85,
+        2_000_000,
+    )];
+    let mut game = make_strategic_game(1_200, 1, seller_players, vec![]);
+
+    ai_strategic_recruitment(&mut game, "buyer");
+
+    let star = game
+        .players
+        .iter()
+        .find(|p| p.id == "star-support")
+        .unwrap();
+    assert_eq!(
+        star.team_id.as_deref(),
+        Some("buyer"),
+        "high-impact upgrade should move to buyer"
+    );
+    assert!(star.wage > 0, "player wage must be non-zero after transfer");
+
+    let entry = game
+        .transfer_history
+        .entries
+        .iter()
+        .find(|e| e.player_id == "star-support")
+        .expect("history entry should exist");
+    assert!(
+        entry.annual_wage > 0,
+        "history annual_wage must be non-zero"
+    );
+    assert!(
+        entry.contract_years >= 1 && entry.contract_years <= 5,
+        "history contract_years must be realistic"
+    );
+    assert_eq!(
+        entry.annual_wage, star.wage,
+        "history wage must match player wage"
+    );
+}
+
+#[test]
+fn strategic_recruitment_respects_daily_cap() {
+    let seller_players = vec![
+        player(
+            "star-support",
+            Some("seller"),
+            LolRole::Support,
+            85,
+            2_000_000,
+        ),
+        player("star-top", Some("seller"), LolRole::Top, 85, 1_900_000),
+        player(
+            "star-jungle",
+            Some("seller"),
+            LolRole::Jungle,
+            85,
+            1_800_000,
+        ),
+    ];
+    let mut game = make_strategic_game(1_200, 1, seller_players, vec![]);
+    game.teams
+        .iter_mut()
+        .find(|team| team.id == "buyer")
+        .expect("buyer should exist")
+        .transfer_budget = 10_000_000;
+    game.teams
+        .iter_mut()
+        .find(|team| team.id == "buyer")
+        .expect("buyer should exist")
+        .finance = 10_000_000;
+
+    // First and second calls consume the daily strategic transfer cap.
+    ai_strategic_recruitment(&mut game, "buyer");
+    assert_eq!(
+        game.players
+            .iter()
+            .find(|p| p.id == "star-support")
+            .unwrap()
+            .team_id
+            .as_deref(),
+        Some("buyer")
+    );
+
+    ai_strategic_recruitment(&mut game, "buyer");
+    assert_eq!(
+        game.players
+            .iter()
+            .find(|p| p.id == "star-top")
+            .unwrap()
+            .team_id
+            .as_deref(),
+        Some("buyer")
+    );
+
+    // Third call on the same day still has an eligible candidate, so only the
+    // daily cap can block the signing.
+    ai_strategic_recruitment(&mut game, "buyer");
+    assert_eq!(
+        game.players
+            .iter()
+            .find(|p| p.id == "star-jungle")
+            .unwrap()
+            .team_id
+            .as_deref(),
+        Some("seller")
+    );
+    let entries_for_buyer = game
+        .transfer_history
+        .entries
+        .iter()
+        .filter(|e| e.to_team_id == "buyer")
+        .count();
+    assert_eq!(
+        entries_for_buyer, 2,
+        "third strategic signing should be capped"
+    );
+}
+
+#[test]
+fn process_day_runs_strategic_recruitment_for_eligible_team() {
+    let seller_players = vec![player(
+        "star-support",
+        Some("seller"),
+        LolRole::Support,
+        85,
+        2_000_000,
+    )];
+    let mut game = make_strategic_game(1_200, 1, seller_players, vec![]);
+
+    // Advance one day to trigger turn pipeline
+    turn::process_day(&mut game);
+
+    let star = game
+        .players
+        .iter()
+        .find(|p| p.id == "star-support")
+        .unwrap();
+    assert_eq!(
+        star.team_id.as_deref(),
+        Some("buyer"),
+        "turn wiring should run strategic recruitment and complete upgrade"
+    );
+}
+
+#[test]
+fn strategic_recruitment_fa_fallback_signs_high_impact_free_agent() {
+    let free_agents = vec![free_agent("fa-star", LolRole::Support, 85, 2_000_000)];
+    let mut game = make_strategic_game(1_200, 1, vec![], free_agents);
+
+    ai_strategic_recruitment(&mut game, "buyer");
+
+    let fa = game.players.iter().find(|p| p.id == "fa-star").unwrap();
+    assert_eq!(
+        fa.team_id.as_deref(),
+        Some("buyer"),
+        "high-impact FA fallback should sign"
+    );
+    assert!(fa.wage > 0);
+
+    let entry = game
+        .transfer_history
+        .entries
+        .iter()
+        .find(|e| e.player_id == "fa-star")
+        .expect("history entry should exist");
+    assert!(entry.annual_wage > 0);
+}
+
+#[test]
+fn strategic_recruitment_generates_rejection_news_with_intent_metadata() {
+    let free_agents = vec![free_agent("fa-low", LolRole::Support, 60, 100_000)];
+    let mut game = make_strategic_game(1_200, 1, vec![], free_agents);
+
+    ai_strategic_recruitment(&mut game, "buyer");
+
+    let article = game
+        .news
+        .iter()
+        .find(|n| n.id.starts_with("ai_strategic_rejected_buyer_"))
+        .expect("strategic rejection news should be generated");
+    assert_eq!(
+        article.i18n_params.get("intent"),
+        Some(&"strategic".to_string())
+    );
+    assert_eq!(
+        article.i18n_params.get("outcome"),
+        Some(&"rejected".to_string())
+    );
+    assert!(
+        !article.headline.is_empty(),
+        "raw headline fallback should be non-empty"
+    );
+    assert!(
+        !article.body.is_empty(),
+        "raw body fallback should be non-empty"
+    );
+    assert!(
+        !article.source.is_empty(),
+        "raw source fallback should be non-empty"
+    );
+    assert!(article.player_ids.contains(&"fa-low".to_string()));
+}
+
+#[test]
+fn process_day_fourteen_days_respects_cap_and_no_zero_wage_entries() {
+    // Provide a pool of high-impact Support players on the seller so strategic
+    // recruitment has club-to-club upgrade opportunities across multiple days.
+    let seller_players: Vec<Player> = (0..5)
+        .map(|i| {
+            player(
+                &format!("star-support-{i}"),
+                Some("seller"),
+                LolRole::Support,
+                85,
+                2_000_000,
+            )
+        })
+        .collect();
+    let mut game = make_strategic_game(1_200, 1, seller_players, vec![]);
+
+    // Push the only fixture far into the future so no matchday simulation runs
+    // during the 14-day window (keeps the test focused on transfer behaviour).
+    if let Some(league) = game.leagues.first_mut() {
+        for fixture in &mut league.fixtures {
+            fixture.date = "2026-09-01".to_string();
+        }
+    }
+
+    for _ in 0..14 {
+        turn::process_day(&mut game);
+    }
+
+    // No transfer history entry may contain a zero wage or zero contract term.
+    for entry in &game.transfer_history.entries {
+        assert!(
+            entry.annual_wage > 0,
+            "entry {} for player {} has zero annual_wage",
+            entry.id,
+            entry.player_id
+        );
+        assert!(
+            entry.contract_years > 0 && entry.contract_years <= 5,
+            "entry {} for player {} has unrealistic contract_years: {}",
+            entry.id,
+            entry.player_id,
+            entry.contract_years
+        );
+    }
+
+    // Per-team daily cap audit: AI-initiated transfers are limited to
+    // MAX_AI_TRANSFERS_PER_DAY (2) + MAX_AI_EMERGENCY_TRANSFERS_PER_DAY (1).
+    let mut daily_counts: HashMap<(String, String), usize> = HashMap::new();
+    let mut emergency_counts: HashMap<(String, String), usize> = HashMap::new();
+    for entry in &game.transfer_history.entries {
+        if entry.is_user_involved {
+            continue;
+        }
+        let key = (entry.date.clone(), entry.to_team_id.clone());
+        *daily_counts.entry(key.clone()).or_insert(0) += 1;
+        if entry.intent.as_deref() == Some("emergency") {
+            *emergency_counts.entry(key).or_insert(0) += 1;
+        }
+    }
+
+    for ((date, team_id), count) in &daily_counts {
+        assert!(
+            *count <= 3,
+            "team {} on {} has {} AI-initiated transfers (exceeds 2 strategic/FA/club-to-club + 1 emergency)",
+            team_id,
+            date,
+            count
+        );
+    }
+
+    for ((date, team_id), count) in &emergency_counts {
+        assert!(
+            *count <= 1,
+            "team {} on {} has {} emergency transfers (exceeds 1 per day)",
+            team_id,
+            date,
+            count
+        );
+    }
+}

--- a/src-tauri/crates/olm_core/tests/turn_tests.rs
+++ b/src-tauri/crates/olm_core/tests/turn_tests.rs
@@ -162,6 +162,9 @@ fn make_game_with_match() -> Game {
             StandingEntry::new("team1".to_string()),
             StandingEntry::new("team2".to_string()),
         ],
+        split_index: 0,
+        tier: 1,
+        active: true,
     };
 
     let mut game = Game::new(clock, manager, vec![team1, team2], players, vec![], vec![]);
@@ -405,7 +408,10 @@ fn process_day_releases_players_with_expired_contracts() {
     let released_player = game.players.iter().find(|p| p.id == "t1_fwd0").unwrap();
     assert_eq!(released_player.team_id, None);
     assert_eq!(released_player.contract_end, None);
-    assert_eq!(released_player.wage, 0);
+    assert!(
+        released_player.wage > 0,
+        "Expired contract should preserve non-zero wage baseline"
+    );
     assert!(
         game.messages
             .iter()
@@ -1384,6 +1390,9 @@ fn make_round_summary_game() -> Game {
             standing_entry("team3", 11, 31, 18, 8),
             standing_entry("team4", 11, 27, 19, 14),
         ],
+        split_index: 0,
+        tier: 1,
+        active: true,
     };
 
     let mut game = Game::new(
@@ -1549,4 +1558,172 @@ fn build_round_summary_ignores_non_competitive_matchday_zero_fixtures() {
     let summary = turn::build_round_summary(&game, 0, &previous_round_standings());
 
     assert!(summary.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// AI transfer daily cap integration
+// ---------------------------------------------------------------------------
+
+fn make_role_player(id: &str, team_id: &str, role: LolRole) -> Player {
+    let attrs = default_attrs();
+    let mut p = Player::new(
+        id.to_string(),
+        id.to_string(),
+        id.to_string(),
+        "2000-01-01".to_string(),
+        "England".to_string(),
+        role,
+        attrs,
+    );
+    p.team_id = Some(team_id.to_string());
+    p.contract_end = Some("2028-06-30".to_string());
+    p.wage = 50_000;
+    p.market_value = 300_000;
+    p
+}
+
+fn make_free_agent_for_cap(id: &str, role: LolRole) -> Player {
+    let mut p = Player::new(
+        id.to_string(),
+        id.to_string(),
+        id.to_string(),
+        "2000-01-01".to_string(),
+        "England".to_string(),
+        role,
+        default_attrs(),
+    );
+    p.team_id = None;
+    p.contract_end = None;
+    p.wage = 40_000;
+    p.market_value = 200_000;
+    p
+}
+
+fn make_cap_game() -> Game {
+    use olm_core::domain::season::TransferWindowStatus;
+
+    let date = Utc.with_ymd_and_hms(2026, 1, 5, 12, 0, 0).unwrap();
+    let clock = GameClock::new(date);
+    let mut manager = Manager::new(
+        "mgr1".to_string(),
+        "Test".to_string(),
+        "Manager".to_string(),
+        "1980-01-01".to_string(),
+        "England".to_string(),
+    );
+    manager.hire("user-team".to_string());
+
+    let mut user_team = make_team("user-team", "User FC");
+    user_team.manager_id = Some("mgr1".to_string());
+
+    let mut ai_team_1 = make_team("ai-1", "AI One");
+    ai_team_1.wage_budget = 2_000_000;
+    ai_team_1.transfer_budget = 2_000_000;
+    ai_team_1.finance = 5_000_000;
+
+    let mut ai_team_2 = make_team("ai-2", "AI Two");
+    ai_team_2.wage_budget = 2_000_000;
+    ai_team_2.transfer_budget = 2_000_000;
+    ai_team_2.finance = 5_000_000;
+
+    let mut players = vec![
+        make_role_player("u-top", "user-team", LolRole::Top),
+        make_role_player("u-jungle", "user-team", LolRole::Jungle),
+        make_role_player("u-mid", "user-team", LolRole::Mid),
+        make_role_player("u-adc", "user-team", LolRole::Adc),
+        make_role_player("u-support", "user-team", LolRole::Support),
+        make_role_player("a1-top", "ai-1", LolRole::Top),
+        make_role_player("a1-jungle", "ai-1", LolRole::Jungle),
+        make_role_player("a2-mid", "ai-2", LolRole::Mid),
+        make_role_player("a2-adc", "ai-2", LolRole::Adc),
+    ];
+
+    let roles = [
+        LolRole::Top,
+        LolRole::Jungle,
+        LolRole::Mid,
+        LolRole::Adc,
+        LolRole::Support,
+    ];
+    for i in 0..20 {
+        let role = roles[i % roles.len()];
+        players.push(make_free_agent_for_cap(&format!("fa-{i}"), role));
+    }
+
+    let today = date.format("%Y-%m-%d").to_string();
+    let league = League {
+        id: "league1".to_string(),
+        name: "Test League".to_string(),
+        season: 1,
+        competition_id: Some("comp-1".to_string()),
+        logo: None,
+        league_kind: LeagueKind::Main,
+        fixtures: vec![
+            Fixture {
+                id: "fix1".to_string(),
+                matchday: 1,
+                date: today.clone(),
+                home_team_id: "user-team".to_string(),
+                away_team_id: "ai-1".to_string(),
+                match_type: MatchType::League,
+                best_of: 1,
+                status: FixtureStatus::Scheduled,
+                result: None,
+            },
+            Fixture {
+                id: "fix2".to_string(),
+                matchday: 1,
+                date: today.clone(),
+                home_team_id: "ai-2".to_string(),
+                away_team_id: "user-team".to_string(),
+                match_type: MatchType::League,
+                best_of: 1,
+                status: FixtureStatus::Scheduled,
+                result: None,
+            },
+        ],
+        standings: vec![
+            StandingEntry::new("user-team".to_string()),
+            StandingEntry::new("ai-1".to_string()),
+            StandingEntry::new("ai-2".to_string()),
+        ],
+        split_index: 0,
+        tier: 2,
+        active: true,
+    };
+
+    let mut game = Game::new(
+        clock,
+        manager,
+        vec![user_team, ai_team_1, ai_team_2],
+        players,
+        vec![],
+        vec![],
+    );
+    game.leagues = vec![league];
+    game.user_competition_id = Some("comp-1".to_string());
+    game.season_context.transfer_window.status = TransferWindowStatus::Open;
+    game
+}
+
+#[test]
+fn process_day_enforces_daily_ai_transfer_cap() {
+    let mut game = make_cap_game();
+
+    for _ in 0..14 {
+        turn::process_day_with_capture(&mut game, &mut |_| {});
+    }
+
+    let mut counts: HashMap<(String, String), usize> = HashMap::new();
+    for entry in game.transfer_history.entries.iter() {
+        let key = (entry.to_team_id.clone(), entry.date.clone());
+        *counts.entry(key).or_insert(0) += 1;
+    }
+
+    for ((team_id, date), count) in counts {
+        assert!(
+            count <= 2,
+            "team {team_id} on {date} exceeded daily cap with {count} transfers"
+        );
+    }
 }


### PR DESCRIPTION
Closes #350

## Summary
- Rework AI transfer market to eliminate zero-wage free agent behavior, add realistic signing terms, shared signing policy, daily cap, and strategic recruitment for top-tier teams.

## Changes
| File | Change |
|------|--------|
| `src-tauri/crates/olm_core/src/ai_team_agent.rs` | Added `ai_strategic_recruitment`, club-to-club upgrade pursuit, FA fallback |
| `src-tauri/crates/olm_core/src/contract_wage_policy.rs` | Shared `ai_signing_policy`, reputation/tier gating, daily cap, wage-budget guard |
| `src-tauri/crates/olm_core/src/contracts.rs` | Contract expiry preserves non-zero wage; wage floor for zero-wage free agents |
| `src-tauri/crates/olm_core/src/db/save_manager.rs` | Sample game init with daily cap fields |
| `src-tauri/crates/olm_core/src/domain/transfer_history.rs` | Added `intent` field to transfer history |
| `src-tauri/crates/olm_core/src/game.rs` | Daily AI transfer cap state fields |
| `src-tauri/crates/olm_core/src/roster_stability.rs` | `RosterStabilityReason::Emergency`, policy-routed repair |
| `src-tauri/crates/olm_core/src/transfers.rs` | Policy-routed FA/club-to-club signings, fixed cap consumption ordering |
| `src-tauri/crates/olm_core/src/turn/mod.rs` | Strategic recruitment wiring, cap reset in process_day + live_match_day |
| `src-tauri/crates/olm_core/src/turn/news.rs` | Strategic rejection/emergency news with non-empty raw fallbacks |
| `src-tauri/crates/olm_core/tests/ai_signing_policy_tests.rs` | 14 policy/cap tests (new) |
| `src-tauri/crates/olm_core/tests/turn_strategic_recruitment_tests.rs` | 7 strategic recruitment + 14-day integration tests (new) |
| `src-tauri/crates/olm_core/tests/contracts_tests.rs` | Contract expiry wage tests |
| `src-tauri/crates/olm_core/tests/roster_stability_tests.rs` | Emergency/non-emergency repair tests |
| `src-tauri/crates/olm_core/tests/transfers_tests.rs` | Transfer terms, policy, cap consumption tests |
| `src-tauri/crates/olm_core/tests/turn_tests.rs` | Turn integration tests including cap-reset and renewal fix |

## Test Plan
- [x] `cargo test -p olm_core --test transfers_tests` — 40 passed
- [x] `cargo test -p olm_core --test contracts_tests` — 15 passed
- [x] `cargo test -p olm_core --test turn_strategic_recruitment_tests` — 7 passed
- [x] `cargo test -p olm_core --test roster_stability_tests` — 26 passed
- [x] `cargo test -p olm_core --test ai_signing_policy_tests` — 14 passed
- [x] `cargo test -p olm_core --test turn_tests` — 56 passed
- [x] `npm run build` — passed